### PR TITLE
Add Google-style .clang-format file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ will be expected to conform to the style outlined
     made and **why** it was made. Link to a GitHub issue if it exists.
 
 *   Don't fix code style and formatting unless you are already changing that
-    line to address an issue. PRs with irrelevant changes won't be merged. If
+    line to address an issue. Formatting of modified lines may be done using
+    `git clang-format`. PRs with irrelevant changes won't be merged. If
     you do want to fix formatting or style, do that in a separate PR.
 
 *   Unless your PR is trivial, you should expect there will be reviewer comments


### PR DESCRIPTION
It would be nice if the repository contained a clang-format
config file so that PR submitters could use tooling to correctly
format their code match Googles/abseils style.

This also makes it easier for reviewers to specify what coding style
should be used. ie the one the tooling produces.

The clang-format file is the default Google configuration as dumped by `clang-format`.
I'm not sure abseil will want the exact same options, but it seemed like the right
starting place.