### PR TITLE
Fix CMake build

### DIFF
--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -163,3 +163,13 @@ absl_test(
   PUBLIC_LIBRARIES
     ${TEST_INSTANCE_TRACKER_TEST_PUBLIC_LIBRARIES}
 )
+
+
+absl_test(
+  TARGET
+    raw_hash_set_test
+  SOURCES
+    "internal/raw_hash_set_test.cc"
+  PUBLIC_LIBRARIES
+    absl::base absl::hash absl_throw_delegate test_instance_tracker_lib
+)

--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -47,10 +47,11 @@ list(APPEND CONTAINER_INTERNAL_HEADERS
   "internal/unordered_set_modifiers_test.h"
 )
 
-
-absl_header_library(
+absl_library(
   TARGET
     absl_container
+  SOURCES
+    "internal/raw_hash_set.cc"
   EXPORT_NAME
     container
 )
@@ -162,5 +163,3 @@ absl_test(
   PUBLIC_LIBRARIES
     ${TEST_INSTANCE_TRACKER_TEST_PUBLIC_LIBRARIES}
 )
-
-


### PR DESCRIPTION
Hi guys,

thanks for finally opensourcing Swissmap!

I just tried to build it using the CMake way but it seems that is currently broken as `absl::container` now needs to be a source library.

Fix for that is attached.

I have also enabled one of the hash map tests in the cmake tests to show the problem and avoid regressions. I can also enable the other tests as well if you want to (probably in another PR).