### PR TITLE
Set the FOLDER property for Abseil targets.

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -16,6 +16,11 @@
 
 include(CMakeParseArguments)
 
+# The IDE folder for Abseil that will be used if Abseil is included in a CMake
+# project that sets
+#    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+# For example, Visual Studio supports folders.
+set(ABSL_IDE_FOLDER Abseil)
 
 #
 # create a library in the absl namespace
@@ -50,7 +55,7 @@ function(absl_library)
     PRIVATE ${ABSL_LIB_PRIVATE_INCLUDE_DIRS}
   )
   # Add all Abseil targets to a a folder in the IDE for organization.
-  set_property(TARGET ${_NAME} PROPERTY FOLDER Abseil)
+  set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
 
   if(ABSL_LIB_EXPORT_NAME)
     add_library(absl::${ABSL_LIB_EXPORT_NAME} ALIAS ${_NAME})
@@ -95,7 +100,7 @@ function(absl_header_library)
     PRIVATE ${ABSL_HO_LIB_PRIVATE_INCLUDE_DIRS}
   )
   # Add all Abseil targets to a a folder in the IDE for organization.
-  set_property(TARGET ${_NAME} PROPERTY FOLDER Abseil)
+  set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
 
   if(ABSL_HO_LIB_EXPORT_NAME)
     add_library(absl::${ABSL_HO_LIB_EXPORT_NAME} ALIAS ${_NAME})
@@ -143,7 +148,7 @@ function(absl_test)
       PRIVATE ${GMOCK_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS}
     )
     # Add all Abseil targets to a a folder in the IDE for organization.
-    set_property(TARGET ${_NAME}_bin PROPERTY FOLDER Abseil)
+    set_property(TARGET ${_NAME}_bin PROPERTY FOLDER ${ABSL_IDE_FOLDER})
 
     add_test(${_NAME} ${_NAME}_bin)
   endif(BUILD_TESTING)

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -49,6 +49,8 @@ function(absl_library)
     PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_LIB_PUBLIC_INCLUDE_DIRS}
     PRIVATE ${ABSL_LIB_PRIVATE_INCLUDE_DIRS}
   )
+  # Add all Abseil targets to a a folder in the IDE for organization.
+  set_property(TARGET ${_NAME} PROPERTY FOLDER Abseil)
 
   if(ABSL_LIB_EXPORT_NAME)
     add_library(absl::${ABSL_LIB_EXPORT_NAME} ALIAS ${_NAME})
@@ -92,6 +94,8 @@ function(absl_header_library)
     PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_HO_LIB_PUBLIC_INCLUDE_DIRS}
     PRIVATE ${ABSL_HO_LIB_PRIVATE_INCLUDE_DIRS}
   )
+  # Add all Abseil targets to a a folder in the IDE for organization.
+  set_property(TARGET ${_NAME} PROPERTY FOLDER Abseil)
 
   if(ABSL_HO_LIB_EXPORT_NAME)
     add_library(absl::${ABSL_HO_LIB_EXPORT_NAME} ALIAS ${_NAME})
@@ -138,6 +142,8 @@ function(absl_test)
       PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_TEST_PUBLIC_INCLUDE_DIRS}
       PRIVATE ${GMOCK_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS}
     )
+    # Add all Abseil targets to a a folder in the IDE for organization.
+    set_property(TARGET ${_NAME}_bin PROPERTY FOLDER Abseil)
 
     add_test(${_NAME} ${_NAME}_bin)
   endif(BUILD_TESTING)


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.0/prop_tgt/FOLDER.html
This only affects IDEs and will further only take effect if

    set_property(GLOBAL PROPERTY USE_FOLDERS ON)

is set in the main CMakeLists.txt of the project.

I found using this quite helpful when adding Abseil to larger CMake
projects.