### PR TITLE
Annotate printf-like functions as such

### DIFF
--- a/absl/base/internal/raw_logging.cc
+++ b/absl/base/internal/raw_logging.cc
@@ -81,6 +81,8 @@ static const char kTruncated[] = " ... (message truncated)\n";
 // consumed bytes, and return whether the message fit without truncation.  If
 // truncation occurred, if possible leave room in the buffer for the message
 // kTruncated[].
+inline static bool VADoRawLog(char** buf, int* size, const char* format,
+                              va_list ap) ABSL_PRINTF_ATTRIBUTE(3, 0);
 inline static bool VADoRawLog(char** buf, int* size,
                               const char* format, va_list ap) {
   int n = vsnprintf(*buf, *size, format, ap);
@@ -128,6 +130,8 @@ bool DoRawLog(char** buf, int* size, const char* format, ...) {
   return true;
 }
 
+void RawLogVA(absl::LogSeverity severity, const char* file, int line,
+              const char* format, va_list ap) ABSL_PRINTF_ATTRIBUTE(4, 0);
 void RawLogVA(absl::LogSeverity severity, const char* file, int line,
               const char* format, va_list ap) {
   char buffer[kLogBufSize];
@@ -203,6 +207,8 @@ void SafeWriteToStderr(const char *s, size_t len) {
 #endif
 }
 
+void RawLog(absl::LogSeverity severity, const char* file, int line,
+            const char* format, ...) ABSL_PRINTF_ATTRIBUTE(4, 5);
 void RawLog(absl::LogSeverity severity, const char* file, int line,
             const char* format, ...) {
   va_list ap;

--- a/absl/base/internal/raw_logging.cc
+++ b/absl/base/internal/raw_logging.cc
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "absl/base/attributes.h"
 #include "absl/base/config.h"
 #include "absl/base/internal/atomic_hook.h"
 #include "absl/base/log_severity.h"


### PR DESCRIPTION
This solves the following error:

```
../absl/base/internal/raw_logging.cc:86:34: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
  int n = vsnprintf(*buf, *size, format, ap);
```