### PR TITLE
Add reverse_range helper function

### DIFF
--- a/absl/algorithm/container_test.cc
+++ b/absl/algorithm/container_test.cc
@@ -994,4 +994,22 @@ TEST(MutatingTest, PermutationOperations) {
   EXPECT_EQ(initial, permuted);
 }
 
+TEST(ReverseRange, Vector) {
+  std::vector<int> data = {1, 2, 3, 4};
+  auto reverse = absl::reverse_range(data);
+  ASSERT_TRUE(std::equal(data.rbegin(), data.rend(), reverse.begin()));
+}
+
+TEST(ReverseRange, Set) {
+  std::set<int> data = {2, 3, 4, 7};
+  auto reverse = absl::reverse_range(data);
+  ASSERT_TRUE(std::equal(data.rbegin(), data.rend(), reverse.begin()));
+}
+
+TEST(ReverseRange, Array) {
+  std::array<int, 4> data = {3, 5, 7, 9};
+  auto reverse = absl::reverse_range(data);
+  ASSERT_TRUE(std::equal(data.rbegin(), data.rend(), reverse.begin()));
+}
+
 }  // namespace


### PR DESCRIPTION
This adds a simple helper function, that redirects begin/end of a container to rbegin/rend.
It's main usage is for range based loops in reverse order where the following is equivalent:

vector<int> foo;
for (int elem : absl::reverse_range(foo)) {
    ...
}

for (auto rit = foo.rbegin(); rit!= foo.rend(); ++rit) {
    int elem = *rit;
    ...
}

Sadly std::rbegin/std::rend were only introduced with C++14 so i used the C++11 way