### PR TITLE
Indicate Solaris / Illumos has mmap support

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -268,7 +268,7 @@
 #error ABSL_HAVE_MMAP cannot be directly set
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||   \
     defined(__ros__) || defined(__native_client__) || defined(__asmjs__) || \
-    defined(__wasm__) || defined(__Fuchsia__)
+    defined(__wasm__) || defined(__Fuchsia__) || defined(__sun)
 #define ABSL_HAVE_MMAP 1
 #endif
 


### PR DESCRIPTION
After bumping into #98 on SmartOS (Illumos derivative) I added Solaris to the list of OS'es with `mmap` support.