### PR TITLE
Add config_setting for cpu value equals x64_windows

### DIFF
--- a/absl/BUILD.bazel
+++ b/absl/BUILD.bazel
@@ -36,6 +36,14 @@ config_setting(
 config_setting(
     name = "windows",
     values = {
+        "cpu": "x64_windows",
+    },
+)
+
+# TODO: Remove the following config_setting when nobody is using --cpu=x64_windows_msvc
+config_setting(
+    name = "windows_msvc",
+    values = {
         "cpu": "x64_windows_msvc",
     },
 )

--- a/absl/base/BUILD.bazel
+++ b/absl/base/BUILD.bazel
@@ -331,6 +331,7 @@ cc_test(
     copts = ABSL_TEST_COPTS,
     linkopts = select({
         "//absl:windows": [],
+        "//absl:windows_msvc": [],
         "//conditions:default": ["-pthread"],
     }),
     deps = [":malloc_internal"],
@@ -343,6 +344,7 @@ cc_test(
     copts = ABSL_TEST_COPTS,
     linkopts = select({
         "//absl:windows": [],
+        "//absl:windows_msvc": [],
         "//conditions:default": ["-pthread"],
     }),
     deps = [
@@ -359,6 +361,9 @@ cc_test(
     srcs = ["internal/malloc_extension_test.cc"],
     copts = select({
         "//absl:windows": [
+            "/DABSL_MALLOC_EXTENSION_TEST_ALLOW_MISSING_EXTENSION=1",
+        ],
+        "//absl:windows_msvc": [
             "/DABSL_MALLOC_EXTENSION_TEST_ALLOW_MISSING_EXTENSION=1",
         ],
         "//conditions:default": [

--- a/absl/copts.bzl
+++ b/absl/copts.bzl
@@ -114,6 +114,7 @@ MSVC_TEST_FLAGS = [
 # /Wall with msvc includes unhelpful warnings such as C4711, C4710, ...
 ABSL_DEFAULT_COPTS = select({
     "//absl:windows": MSVC_FLAGS,
+    "//absl:windows_msvc": MSVC_FLAGS,
     "//absl:llvm_compiler": LLVM_FLAGS,
     "//conditions:default": GCC_FLAGS,
 })
@@ -122,11 +123,13 @@ ABSL_DEFAULT_COPTS = select({
 # to their (included header) dependencies and fail to build outside absl
 ABSL_TEST_COPTS = ABSL_DEFAULT_COPTS + select({
     "//absl:windows": MSVC_TEST_FLAGS,
+    "//absl:windows_msvc": MSVC_TEST_FLAGS,
     "//absl:llvm_compiler": LLVM_TEST_FLAGS,
     "//conditions:default": GCC_TEST_FLAGS,
 })
 
 ABSL_EXCEPTIONS_FLAG = select({
     "//absl:windows": ["/U_HAS_EXCEPTIONS", "/D_HAS_EXCEPTIONS=1", "/EHsc"],
+    "//absl:windows_msvc": ["/U_HAS_EXCEPTIONS", "/D_HAS_EXCEPTIONS=1", "/EHsc"],
     "//conditions:default": ["-fexceptions"],
 })

--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -76,6 +76,7 @@ cc_library(
         # guaranteed definitions for weak symbols.
         "//absl:ios": [],
         "//absl:windows": [],
+        "//absl:windows_msvc": [],
         "//conditions:default": [
             "leak_check.cc",
         ],
@@ -83,6 +84,7 @@ cc_library(
     hdrs = select({
         "//absl:ios": [],
         "//absl:windows": [],
+        "//absl:windows_msvc": [],
         "//conditions:default": ["leak_check.h"],
     }),
     deps = ["//absl/base:core_headers"],


### PR DESCRIPTION
Now users don't have to add --cpu=x64_windows_msvc flag for Windows
build.

x64_windows is the default cpu value on Windows.
And the corresponding CROSSTOOL is using MSVC by default as well.

Still keep the x64_windows_msvc confg_setting, but it should be removed
in future.

Fix https://github.com/abseil/abseil-cpp/issues/15