### PR TITLE
MSVC fixes

### DIFF
--- a/CMake/README.md
+++ b/CMake/README.md
@@ -43,6 +43,11 @@
 
       set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 
+      if (MSVC)
+        add_compile_options(/wd4005 /wd4068 /wd4244 /wd4267 /wd4800)
+        add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS)
+      endif()
+
       add_subdirectory(googletest)
       add_subdirectory(cctz)
       add_subdirectory(abseil-cpp)
@@ -51,7 +56,7 @@
       target_link_libraries(my_exe absl::base absl::synchronization absl::strings)
 
 
-You will need to create your own CMake files for cctz until https://github.com/google/cctz/pull/54 lands.  As of this writing, that pull request requires -DBUILD_TESTING=OFF as it doesn't correctly export cctz's dependency on Google Benchmark.
+As of this writing, that pull request requires -DBUILD_TESTING=OFF as it doesn't correctly export cctz's dependency on Google Benchmark.
 
     You will find here a non exhaustive list of absl public targets
 

--- a/CMake/README.md
+++ b/CMake/README.md
@@ -44,6 +44,11 @@
       set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 
       if (MSVC)
+        # /wd4005  macro-redefinition
+        # /wd4068  unknown pragma
+        # /wd4244  conversion from 'type1' to 'type2'
+        # /wd4267  conversion from 'size_t' to 'type2'
+        # /wd4800  force value to bool 'true' or 'false' (performance warning)
         add_compile_options(/wd4005 /wd4068 /wd4244 /wd4267 /wd4800)
         add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS)
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,13 @@ include(AbseilHelpers)
 
 # config options
 if (MSVC)
-  add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS)
+  # /wd4005  macro-redefinition
+  # /wd4068  unknown pragma
+  # /wd4244  conversion from 'type1' to 'type2'
+  # /wd4267  conversion from 'size_t' to 'type2'
+  # /wd4800  force value to bool 'true' or 'false' (performance warning)
   add_compile_options(/W3 /WX /wd4005 /wd4068 /wd4244 /wd4267 /wd4800)
+  add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS)
 else()
   set(ABSL_STD_CXX_FLAG "-std=c++11" CACHE STRING "c++ std flag (default: c++11)")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,12 @@ include(AbseilHelpers)
 
 
 # config options
-set(ABSL_STD_CXX_FLAG "-std=c++11" CACHE STRING "c++ std flag (default: c++11)")
+if (MSVC)
+  add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS)
+  add_compile_options(/W3 /WX /wd4005 /wd4068 /wd4244 /wd4267 /wd4800)
+else()
+  set(ABSL_STD_CXX_FLAG "-std=c++11" CACHE STRING "c++ std flag (default: c++11)")
+endif()
 
 
 
@@ -65,9 +70,6 @@ check_target(gmock)
 
 # -fexceptions
 set(ABSL_EXCEPTIONS_FLAG "${CMAKE_CXX_EXCEPTIONS}")
-
-# fix stuff
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FIX_MSVC} ${CMAKE_CXX_FLAGS}")
 
 list(APPEND ABSL_TEST_COMMON_LIBRARIES
   gtest_main

--- a/absl/copts.bzl
+++ b/absl/copts.bzl
@@ -103,7 +103,9 @@ MSVC_FLAGS = [
     "/wd4244",  # conversion from 'type1' to 'type2', possible loss of data
     "/wd4267",  # conversion from 'size_t' to 'type', possible loss of data
     "/wd4800",  # forcing value to bool 'true' or 'false' (performance warning)
+    "/DNOMINMAX",  # Don't define min and max macros (windows.h)
     "/DWIN32_LEAN_AND_MEAN",  # Don't bloat namespace with incompatible winsock versions.
+    "/D_CRT_SECURE_NO_WARNINGS",  # Don't warn about usage of insecure C functions
 ]
 
 MSVC_TEST_FLAGS = [

--- a/absl/time/clock.cc
+++ b/absl/time/clock.cc
@@ -510,7 +510,7 @@ namespace {
 // Returns the maximum duration that SleepOnce() can sleep for.
 constexpr absl::Duration MaxSleep() {
 #ifdef _WIN32
-  // Windows _sleep() takes unsigned long argument in milliseconds.
+  // Windows Sleep() takes unsigned long argument in milliseconds.
   return absl::Milliseconds(
       std::numeric_limits<unsigned long>::max());  // NOLINT(runtime/int)
 #else
@@ -522,7 +522,7 @@ constexpr absl::Duration MaxSleep() {
 // REQUIRES: to_sleep <= MaxSleep().
 void SleepOnce(absl::Duration to_sleep) {
 #ifdef _WIN32
-  _sleep(to_sleep / absl::Milliseconds(1));
+  Sleep(to_sleep / absl::Milliseconds(1));
 #else
   struct timespec sleep_time = absl::ToTimespec(to_sleep);
   while (nanosleep(&sleep_time, &sleep_time) != 0 && errno == EINTR) {


### PR DESCRIPTION
With this PR, abseil can be built with CMake on Windows successfully.

- `NOMINMAX` is required to prevent `windows.h` from defining `min` and `max` macros, which mess up with things like `std::numeric_limits<T>::max()` as seen in #34 (Also added to Bazel).
- `_CRT_SECURE_NO_WARNINGS` is required to stop MSVC from complaining about the usage of insecure `getenv` over secure `getenv_s`. (Also added to Bazel).
- Deprecated `_sleep` is replaced with Win32 `Sleep` function.
- VS 2015 and above does not understand `-std=c++11` or `/std:c++11`, default is `/std:c++14`.
- `CMAKE_CXX_FIX_MSVC` is removed (not initialized by anyone).

The following code is needed in both abseil side and user side because `add_subdirectory` will not export `CMAKE_CXX_FLAGS` outside the directory.

```cmake
add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS)  
add_compile_options(/W3 /WX /wd4005 /wd4068 /wd4244 /wd4267 /wd4800)
```