### PR TITLE
Converted absl_utility to Header-only CMake Target

### DIFF
--- a/absl/utility/CMakeLists.txt
+++ b/absl/utility/CMakeLists.txt
@@ -19,19 +19,12 @@ list(APPEND UTILITY_PUBLIC_HEADERS
   "utility.h"
 )
 
-
-
-list(APPEND UTILITY_SRC
-  ${UTILITY_PUBLIC_HEADERS}
-)
-
 absl_header_library(
   TARGET
     absl_utility
   EXPORT_NAME
     utility
 )
-
 
 
 #

--- a/absl/utility/CMakeLists.txt
+++ b/absl/utility/CMakeLists.txt
@@ -25,13 +25,9 @@ list(APPEND UTILITY_SRC
   ${UTILITY_PUBLIC_HEADERS}
 )
 
-absl_library(
+absl_header_library(
   TARGET
     absl_utility
-  SOURCES
-    ${UTILITY_SRC}
-  PUBLIC_LIBRARIES
-    ${UTILITY_PUBLIC_LIBRARIES}
   EXPORT_NAME
     utility
 )


### PR DESCRIPTION
When generating a build with CMake, I got the following error:
```
-- Configuring done
CMake Error: Cannot determine link language for target "absl_utility".
CMake Error: CMake can not determine linker language for target: absl_utility
```

Currently absl_utility has no actual sources, so there really isn't a link language. To correct this, I simply replicated the Header-only CMake config in [absl_algorithm](https://github.com/abseil/abseil-cpp/blob/master/absl/algorithm/CMakeLists.txt).