### PR TITLE
hash operator() must not throw exceptions

### DIFF
--- a/absl/types/optional.h
+++ b/absl/types/optional.h
@@ -457,7 +457,7 @@ struct optional_hash_base<T, decltype(std::hash<absl::remove_const_t<T> >()(
                                  std::declval<absl::remove_const_t<T> >()))> {
   using argument_type = absl::optional<T>;
   using result_type = size_t;
-  size_t operator()(const absl::optional<T>& opt) const {
+  size_t operator()(const absl::optional<T>& opt) const noexcept {
     if (opt) {
       return std::hash<absl::remove_const_t<T> >()(*opt);
     } else {


### PR DESCRIPTION
hash operator() must not throw exceptions, so let it be noexcept