### PR TITLE
Fix tests for the cmake-build

### DIFF
--- a/absl/types/CMakeLists.txt
+++ b/absl/types/CMakeLists.txt
@@ -130,7 +130,7 @@ absl_test(
 
 # test any_exception_safety_test
 set(ANY_EXCEPTION_SAFETY_TEST_SRC "any_exception_safety_test.cc")
-set(ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES absl::any absl::base)
+set(ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES absl::any absl::base absl::bad_any_cast absl::strings)
 
 absl_test(
   TARGET

--- a/absl/types/CMakeLists.txt
+++ b/absl/types/CMakeLists.txt
@@ -130,7 +130,7 @@ absl_test(
 
 # test any_exception_safety_test
 set(ANY_EXCEPTION_SAFETY_TEST_SRC "any_exception_safety_test.cc")
-set(ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES absl::any absl::base absl::bad_any_cast absl::strings)
+set(ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES absl::bad_any_cast absl::strings)
 
 absl_test(
   TARGET

--- a/absl/utility/CMakeLists.txt
+++ b/absl/utility/CMakeLists.txt
@@ -44,7 +44,7 @@ absl_library(
 
 # test utility_test
 set(UTILITY_TEST_SRC "utility_test.cc")
-set(UTILITY_TEST_PUBLIC_LIBRARIES absl::utility)
+set(UTILITY_TEST_PUBLIC_LIBRARIES absl::utility absl::strings)
 
 absl_test(
   TARGET

--- a/absl/utility/CMakeLists.txt
+++ b/absl/utility/CMakeLists.txt
@@ -44,7 +44,7 @@ absl_library(
 
 # test utility_test
 set(UTILITY_TEST_SRC "utility_test.cc")
-set(UTILITY_TEST_PUBLIC_LIBRARIES absl::utility absl::strings)
+set(UTILITY_TEST_PUBLIC_LIBRARIES absl::utility absl::strings absl::memory)
 
 absl_test(
   TARGET


### PR DESCRIPTION
Some tests are failing to compile on the link-stage. This commit fixes it.