### PR TITLE
[CMake] Implement absl_cc_library as Bazel's cc_library 

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -121,7 +121,7 @@ function(absl_cc_library)
     ${ARGN}
   )
 
-  if (NOT ABSL_CC_LIB_TESTONLY OR BUILD_TESTING)
+  if (NOT ABSL_CC_LIB_TESTONLY OR ABSL_RUN_TESTS)
     set(_NAME "absl_${ABSL_CC_LIB_NAME}")
     string(TOUPPER ${_NAME} _UPPER_NAME)
 

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -73,7 +73,7 @@ endfunction()
 # COPTS: List of private compile options
 # DEFINES: List of public defines
 # LINKOPTS: List of link options
-# VISIBILITY_PUBLIC: Add this so that this library will be exported under absl:: (see Note).
+# PUBLIC: Add this so that this library will be exported under absl:: (see Note).
 # TESTONLY: When added, this target will only be built if user passes -DBUILD_TESTING=ON to CMake.
 #
 # Note:
@@ -99,14 +99,14 @@ endfunction()
 #     absl_internal_awesome_lib # not "awesome_lib"!
 # )
 #
-# If VISIBILITY_PUBLIC is set, absl_cc_library will also create an alias absl::${NAME}
+# If PUBLIC is set, absl_cc_library will also create an alias absl::${NAME}
 # for public use in addition to absl_internal_${NAME}.
 #
 # absl_cc_library(
 #   NAME
 #     main_lib
 #   ...
-#   VISIBILITY_PUBLIC
+#   PUBLIC
 # )
 #
 # User can then use the library as absl::main_lib (although absl_internal_main_lib is defined too).
