### PR TITLE
Remove usage of soon-to-be-deprecated http_archive rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,6 @@
 workspace(name = "com_google_absl")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Bazel toolchains
 http_archive(
   name = "bazel_toolchains",


### PR DESCRIPTION
Per https://groups.google.com/d/msg/bazel-discuss/dO2MHQLwJF0/2OXHjMAaAAAJ the native rules for http_archive are to be replaced with their skylark implementations. This commit updates the WORKSPACE to use the skylark definitions.

Tested using `bazel build //... --incompatible_remove_native_http_archive --incompatible_remove_native_git_repository`