### PR TITLE
Fix builds with BUILD_TESTING=OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,12 @@ find_package(Threads REQUIRED)
 
 ## check targets
 check_target(cctz)
-check_target(gtest)
-check_target(gtest_main)
-check_target(gmock)
+
+if (CONFIG_TESTING)
+  check_target(gtest)
+  check_target(gtest_main)
+  check_target(gmock)
+endif (CONFIG_TESTING)
 
 # -fexceptions
 set(ABSL_EXCEPTIONS_FLAG "${CMAKE_CXX_EXCEPTIONS}")


### PR DESCRIPTION
Abseil requires the gtest/gmock/gtest_main targets even for
builds where BUILD_TESTING=OFF, where those targets are not
used.

The attached [CMakeLists.txt](https://github.com/abseil/abseil-cpp/files/1601827/CMakeLists.txt) can be used to reproduce the problem.

