### PR TITLE
Only MSVC does not have sys/time.h

### DIFF
--- a/absl/time/time.h
+++ b/absl/time/time.h
@@ -50,7 +50,7 @@
 #ifndef ABSL_TIME_TIME_H_
 #define ABSL_TIME_TIME_H_
 
-#if !defined(_WIN32)
+#if !defined(_MSC_VER)
 #include <sys/time.h>
 #else
 #include <winsock2.h>


### PR DESCRIPTION
Mingw has `<sys/time.h>`, no need to get `struct timeval` from `<winsock2.h>`.

#34