### PR TITLE
Fixes a failed compiler version check for clang-cl

### DIFF
--- a/absl/base/policy_checks.h
+++ b/absl/base/policy_checks.h
@@ -46,7 +46,7 @@
 
 // We support MSVC++ 14.0 update 2 and later.
 // This minimum will go up.
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023918
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023918 && !defined(__clang__)
 #error "This package requires Visual Studio 2015 Update 2 or higher"
 #endif
 


### PR DESCRIPTION
clang-cl identifies itself as MSVC, which limits the code features unnecessary.