### PR TITLE
Add configurable support for selecting mutex_nonprod.

### DIFF
--- a/absl/synchronization/BUILD.bazel
+++ b/absl/synchronization/BUILD.bazel
@@ -24,6 +24,13 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+config_setting(
+    name = "use_nonprod_mutex",
+    values = {
+      "define": "ABSL_USE_NONPROD_MUTEX=1",
+    },
+)
+
 # Internal data structure for efficiently detecting mutex dependency cycles
 cc_library(
     name = "graphcycles_internal",
@@ -54,6 +61,7 @@ cc_library(
         "internal/waiter.cc",
         "notification.cc",
     ] + select({
+        ":use_nonprod_mutex": ["internal/mutex_nonprod.cc"],
         "//conditions:default": ["mutex.cc"],
     }),
     hdrs = [

--- a/absl/synchronization/mutex.h
+++ b/absl/synchronization/mutex.h
@@ -75,7 +75,7 @@
 // the production implementation hasn't been fully ported yet.
 #ifdef ABSL_INTERNAL_USE_NONPROD_MUTEX
 #error ABSL_INTERNAL_USE_NONPROD_MUTEX cannot be directly set
-#elif defined(ABSL_LOW_LEVEL_ALLOC_MISSING)
+#elif defined(ABSL_LOW_LEVEL_ALLOC_MISSING) || defined(ABSL_USE_NONPROD_MUTEX)
 #define ABSL_INTERNAL_USE_NONPROD_MUTEX 1
 #include "absl/synchronization/internal/mutex_nonprod.inc"
 #endif


### PR DESCRIPTION
Our platform needs to be able to select the nonprod implementation of absl::Mutex. We can add --ABSL_USE_NONPROD_MUTEX=1 to our .bazelrc and compiler_flag: "-DABSL_USE_NONPROD_MUTEX" in our CROSSTOOL.