### PR TITLE
fix multiple define problem with ppc64le

### DIFF
--- a/absl/debugging/internal/stacktrace_powerpc-inl.inc
+++ b/absl/debugging/internal/stacktrace_powerpc-inl.inc
@@ -31,6 +31,8 @@
 #include <cstdint>
 #include <cstdio>
 
+#include "absl/base/attributes.h"
+#include "absl/base/optimization.h"
 #include "absl/base/port.h"
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/internal/address_is_readable.h"
@@ -150,8 +152,9 @@ static void **NextStackFrame(void **old_sp, const void *uc) {
 }
 
 // This ensures that absl::GetStackTrace sets up the Link Register properly.
-void AbslStacktracePowerPCDummyFunction() __attribute__((noinline));
-void AbslStacktracePowerPCDummyFunction() { __asm__ volatile(""); }
+ABSL_ATTRIBUTE_NOINLINE static void AbslStacktracePowerPCDummyFunction() {
+  ABSL_BLOCK_TAIL_CALL_OPTIMIZATION();
+}
 
 template <bool IS_STACK_FRAMES, bool IS_WITH_CONTEXT>
 ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS  // May read random elements from stack.

--- a/absl/debugging/internal/stacktrace_powerpc-inl.inc
+++ b/absl/debugging/internal/stacktrace_powerpc-inl.inc
@@ -150,8 +150,8 @@ static void **NextStackFrame(void **old_sp, const void *uc) {
 }
 
 // This ensures that absl::GetStackTrace sets up the Link Register properly.
-void StacktracePowerPCDummyFunction() __attribute__((noinline));
-void StacktracePowerPCDummyFunction() { __asm__ volatile(""); }
+void AbslStacktracePowerPCDummyFunction() __attribute__((noinline));
+void AbslStacktracePowerPCDummyFunction() { __asm__ volatile(""); }
 
 template <bool IS_STACK_FRAMES, bool IS_WITH_CONTEXT>
 ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS  // May read random elements from stack.
@@ -176,7 +176,7 @@ static int UnwindImpl(void** result, int* sizes, int max_depth, int skip_count,
   // want here.  While the compiler will always(?) set up LR for
   // subroutine calls, it may not for leaf functions (such as this one).
   // This routine forces the compiler (at least gcc) to push it anyway.
-  StacktracePowerPCDummyFunction();
+  AbslStacktracePowerPCDummyFunction();
 
   // The LR save area is used by the callee, so the top entry is bogus.
   skip_count++;


### PR DESCRIPTION
building anything, e.g. envoy, that also builds gperftools, results in
the error that StacktracePowerPCDummyFunction was previously defined.

Rename this one, as its only a dummy function and is only used in this
one place.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>