### PR TITLE
absl::meta Fix test alignment conformance for VS 2017 >= 15.8 (fix #193)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,15 @@ if (MSVC)
   # /wd4267  conversion from 'size_t' to 'type2'
   # /wd4800  force value to bool 'true' or 'false' (performance warning)
   add_compile_options(/W3 /wd4005 /wd4068 /wd4244 /wd4267 /wd4800)
-  add_definitions(/DNOMINMAX /DWIN32_LEAN_AND_MEAN=1 /D_CRT_SECURE_NO_WARNINGS /D_SCL_SECURE_NO_WARNINGS)
+  # /D_ENABLE_EXTENDED_ALIGNED_STORAGE Introduced in VS 2017 15.8, before the
+  # member type would non-conformingly have an alignment of only alignof(max_align_t).
+  add_definitions(
+    /DNOMINMAX
+    /DWIN32_LEAN_AND_MEAN=1
+    /D_CRT_SECURE_NO_WARNINGS
+    /D_SCL_SECURE_NO_WARNINGS
+    /D_ENABLE_EXTENDED_ALIGNED_STORAGE
+  )
 else()
   set(ABSL_STD_CXX_FLAG "-std=c++11" CACHE STRING "c++ std flag (default: c++11)")
 endif()

--- a/absl/copts.bzl
+++ b/absl/copts.bzl
@@ -130,7 +130,9 @@ MSVC_FLAGS = [
     "/wd4800",  # forcing value to bool 'true' or 'false' (performance warning)
     "/DNOMINMAX",  # Don't define min and max macros (windows.h)
     "/DWIN32_LEAN_AND_MEAN",  # Don't bloat namespace with incompatible winsock versions.
-    "/D_CRT_SECURE_NO_WARNINGS",  # Don't warn about usage of insecure C functions
+    "/D_CRT_SECURE_NO_WARNINGS",  # Don't warn about usage of insecure C functions.
+    "/D_ENABLE_EXTENDED_ALIGNED_STORAGE", # Introduced in VS 2017 15.8,
+    # before the member type would non-conformingly have an alignment of only alignof(max_align_t).
 ]
 
 MSVC_TEST_FLAGS = [


### PR DESCRIPTION
The Fix for #193 concerning the alignment issue with VS 15.8

* [x] CMake fix
* [x] Bazel fix

note: since I removed the other commits we loose the CI tests from #197 here....
