### PR TITLE
Fix build under MSVC

### DIFF
--- a/absl/base/internal/low_level_alloc.cc
+++ b/absl/base/internal/low_level_alloc.cc
@@ -35,6 +35,9 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #else
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 

--- a/absl/base/internal/spinlock_win32.inc
+++ b/absl/base/internal/spinlock_win32.inc
@@ -14,6 +14,9 @@
 //
 // This file is a Win32-specific part of spinlock_wait.cc
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <atomic>
 #include "absl/base/internal/scheduling_mode.h"

--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -15,6 +15,9 @@
 #include "absl/base/internal/sysinfo.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <shlwapi.h>
 #include <windows.h>
 #else

--- a/absl/debugging/internal/stacktrace_win32-inl.inc
+++ b/absl/debugging/internal/stacktrace_win32-inl.inc
@@ -37,6 +37,9 @@
 #ifndef ABSL_DEBUGGING_INTERNAL_STACKTRACE_WIN32_INL_H_
 #define ABSL_DEBUGGING_INTERNAL_STACKTRACE_WIN32_INL_H_
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>    // for GetProcAddress and GetModuleHandle
 #include <cassert>
 

--- a/absl/synchronization/internal/waiter.cc
+++ b/absl/synchronization/internal/waiter.cc
@@ -17,6 +17,9 @@
 #include "absl/base/config.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <pthread.h>

--- a/absl/synchronization/internal/waiter.h
+++ b/absl/synchronization/internal/waiter.h
@@ -19,6 +19,9 @@
 #include "absl/base/config.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <pthread.h>

--- a/absl/synchronization/mutex.cc
+++ b/absl/synchronization/mutex.cc
@@ -1,6 +1,9 @@
 #include "absl/synchronization/mutex.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #ifdef ERROR
 #undef ERROR

--- a/absl/synchronization/mutex_test.cc
+++ b/absl/synchronization/mutex_test.cc
@@ -15,6 +15,9 @@
 #include "absl/synchronization/mutex.h"
 
 #ifdef WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 

--- a/absl/time/clock.cc
+++ b/absl/time/clock.cc
@@ -1,6 +1,9 @@
 #include "absl/time/clock.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
MSVC defines macros named `min` and `max` which conflict with
std::min/std::max.