### PR TITLE
Add MIPS support to GetProgramCounter()

### DIFF
--- a/absl/debugging/internal/examine_stack.cc
+++ b/absl/debugging/internal/examine_stack.cc
@@ -46,6 +46,8 @@ void* GetProgramCounter(void* vuc) {
 #elif defined(__i386__)
     if (14 < ABSL_ARRAYSIZE(context->uc_mcontext.gregs))
       return reinterpret_cast<void*>(context->uc_mcontext.gregs[14]);
+#elif defined(__mips__)
+    return reinterpret_cast<void*>(context->uc_mcontext.pc);
 #elif defined(__powerpc64__)
     return reinterpret_cast<void*>(context->uc_mcontext.gp_regs[32]);
 #elif defined(__powerpc__)


### PR DESCRIPTION
Change adds __mips__ case to the GetProgramCounter function in abseil.

Chromium bug: 850029