### PR TITLE
Fix CMake declaration for absl_str_format

### DIFF
--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -82,11 +82,9 @@ absl_library(
 )
 
 # add str_format library
-absl_library(
+absl_header_library(
   TARGET
     absl_str_format
-  SOURCES
-    "str_format.h"
   PUBLIC_LIBRARIES
     str_format_internal
   EXPORT_NAME
@@ -94,7 +92,7 @@ absl_library(
 )
 
 # str_format_internal
- absl_library(
+absl_library(
   TARGET
     str_format_internal
   SOURCES
@@ -123,7 +121,7 @@ absl_library(
 # str_format_extension_internal
 absl_library(
   TARGET
-  str_format_extension_internal
+    str_format_extension_internal
   SOURCES
     "internal/str_format/extension.cc"
     "internal/str_format/extension.h"


### PR DESCRIPTION
`absl_str_format` target has only one header file. When `absl_library` is used but `SOURCES` only has header files, CMake won't create an archive (`.lib` or `.a`), so final linking will fail because build system cannot find the archive.

Change `absl_str_format` to `absl_header_library` that depends on `str_format_internal`, CMake will figure out the rest.

Many congrats for releasing `str_format`, it is huge!