### PR TITLE
Enhancing tests for unescaping strings

### DIFF
--- a/absl/strings/escaping_test.cc
+++ b/absl/strings/escaping_test.cc
@@ -281,96 +281,71 @@ TEST_F(CUnescapeTest, UnescapesMultipleUnicodeNulls) {
                    "\0", 5), result_string_);
 }
 
-TEST(CUnescape, NonNullTerminatedOctal1) {
-  absl::string_view reference("\\111", 2);
-
-  std::string unescaped_str;
-  EXPECT_TRUE(absl::CUnescape(reference, &unescaped_str));
-
-  EXPECT_EQ(unescaped_str, "\1");
+TEST_F(CUnescapeTest, NonNullTerminatedOctal1) {
+  absl::string_view original_string("\\111", 2);
+  EXPECT_TRUE(absl::CUnescape(original_string, &result_string_));
+  EXPECT_EQ(result_string_, "\1");
 }
 
-TEST(CUnescape, NonNullTerminatedOctal2) {
-  absl::string_view reference("\\1z1", 3);
-
-  std::string unescaped_str;
-  EXPECT_TRUE(absl::CUnescape(reference, &unescaped_str));
-
-  EXPECT_EQ(unescaped_str, "\1z");
+TEST_F(CUnescapeTest, NonNullTerminatedOctal2) {
+  absl::string_view original_string("\\1z1", 3);
+  EXPECT_TRUE(absl::CUnescape(original_string, &result_string_));
+  EXPECT_EQ(result_string_, "\1z");
 }
 
-TEST(CUnescape, NonNullTerminatedHex) {
-  absl::string_view reference("\\x11", 3);
-
-  std::string unescaped_str;
-  EXPECT_TRUE(absl::CUnescape(reference, &unescaped_str));
-
-  EXPECT_EQ(unescaped_str, "\x1");
+TEST_F(CUnescapeTest, HexUnescapingDoesNotOverrunBuffer) {
+  absl::string_view original_string("\\x11", 3);
+  EXPECT_TRUE(absl::CUnescape(original_string, &result_string_));
+  EXPECT_EQ(result_string_, "\x1");
 }
 
-TEST(CUnescape, NonNullTerminatedInvalidHex) {
-  absl::string_view reference("\\x1", 2);
-
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape(reference, &unescaped_str));
+TEST_F(CUnescapeTest, NonNullTerminatedInvalidHex) {
+  absl::string_view original_string("\\x1", 2);
+  EXPECT_FALSE(absl::CUnescape(original_string, &result_string_));
 }
 
-TEST(CUnescape, NonNullTerminatedInvalidUtf1) {
-  absl::string_view reference("\\u11111", 5);
-
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape(reference, &unescaped_str));
+TEST_F(CUnescapeTest, ShortUnicodeUnescapingDoesNotOverrunBuffer) {
+  absl::string_view original_string("\\u11111", 5);
+  EXPECT_FALSE(absl::CUnescape(original_string, &result_string_));
 }
 
-TEST(CUnescape, NonNullTerminatedInvalidUtf2) {
-  absl::string_view reference("\\u1z11", 6);
-
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape(reference, &unescaped_str));
+TEST_F(CUnescapeTest, NonNullTerminatedInvalidUnicode) {
+  absl::string_view original_string("\\U0000000000000", 9);
+  EXPECT_FALSE(absl::CUnescape(original_string, &result_string_));
 }
 
-TEST(CUnescape, NonNullTerminatedInvalidUtf3) {
-  absl::string_view reference("\\U0000000000000", 9);
-
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape(reference, &unescaped_str));
+TEST_F(CUnescapeTest, InvalidHex) {
+  EXPECT_FALSE(absl::CUnescape("\\xz", &result_string_));
 }
 
-TEST(CUnescape, InvalidHex) {
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape("\\xz", &unescaped_str));
+TEST_F(CUnescapeTest, InvalidLongUnicode) {
+  EXPECT_FALSE(absl::CUnescape("\\U1z111111", &result_string_));
 }
 
-TEST(CUnescape, InvalidUtf) {
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape("\\U1z111111", &unescaped_str));
+TEST_F(CUnescapeTest, InvalidShortUnicode) {
+  EXPECT_FALSE(absl::CUnescape("\\u1z11", &result_string_));
 }
 
-TEST(CUnescape, InvalidEscaping) {
-  std::string unescaped_str;
-  EXPECT_FALSE(absl::CUnescape("\\z", &unescaped_str));
+TEST_F(CUnescapeTest, InvalidEscapedCharacter) {
+  EXPECT_FALSE(absl::CUnescape("\\z", &result_string_));
 }
 
-TEST(CUnescape, OctalLimits) {
-  std::string reference = "\\377";
-  std::string expected = "\377";
+TEST_F(CUnescapeTest, OctalLimits) {
+  std::string original_string = "\\377";
 
-  std::string unescaped_str;
-  EXPECT_TRUE(absl::CUnescape(reference, &unescaped_str));
-  EXPECT_EQ(unescaped_str, expected);
+  EXPECT_TRUE(absl::CUnescape(original_string, &result_string_));
+  EXPECT_EQ(result_string_, "\377");
 
-  EXPECT_FALSE(absl::CUnescape("\\400", &unescaped_str));
+  EXPECT_FALSE(absl::CUnescape("\\400", &result_string_));
 }
 
-TEST(CUnescape, UtfULimits) {
-  std::string reference = "\\U0010FFFF";
-  std::string expected = "\U0010FFFF";
+TEST_F(CUnescapeTest, UnicodeLimits) {
+  std::string original_string = "\\U0010FFFF";
 
-  std::string unescaped_str;
-  EXPECT_TRUE(absl::CUnescape(reference, &unescaped_str));
-  EXPECT_EQ(unescaped_str, expected);
+  EXPECT_TRUE(absl::CUnescape(original_string, &result_string_));
+  EXPECT_EQ(result_string_, "\U0010FFFF");
 
-  EXPECT_FALSE(absl::CUnescape("\\U00110000", &unescaped_str));
+  EXPECT_FALSE(absl::CUnescape("\\U00110000", &result_string_));
 }
 
 static struct {


### PR DESCRIPTION
These tests enhance the coverage of CUnescapeInternal method from absl/strings/escaping.cc.

I want to start contributing, so this first pull request serves more as experience.

I took the CUnescapeInternal method and systematically inserted small bugs to check the test coverage. From that experience, I found a few modifications that went undetected and added tests specifically for them.

I'm not sure how valuable this is since this function looks very stable. But I believe the PR would still be a good addition to the test suite in case this is changed for optimizations in the future.

See below a set of changes that would go undetected (if done individually).

```
--- a/absl/strings/escaping.cc
+++ b/absl/strings/escaping.cc
@@ -95,6 +95,7 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
   const char* p = source.data();
   const char* end = source.end();
   const char* last_byte = end - 1;
+//const char* last_byte = end - 0;
 
   // Small optimization for case where source = dest and there's no escaping
   while (p == d && p < end && *p != '\\') p++, d++;
@@ -131,9 +132,11 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
           const char* octal_start = p;
           unsigned int ch = *p - '0';
           if (p < last_byte && is_octal_digit(p[1])) ch = ch * 8 + *++p - '0';
+//        if (p <= last_byte && is_octal_digit(p[2])) ch = ch * 8 + *++p - '0';
           if (p < last_byte && is_octal_digit(p[1]))
+//        if (p <= last_byte && is_octal_digit(p[1]))
             ch = ch * 8 + *++p - '0';      // now points at last digit
           if (ch > 0xff) {
+//        if (ch >= 0xff) {
             if (error) {
               *error = "Value of \\" +
                        std::string(octal_start, p + 1 - octal_start) +
@@ -155,11 +158,14 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
         case 'x':
         case 'X': {
           if (p >= last_byte) {
+//        if (p > last_byte) {
             if (error) *error = "String cannot end with \\x";
             return false;
+//        /*return false;*/
           } else if (!absl::ascii_isxdigit(p[1])) {
             if (error) *error = "\\x cannot be followed by a non-hex digit";
             return false;
+//        /*return false;*/
           }
           unsigned int ch = 0;
           const char* hex_start = p;
@@ -194,6 +200,7 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
                        std::string(hex_start, p + 1 - hex_start);
             }
             return false;
+//        /*return false;*/
           }
           for (int i = 0; i < 4; ++i) {
             // Look one char ahead.
@@ -205,6 +212,7 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
                          std::string(hex_start, p + 1 - hex_start);
               }
               return false;
+//          /*return false;*/
             }
           }
           if ((rune == 0) && leave_nulls_escaped) {
@@ -227,6 +235,7 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
                        std::string(hex_start, p + 1 - hex_start);
             }
             return false;
+//        /*return false;*/
           }
           for (int i = 0; i < 8; ++i) {
             // Look one char ahead.
@@ -235,12 +244,14 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
               // is within the Unicode limit, but do advance p.
               uint32_t newrune = (rune << 4) + hex_digit_to_int(*++p);
               if (newrune > 0x10FFFF) {
+//            if (newrune >= 0x10FFFF) {
                 if (error) {
                   *error = "Value of \\" +
                            std::string(hex_start, p + 1 - hex_start) +
                            " exceeds Unicode limit (0x10FFFF)";
                 }
                 return false;
+//            /*return false;*/
               } else {
                 rune = newrune;
               }
@@ -250,6 +261,7 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
                          std::string(hex_start, p + 1 - hex_start);
               }
               return false;
+//          /*return false;*/
             }
           }
           if ((rune == 0) && leave_nulls_escaped) {
@@ -265,6 +277,7 @@ bool CUnescapeInternal(absl::string_view source, bool leave_nulls_escaped,
         default: {
           if (error) *error = std::string("Unknown escape sequence: \\") + *p;
           return false;
+//      /*return false;*/
         }
       }
       p++;                                 // read past letter we escaped


```