@@ -115,7 +115,7 @@ endfunction()
 
 function(absl_cc_library)
   cmake_parse_arguments(ABSL_CC_LIB
-    "DISABLE_INSTALL;VISIBILITY_PUBLIC;TESTONLY"
+    "DISABLE_INSTALL;PUBLIC;TESTONLY"
     "NAME"
     "HDRS;SRCS;COPTS;DEFINES;LINKOPTS;DEPS"
     ${ARGN}
@@ -123,7 +123,6 @@ function(absl_cc_library)
 
   if (NOT ABSL_CC_LIB_TESTONLY OR ABSL_RUN_TESTS)
     set(_NAME "absl_internal_${ABSL_CC_LIB_NAME}")
-    string(TOUPPER ${_NAME} _UPPER_NAME)
 
     # Check if this is a header-only library
     if (ABSL_CC_LIB_SRCS)
@@ -157,7 +156,7 @@ function(absl_cc_library)
       target_compile_definitions(${_NAME} INTERFACE ${ABSL_CC_LIB_DEFINES})
     endif()
 
-    if(ABSL_CC_LIB_VISIBILITY_PUBLIC)
+    if(ABSL_CC_LIB_PUBLIC)
       add_library(absl::${ABSL_CC_LIB_NAME} ALIAS ${_NAME})
     endif()
   endif()

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -136,34 +136,26 @@ function(absl_cc_library)
 
     if(ABSL_CC_LIB_SRCS_LEN)
       add_library(${_NAME} STATIC ${ABSL_CC_LIB_SRCS} ${ABSL_CC_LIB_HDRS})
+      target_include_directories(${_NAME}
+        PUBLIC ${ABSL_COMMON_INCLUDE_DIRS})
+      target_compile_options(${_NAME}
+        PRIVATE ${ABSL_COMPILE_CXXFLAGS} ${ABSL_CC_LIB_COPTS})
+      target_link_libraries(${_NAME}
+        PUBLIC ${ABSL_CC_LIB_DEPS}
+        PRIVATE ${ABSL_CC_LIB_LINKOPTS}
+      )
+      target_compile_definitions(${_NAME} PUBLIC ${ABSL_CC_LIB_DEFINES})
+
+      # Add all Abseil targets to a a folder in the IDE for organization.
+      set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
     else()
-      set(__dummy_header_only_lib_file "${CMAKE_CURRENT_BINARY_DIR}/${_NAME}_header_only_dummy.cc")
-
-      if(NOT EXISTS ${__dummy_header_only_lib_file})
-        file(WRITE ${__dummy_header_only_lib_file}
-          "/* generated file for header-only cmake target */
-
-          namespace absl {
-            // single meaningless symbol
-            void ${_NAME}__header_fakesym() {}
-          }  // namespace absl")
-      endif()
-
-      add_library(${_NAME} ${__dummy_header_only_lib_file} ${ABSL_CC_LIB_HDRS})
+      add_library(${_NAME} INTERFACE)
+      target_include_directories(${_NAME} INTERFACE ${ABSL_COMMON_INCLUDE_DIRS})
+      target_link_libraries(${_NAME}
+        INTERFACE ${ABSL_CC_LIB_DEPS} ${ABSL_CC_LIB_LINKOPTS}
+      )
+      target_compile_definitions(${_NAME} INTERFACE ${ABSL_CC_LIB_DEFINES})
     endif()
-
-    target_compile_options(${_NAME} PRIVATE ${ABSL_COMPILE_CXXFLAGS} ${ABSL_CC_LIB_COPTS})
-    target_link_libraries(${_NAME}
-      PUBLIC ${ABSL_CC_LIB_DEPS}
-      PRIVATE ${ABSL_CC_LIB_LINKOPTS}
-    )
-    target_compile_definitions(${_NAME} PUBLIC ${ABSL_CC_LIB_DEFINES})
-
-    target_include_directories(${_NAME}
-      PUBLIC ${ABSL_COMMON_INCLUDE_DIRS}
-    )
-    # Add all Abseil targets to a a folder in the IDE for organization.
-    set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
 
     if(ABSL_CC_LIB_VISIBILITY_PUBLIC)
       add_library(absl::${ABSL_CC_LIB_NAME} ALIAS ${_NAME})

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -137,6 +137,7 @@ function(absl_cc_library)
       add_library(${_NAME} STATIC ${ABSL_CC_LIB_SRCS} ${ABSL_CC_LIB_HDRS})
       target_include_directories(${_NAME}
         PUBLIC ${ABSL_COMMON_INCLUDE_DIRS})
+      # TODO(rongjiecomputer): Revisit ABSL_COMPILE_CXXFLAGS when fixing GH#123
       target_compile_options(${_NAME}
         PRIVATE ${ABSL_COMPILE_CXXFLAGS} ${ABSL_CC_LIB_COPTS})
       target_link_libraries(${_NAME}
@@ -148,6 +149,7 @@ function(absl_cc_library)
       # Add all Abseil targets to a a folder in the IDE for organization.
       set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
     else()
+      # Generating header-only library
       add_library(${_NAME} INTERFACE)
       target_include_directories(${_NAME} INTERFACE ${ABSL_COMMON_INCLUDE_DIRS})
       target_link_libraries(${_NAME}

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -129,16 +129,15 @@ function(absl_cc_library)
     endif()
 
     # Check if this is a header-only library
-    if (ABSL_CC_LIB_SRCS)
-      set(_SRCS ${ABSL_CC_LIB_SRCS})
-      list(FILTER _SRCS INCLUDE REGEX "\.cc$")
-      list(LENGTH _SRCS ABSL_CC_LIB_SRCS_LEN)
+    if ("${ABSL_CC_LIB_SRCS}" STREQUAL "")
+      set(ABSL_CC_LIB_IS_INTERFACE 1)
     else()
-      set(ABSL_CC_LIB_SRCS_LEN 0)
+      set(ABSL_CC_LIB_IS_INTERFACE 0)
     endif()
 
-    if(ABSL_CC_LIB_SRCS_LEN)
-      add_library(${_NAME} STATIC ${ABSL_CC_LIB_SRCS} ${ABSL_CC_LIB_HDRS})
+    if(NOT ABSL_CC_LIB_IS_INTERFACE)
+      add_library(${_NAME} STATIC "")
+      target_sources(${_NAME} PRIVATE ${ABSL_CC_LIB_SRCS} ${ABSL_CC_LIB_HDRS})
       target_include_directories(${_NAME}
         PUBLIC ${ABSL_COMMON_INCLUDE_DIRS})
       # TODO(rongjiecomputer): Revisit ABSL_COMPILE_CXXFLAGS when fixing GH#123

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -122,7 +122,11 @@ function(absl_cc_library)
   )
 
   if (NOT ABSL_CC_LIB_TESTONLY OR ABSL_RUN_TESTS)
-    set(_NAME "absl_internal_${ABSL_CC_LIB_NAME}")
+    if (ABSL_CC_LIB_PUBLIC)
+      set(_NAME "absl_${ABSL_CC_LIB_NAME}")
+    else()
+      set(_NAME "absl_internal_${ABSL_CC_LIB_NAME}")
+    endif()
 
     # Check if this is a header-only library
     if (ABSL_CC_LIB_SRCS)

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -74,7 +74,7 @@ endfunction()
 # DEFINES: List of public defines
 # LINKOPTS: List of link options
 # PUBLIC: Add this so that this library will be exported under absl:: (see Note).
-# TESTONLY: When added, this target will only be built if user passes -DBUILD_TESTING=ON to CMake.
+# TESTONLY: When added, this target will only be built if user passes -DABSL_RUN_TESTS=ON to CMake.
 #
 # Note:
 #

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -78,8 +78,8 @@ endfunction()
 #
 # Note:
 #
-# By default, absl_cc_library will always create a library named absl_${NAME},
-# which means other targets can only depend this library as absl_${NAME}, not ${NAME}.
+# By default, absl_cc_library will always create a library named absl_internal_${NAME},
+# which means other targets can only depend this library as absl_internal_${NAME}, not ${NAME}.
 # This is to reduce namespace pollution.
 #
 # absl_cc_library(
@@ -96,11 +96,11 @@ endfunction()
 #   SRCS
 #     "b.cc"
 #   DEPS
-#     absl_awesome_lib # not "awesome_lib"!
+#     absl_internal_awesome_lib # not "awesome_lib"!
 # )
 #
 # If VISIBILITY_PUBLIC is set, absl_cc_library will also create an alias absl::${NAME}
-# for public use.
+# for public use in addition to absl_internal_${NAME}.
 #
 # absl_cc_library(
 #   NAME
@@ -122,7 +122,7 @@ function(absl_cc_library)
   )
 
   if (NOT ABSL_CC_LIB_TESTONLY OR ABSL_RUN_TESTS)
-    set(_NAME "absl_${ABSL_CC_LIB_NAME}")
+    set(_NAME "absl_internal_${ABSL_CC_LIB_NAME}")
     string(TOUPPER ${_NAME} _UPPER_NAME)
 
     # Check if this is a header-only library

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -99,8 +99,8 @@ endfunction()
 #     absl_internal_awesome_lib # not "awesome_lib"!
 # )
 #
-# If PUBLIC is set, absl_cc_library will also create an alias absl::${NAME}
-# for public use in addition to absl_internal_${NAME}.
+# If PUBLIC is set, absl_cc_library will instead create a target named
+# absl_${NAME} and an alias absl::${NAME}.
 #
 # absl_cc_library(
 #   NAME
@@ -109,7 +109,7 @@ endfunction()
 #   PUBLIC
 # )
 #
-# User can then use the library as absl::main_lib (although absl_internal_main_lib is defined too).
+# User can then use the library as absl::main_lib (although absl_main_lib is defined too).
 #
 # TODO: Implement "ALWAYSLINK"
 

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -109,7 +109,7 @@ endfunction()
 #   VISIBILITY_PUBLIC
 # )
 #
-# User can then use the library as absl::main_lib (although absl_main_lib is defined too).
+# User can then use the library as absl::main_lib (although absl_internal_main_lib is defined too).
 #
 # TODO: Implement "ALWAYSLINK"
 

--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -83,20 +83,17 @@ absl_library(
     base
 )
 
-# throw delegate library
-set(THROW_DELEGATE_SRC "internal/throw_delegate.cc")
-
-absl_library(
-  TARGET
-    absl_throw_delegate
-  SOURCES
-    ${THROW_DELEGATE_SRC}
-  PUBLIC_LIBRARIES
-    ${THROW_DELEGATE_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
-  EXPORT_NAME
+absl_cc_library(
+  NAME
     throw_delegate
+  SRCS
+    "internal/throw_delegate.cc"
+  HDRS
+    "internal/throw_delegate.h"
+  COPTS
+    ${ABSL_EXCEPTIONS_FLAG}
+  DEPS
+    absl::base
 )
 
 
@@ -131,29 +128,25 @@ absl_library(
     ${DYNAMIC_ANNOTATIONS_SRC}
 )
 
-
-# spinlock_wait library
-set(SPINLOCK_WAIT_SRC "internal/spinlock_wait.cc")
-
-absl_library(
-  TARGET
-    absl_spinlock_wait
-  SOURCES
-    ${SPINLOCK_WAIT_SRC}
+absl_cc_library(
+  NAME
+    spinlock_wait
+  SRCS
+    "internal/spinlock_wait.cc"
+  HDRS
+    "internal/scheduling_mode.h"
+    "internal/spinlock_wait.h"
 )
 
-
-# malloc_internal library
-list(APPEND MALLOC_INTERNAL_SRC
-  "internal/low_level_alloc.cc"
-)
-
-absl_library(
-  TARGET
-    absl_malloc_internal
-  SOURCES
-    ${MALLOC_INTERNAL_SRC}
-  PUBLIC_LIBRARIES
+absl_cc_library(
+  NAME
+    malloc_internal
+  SRCS
+    "internal/low_level_alloc.cc"
+  HDRS
+    "internal/direct_mmap.h"
+    "internal/low_level_alloc.h"
+  DEPS
     absl_dynamic_annotations
 )
 

--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -99,33 +99,26 @@ absl_library(
     throw_delegate
 )
 
-if(BUILD_TESTING)
-  # exception-safety testing library
-  set(EXCEPTION_SAFETY_TESTING_SRC
+
+# exception-safety testing library
+absl_cc_library(
+  NAME
+    exception_safety_testing
+  HDRS
     "internal/exception_safety_testing.h"
+  SRCS
     "internal/exception_safety_testing.cc"
-  )
-  set(EXCEPTION_SAFETY_TESTING_PUBLIC_LIBRARIES
-    ${ABSL_TEST_COMMON_LIBRARIES}
+  COPTS
+    ${ABSL_EXCEPTIONS_FLAG}
+  DEPS
     absl::base
     absl::memory
     absl::meta
     absl::strings
     absl::optional
     gtest
-  )
-
-absl_library(
-  TARGET
-    absl_base_internal_exception_safety_testing
-  SOURCES
-    ${EXCEPTION_SAFETY_TESTING_SRC}
-  PUBLIC_LIBRARIES
-    ${EXCEPTION_SAFETY_TESTING_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
+  TESTONLY
 )
-endif()
 
 
 # dynamic_annotations library
@@ -368,7 +361,7 @@ absl_test(
 set(EXCEPTION_SAFETY_TESTING_TEST_SRC "exception_safety_testing_test.cc")
 set(EXCEPTION_SAFETY_TESTING_TEST_PUBLIC_LIBRARIES
   absl::base
-  absl_base_internal_exception_safety_testing
+  absl_exception_safety_testing
   absl::memory
   absl::meta
   absl::strings

--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -78,7 +78,7 @@ absl_library(
     ${BASE_SRC}
   PUBLIC_LIBRARIES
     absl_dynamic_annotations
-    absl_spinlock_wait
+    absl_internal_spinlock_wait
   EXPORT_NAME
     base
 )
@@ -197,7 +197,7 @@ absl_test(
 
 # test absl_throw_delegate_test
 set(THROW_DELEGATE_TEST_SRC "throw_delegate_test.cc")
-set(THROW_DELEGATE_TEST_PUBLIC_LIBRARIES absl::base absl_throw_delegate)
+set(THROW_DELEGATE_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate)
 
 absl_test(
   TARGET
@@ -354,7 +354,7 @@ absl_test(
 set(EXCEPTION_SAFETY_TESTING_TEST_SRC "exception_safety_testing_test.cc")
 set(EXCEPTION_SAFETY_TESTING_TEST_PUBLIC_LIBRARIES
   absl::base
-  absl_exception_safety_testing
+  absl_internal_exception_safety_testing
   absl::memory
   absl::meta
   absl::strings

--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -80,7 +80,7 @@ absl_library(
 
 # test fixed_array_test
 set(FIXED_ARRAY_TEST_SRC "fixed_array_test.cc")
-set(FIXED_ARRAY_TEST_PUBLIC_LIBRARIES absl::base absl_throw_delegate test_instance_tracker_lib)
+set(FIXED_ARRAY_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate test_instance_tracker_lib)
 
 absl_test(
   TARGET
@@ -109,7 +109,7 @@ absl_test(
 set(FIXED_ARRAY_EXCEPTION_SAFETY_TEST_SRC "fixed_array_exception_safety_test.cc")
 set(FIXED_ARRAY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
   absl::container
-  absl_base_internal_exception_safety_testing
+  absl_internal_exception_safety_testing
 )
 
 absl_test(
@@ -126,7 +126,7 @@ absl_test(
 
 # test inlined_vector_test
 set(INLINED_VECTOR_TEST_SRC "inlined_vector_test.cc")
-set(INLINED_VECTOR_TEST_PUBLIC_LIBRARIES absl::base absl_throw_delegate test_instance_tracker_lib)
+set(INLINED_VECTOR_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate test_instance_tracker_lib)
 
 absl_test(
   TARGET
@@ -151,7 +151,7 @@ absl_test(
 
 # test test_instance_tracker_test
 set(TEST_INSTANCE_TRACKER_TEST_SRC "internal/test_instance_tracker_test.cc")
-set(TEST_INSTANCE_TRACKER_TEST_PUBLIC_LIBRARIES absl::base absl_throw_delegate test_instance_tracker_lib)
+set(TEST_INSTANCE_TRACKER_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate test_instance_tracker_lib)
 
 
 absl_test(

--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -85,7 +85,7 @@ absl_library(
     ${SYMBOLIZE_SRC}
   PUBLIC_LIBRARIES
     absl::base
-    absl_malloc_internal
+    absl_internal_malloc_internal
   EXPORT_NAME
     symbolize
 )

--- a/absl/memory/CMakeLists.txt
+++ b/absl/memory/CMakeLists.txt
@@ -53,7 +53,7 @@ absl_test(
 set(MEMORY_EXCEPTION_SAFETY_TEST_SRC "memory_exception_safety_test.cc")
 set(MEMORY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
   absl::memory
-  absl_base_internal_exception_safety_testing
+  absl_internal_exception_safety_testing
 )
 
 absl_test(

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -32,7 +32,6 @@ list(APPEND STRINGS_PUBLIC_HEADERS
 
 
 list(APPEND STRINGS_INTERNAL_HEADERS
-  "internal/bits.h"
   "internal/char_map.h"
   "internal/charconv_bigint.h"
   "internal/charconv_parse.h"

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -14,71 +14,88 @@
 # limitations under the License.
 #
 
-absl_cc_library(
-  NAME
+
+list(APPEND STRINGS_PUBLIC_HEADERS
+  "ascii.h"
+  "charconv.h"
+  "escaping.h"
+  "match.h"
+  "numbers.h"
+  "str_cat.h"
+  "string_view.h"
+  "strip.h"
+  "str_join.h"
+  "str_replace.h"
+  "str_split.h"
+  "substitute.h"
+)
+
+
+list(APPEND STRINGS_INTERNAL_HEADERS
+  "internal/bits.h"
+  "internal/char_map.h"
+  "internal/charconv_bigint.h"
+  "internal/charconv_parse.h"
+  "internal/memutil.h"
+  "internal/ostringstream.h"
+  "internal/resize_uninitialized.h"
+  "internal/stl_type_traits.h"
+  "internal/str_join_internal.h"
+  "internal/str_split_internal.h"
+  "internal/utf8.h"
+)
+
+
+
+# add string library
+list(APPEND STRINGS_SRC
+  "ascii.cc"
+  "charconv.cc"
+  "escaping.cc"
+  "internal/charconv_bigint.cc"
+  "internal/charconv_parse.cc"
+  "internal/memutil.cc"
+  "internal/memutil.h"
+  "internal/utf8.cc"
+  "internal/ostringstream.cc"
+  "match.cc"
+  "numbers.cc"
+  "str_cat.cc"
+  "str_replace.cc"
+  "str_split.cc"
+  "string_view.cc"
+  "substitute.cc"
+  ${STRINGS_PUBLIC_HEADERS}
+  ${STRINGS_INTERNAL_HEADERS}
+)
+set(STRINGS_PUBLIC_LIBRARIES absl::base absl_throw_delegate)
+
+absl_library(
+  TARGET
+    absl_strings
+  SOURCES
+    ${STRINGS_SRC}
+  PUBLIC_LIBRARIES
+    ${STRINGS_PUBLIC_LIBRARIES}
+  EXPORT_NAME
     strings
-  HDRS
-    "ascii.h"
-    "charconv.h"
-    "escaping.h"
-    "match.h"
-    "numbers.h"
-    "str_cat.h"
-    "string_view.h"
-    "strip.h"
-    "str_join.h"
-    "str_replace.h"
-    "str_split.h"
-    "substitute.h"
-  SRCS
-    "ascii.cc"
-    "charconv.cc"
-    "escaping.cc"
-    "internal/bits.h"
-    "internal/char_map.h"
-    "internal/charconv_bigint.cc"
-    "internal/charconv_bigint.h"
-    "internal/charconv_parse.cc"
-    "internal/charconv_parse.h"
-    "internal/memutil.cc"
-    "internal/memutil.h"
-    "internal/ostringstream.cc"
-    "internal/ostringstream.h"
-    "internal/resize_uninitialized.h"
-    "internal/stl_type_traits.h"
-    "internal/str_join_internal.h"
-    "internal/str_split_internal.h"
-    "internal/utf8.cc"
-    "internal/utf8.h"
-    "match.cc"
-    "numbers.cc"
-    "str_cat.cc"
-    "str_replace.cc"
-    "str_split.cc"
-    "string_view.cc"
-    "substitute.cc"
-  DEPS
-    absl::base
-    absl_throw_delegate
-  VISIBILITY_PUBLIC
 )
 
 # add str_format library
-absl_cc_library(
-  NAME
+absl_header_library(
+  TARGET
+    absl_str_format
+  PUBLIC_LIBRARIES
+    str_format_internal
+  EXPORT_NAME
     str_format
-  HDRS
-    "str_format.h"
-  DEPS
-    absl_str_format_internal
-  VISIBILITY_PUBLIC
 )
 
 # str_format_internal
-absl_cc_library(
-  NAME
+absl_library(
+  TARGET
     str_format_internal
-  SRCS
+  SOURCES
     "internal/str_format/arg.cc"
     "internal/str_format/bind.cc"
     "internal/str_format/extension.cc"
@@ -92,7 +109,7 @@ absl_cc_library(
     "internal/str_format/float_conversion.h"
     "internal/str_format/output.h"
     "internal/str_format/parser.h"
-  DEPS
+  PUBLIC_LIBRARIES
     str_format_extension_internal
     absl::strings
     absl::base
@@ -399,7 +416,7 @@ absl_test(
   SOURCES
     "internal/str_format/bind_test.cc"
   PUBLIC_LIBRARIES
-    absl_str_format_internal
+    str_format_internal
 )
 
 # test str_format_checker_test
@@ -419,7 +436,7 @@ absl_test(
   SOURCES
     "internal/str_format/convert_test.cc"
   PUBLIC_LIBRARIES
-    absl_str_format_internal
+    str_format_internal
     absl::numeric
 )
 
@@ -440,7 +457,7 @@ absl_test(
   SOURCES
     "internal/str_format/parser_test.cc"
   PUBLIC_LIBRARIES
-    absl_str_format_internal
+    str_format_internal
     absl::base
 )
 

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -68,7 +68,7 @@ list(APPEND STRINGS_SRC
   ${STRINGS_PUBLIC_HEADERS}
   ${STRINGS_INTERNAL_HEADERS}
 )
-set(STRINGS_PUBLIC_LIBRARIES absl::base absl_throw_delegate)
+set(STRINGS_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate)
 
 absl_library(
   TARGET
@@ -208,7 +208,7 @@ absl_test(
 
 # test string_view_test
 set(STRING_VIEW_TEST_SRC "string_view_test.cc")
-set(STRING_VIEW_TEST_PUBLIC_LIBRARIES absl::strings absl_throw_delegate absl::base)
+set(STRING_VIEW_TEST_PUBLIC_LIBRARIES absl::strings absl_internal_throw_delegate absl::base)
 
 absl_test(
   TARGET
@@ -236,7 +236,7 @@ absl_test(
 
 # test str_replace_test
 set(STR_REPLACE_TEST_SRC "str_replace_test.cc")
-set(STR_REPLACE_TEST_PUBLIC_LIBRARIES absl::strings absl::base absl_throw_delegate)
+set(STR_REPLACE_TEST_PUBLIC_LIBRARIES absl::strings absl::base absl_internal_throw_delegate)
 
 absl_test(
   TARGET
@@ -250,7 +250,7 @@ absl_test(
 
 # test str_split_test
 set(STR_SPLIT_TEST_SRC "str_split_test.cc")
-set(STR_SPLIT_TEST_PUBLIC_LIBRARIES absl::strings absl::base absl_throw_delegate)
+set(STR_SPLIT_TEST_PUBLIC_LIBRARIES absl::strings absl::base absl_internal_throw_delegate)
 
 absl_test(
   TARGET

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -14,87 +14,71 @@
 # limitations under the License.
 #
 
-
-list(APPEND STRINGS_PUBLIC_HEADERS
-  "ascii.h"
-  "charconv.h"
-  "escaping.h"
-  "match.h"
-  "numbers.h"
-  "str_cat.h"
-  "string_view.h"
-  "strip.h"
-  "str_join.h"
-  "str_replace.h"
-  "str_split.h"
-  "substitute.h"
-)
-
-
-list(APPEND STRINGS_INTERNAL_HEADERS
-  "internal/char_map.h"
-  "internal/charconv_bigint.h"
-  "internal/charconv_parse.h"
-  "internal/memutil.h"
-  "internal/ostringstream.h"
-  "internal/resize_uninitialized.h"
-  "internal/stl_type_traits.h"
-  "internal/str_join_internal.h"
-  "internal/str_split_internal.h"
-  "internal/utf8.h"
-)
-
-
-
-# add string library
-list(APPEND STRINGS_SRC
-  "ascii.cc"
-  "charconv.cc"
-  "escaping.cc"
-  "internal/charconv_bigint.cc"
-  "internal/charconv_parse.cc"
-  "internal/memutil.cc"
-  "internal/memutil.h"
-  "internal/utf8.cc"
-  "internal/ostringstream.cc"
-  "match.cc"
-  "numbers.cc"
-  "str_cat.cc"
-  "str_replace.cc"
-  "str_split.cc"
-  "string_view.cc"
-  "substitute.cc"
-  ${STRINGS_PUBLIC_HEADERS}
-  ${STRINGS_INTERNAL_HEADERS}
-)
-set(STRINGS_PUBLIC_LIBRARIES absl::base absl_throw_delegate)
-
-absl_library(
-  TARGET
-    absl_strings
-  SOURCES
-    ${STRINGS_SRC}
-  PUBLIC_LIBRARIES
-    ${STRINGS_PUBLIC_LIBRARIES}
-  EXPORT_NAME
+absl_cc_library(
+  NAME
     strings
+  HDRS
+    "ascii.h"
+    "charconv.h"
+    "escaping.h"
+    "match.h"
+    "numbers.h"
+    "str_cat.h"
+    "string_view.h"
+    "strip.h"
+    "str_join.h"
+    "str_replace.h"
+    "str_split.h"
+    "substitute.h"
+  SRCS
+    "ascii.cc"
+    "charconv.cc"
+    "escaping.cc"
+    "internal/bits.h"
+    "internal/char_map.h"
+    "internal/charconv_bigint.cc"
+    "internal/charconv_bigint.h"
+    "internal/charconv_parse.cc"
+    "internal/charconv_parse.h"
+    "internal/memutil.cc"
+    "internal/memutil.h"
+    "internal/ostringstream.cc"
+    "internal/ostringstream.h"
+    "internal/resize_uninitialized.h"
+    "internal/stl_type_traits.h"
+    "internal/str_join_internal.h"
+    "internal/str_split_internal.h"
+    "internal/utf8.cc"
+    "internal/utf8.h"
+    "match.cc"
+    "numbers.cc"
+    "str_cat.cc"
+    "str_replace.cc"
+    "str_split.cc"
+    "string_view.cc"
+    "substitute.cc"
+  DEPS
+    absl::base
+    absl_throw_delegate
+  VISIBILITY_PUBLIC
 )
 
 # add str_format library
-absl_header_library(
-  TARGET
-    absl_str_format
-  PUBLIC_LIBRARIES
-    str_format_internal
-  EXPORT_NAME
+absl_cc_library(
+  NAME
     str_format
+  HDRS
+    "str_format.h"
+  DEPS
+    absl_str_format_internal
+  VISIBILITY_PUBLIC
 )
 
 # str_format_internal
-absl_library(
-  TARGET
+absl_cc_library(
+  NAME
     str_format_internal
-  SOURCES
+  SRCS
     "internal/str_format/arg.cc"
     "internal/str_format/bind.cc"
     "internal/str_format/extension.cc"
@@ -108,7 +92,7 @@ absl_library(
     "internal/str_format/float_conversion.h"
     "internal/str_format/output.h"
     "internal/str_format/parser.h"
-  PUBLIC_LIBRARIES
+  DEPS
     str_format_extension_internal
     absl::strings
     absl::base
@@ -415,7 +399,7 @@ absl_test(
   SOURCES
     "internal/str_format/bind_test.cc"
   PUBLIC_LIBRARIES
-    str_format_internal
+    absl_str_format_internal
 )
 
 # test str_format_checker_test
@@ -435,7 +419,7 @@ absl_test(
   SOURCES
     "internal/str_format/convert_test.cc"
   PUBLIC_LIBRARIES
-    str_format_internal
+    absl_str_format_internal
     absl::numeric
 )
 
@@ -456,7 +440,7 @@ absl_test(
   SOURCES
     "internal/str_format/parser_test.cc"
   PUBLIC_LIBRARIES
-    str_format_internal
+    absl_str_format_internal
     absl::base
 )
 

--- a/absl/types/CMakeLists.txt
+++ b/absl/types/CMakeLists.txt
@@ -123,7 +123,7 @@ absl_library(
 
 # test any_test
 set(ANY_TEST_SRC "any_test.cc")
-set(ANY_TEST_PUBLIC_LIBRARIES absl::base absl::throw_delegate absl::any absl::bad_any_cast test_instance_tracker_lib)
+set(ANY_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate absl::any absl::bad_any_cast test_instance_tracker_lib)
 
 absl_test(
   TARGET
@@ -152,7 +152,7 @@ set(ANY_EXCEPTION_SAFETY_TEST_SRC "any_exception_safety_test.cc")
 set(ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
   absl::any
   absl::base
-  absl_base_internal_exception_safety_testing
+  absl_internal_exception_safety_testing
 )
 
 absl_test(
@@ -169,7 +169,7 @@ absl_test(
 
 # test span_test
 set(SPAN_TEST_SRC "span_test.cc")
-set(SPAN_TEST_PUBLIC_LIBRARIES absl::base absl::strings absl::throw_delegate absl::span test_instance_tracker_lib)
+set(SPAN_TEST_PUBLIC_LIBRARIES absl::base absl::strings absl_internal_throw_delegate absl::span test_instance_tracker_lib)
 
 absl_test(
   TARGET
@@ -197,7 +197,7 @@ absl_test(
 
 # test optional_test
 set(OPTIONAL_TEST_SRC "optional_test.cc")
-set(OPTIONAL_TEST_PUBLIC_LIBRARIES absl::base absl::throw_delegate absl::optional absl_bad_optional_access)
+set(OPTIONAL_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate absl::optional absl_bad_optional_access)
 
 absl_test(
   TARGET
@@ -213,7 +213,7 @@ absl_test(
 set(OPTIONAL_EXCEPTION_SAFETY_TEST_SRC "optional_exception_safety_test.cc")
 set(OPTIONAL_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
   absl::optional
-  absl_base_internal_exception_safety_testing
+  absl_internal_exception_safety_testing
 )
 
 absl_test(


### PR DESCRIPTION
`absl_cc_library` is a `cc_library`-like CMake function to replace `absl_library` and `absl_header_library`.

Please do not start any migration until `absl_cc_binary` and `absl_cc_test` are implemented in future PRs. I migrated a few targets just to showcase how `absl_cc_library` can be used.

#114

@JonathanDCohen PTAL