### PR TITLE
Fix CMakeLists.txt for ostringstream_test

### DIFF
--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -49,6 +49,7 @@ list(APPEND STRINGS_SRC
   "internal/memutil.cc"
   "internal/memutil.h"
   "internal/utf8.cc"
+  "internal/ostringstream.cc"
   "match.cc"
   "numbers.cc"
   "str_cat.cc"
@@ -205,12 +206,15 @@ absl_test(
 
 # test ostringstream_test
 set(OSTRINGSTREAM_TEST_SRC "internal/ostringstream_test.cc")
+set(OSTRINGSTREAM_TEST_PUBLIC_LIBRARIES absl::strings)
 
 absl_test(
   TARGET
     ostringstream_test
   SOURCES
     ${OSTRINGSTREAM_TEST_SRC}
+  PUBLIC_LIBRARIES
+    ${OSTRINGSTREAM_TEST_PUBLIC_LIBRARIES}
 )
 
 


### PR DESCRIPTION
After commit 99b92c87 compiling with CMake stopped working. This commit fixes the issue.