### PR TITLE
Add Travis-CI and Appveyor-CI CMake support (fix #109)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,58 @@
+# Use the Appveyor build number for naming the build.
+# src: https://www.appveyor.com/docs/build-configuration/#build-versioning
+version: '{build}'
+# see https://www.appveyor.com/docs/how-to/repository-shallow-clone/
+shallow_clone: true
+
+platform: x64
+
+environment:
+  matrix:
+# CMake
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    VS: 2017
+    CONFIG: Release
+    TEST: OFF
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    VS: 2017
+    CONFIG: Release
+    TEST: ON
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    VS: 2017
+    CONFIG: Debug
+    TEST: ON
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    VS: 2015
+    CONFIG: Release
+    TEST: OFF
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    VS: 2015
+    CONFIG: Release
+    TEST: ON
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    VS: 2015
+    CONFIG: Debug
+    TEST: ON
+
+matrix:
+  fast_finish: false
+
+before_build:
+  # see https://www.appveyor.com/docs/lang/cpp/#visual-studio-2017
+  - if "%VS%"=="2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - if "%VS%"=="2017" set CMAKE_GENERATOR="Visual Studio 15 2017 Win64"
+  # see https://www.appveyor.com/docs/lang/cpp/#visual-studio-2015
+  - if "%VS%"=="2015" call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+  - if "%VS%"=="2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+  - if "%VS%"=="2015" set CMAKE_GENERATOR="Visual Studio 14 2015 Win64"
+
+build_script:
+  - cmake --version
+  - cmake -H. -Bbuild -DABSL_RUN_TESTS=%TEST% -DABSL_USE_GOOGLETEST_HEAD=%TEST% -G %CMAKE_GENERATOR%
+  - cmake --build build --config %CONFIG% --target ALL_BUILD -- /maxcpucount
+
+test_script:
+  - if "%TEST%"=="ON" set CTEST_OUTPUT_ON_FAILURE=1
+  - if "%TEST%"=="ON" cmake --build build --config %CONFIG% --target RUN_TESTS
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,39 +7,27 @@ matrix:
   include:
     # see https://docs.travis-ci.com/user/languages/cpp/#gcc-on-linux
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       env:
         - BUILD_TYPE=Release
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       env:
         - BUILD_TYPE=Debug
 
     # see https://docs.travis-ci.com/user/languages/cpp/#clang
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: clang
       env:
         - BUILD_TYPE=Release
-        # Need to patch CPATH when using clang on linux
-        # see https://github.com/travis-ci/travis-ci/issues/9550
-        - CPATH=/usr/local/clang-5.0.0/include/c++/v1
-        - LD_LIBRARY_PATH=/usr/local/clang-5.0.0/lib
-        # Trusty only provides libc++ installed for clang
-        - EXTRA_FLAGS="-stdlib=libc++"
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: clang
       env:
         - BUILD_TYPE=Debug
-        # Need to patch CPATH when using clang on linux
-        # see https://github.com/travis-ci/travis-ci/issues/9550
-        - CPATH=/usr/local/clang-5.0.0/include/c++/v1
-        - LD_LIBRARY_PATH=/usr/local/clang-5.0.0/lib
-        # Trusty only provides libc++ installed for clang
-        - EXTRA_FLAGS="-stdlib=libc++"
 
     - os: osx
       osx_image: xcode10.1
@@ -55,7 +43,6 @@ matrix:
 script:
   - cmake --version
   - cmake -H. -Bbuild
-    -DCMAKE_CXX_FLAGS="${EXTRA_FLAGS}"
     -DCMAKE_VERBOSE_MAKEFILE=ON
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
     -DABSL_RUN_TESTS=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,58 @@
+# see https://docs.travis-ci.com/user/reference/trusty/#container-based-with-sudo-false
+sudo: false
+
+# see https://docs.travis-ci.com/user/languages/cpp/
+language: cpp
+
+# For build environment setup
+# see https://docs.travis-ci.com/user/reference/overview/
+matrix:
+  include:
+    # see https://docs.travis-ci.com/user/languages/cpp/#gcc-on-linux
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env:
+        - BUILD_TYPE=Release
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env:
+        - BUILD_TYPE=Debug
+
+    # see https://docs.travis-ci.com/user/languages/cpp/#clang
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env:
+        - BUILD_TYPE=Release
+        # Need to patch CPATH when using clang on linux
+        # see https://github.com/travis-ci/travis-ci/issues/9550
+        - CPATH=/usr/local/clang-5.0.0/include/c++/v1
+        - LD_LIBRARY_PATH=/usr/local/clang-5.0.0/lib
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env:
+        - BUILD_TYPE=Debug
+        # Need to patch CPATH when using clang on linux
+        # see https://github.com/travis-ci/travis-ci/issues/9550
+        - CPATH=/usr/local/clang-5.0.0/include/c++/v1
+        - LD_LIBRARY_PATH=/usr/local/clang-5.0.0/lib
+
+    - os: osx
+      osx_image: xcode9.4
+      compiler: clang
+      env:
+        - BUILD_TYPE=Release
+    - os: osx
+      osx_image: xcode9.4
+      compiler: clang
+      env:
+        - BUILD_TYPE=Debug
+
+script:
+  - cmake --version
+  - cmake -H. -Bbuild -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DABSL_RUN_TESTS=ON -DABSL_USE_GOOGLETEST_HEAD=ON
+  - cmake --build build --target all
+  - CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
         # see https://github.com/travis-ci/travis-ci/issues/9550
         - CPATH=/usr/local/clang-5.0.0/include/c++/v1
         - LD_LIBRARY_PATH=/usr/local/clang-5.0.0/lib
+        # Trusty only provides libc++ installed for clang
+        - EXTRA_FLAGS="-stdlib=libc++"
     - os: linux
       dist: trusty
       compiler: clang
@@ -39,6 +41,8 @@ matrix:
         # see https://github.com/travis-ci/travis-ci/issues/9550
         - CPATH=/usr/local/clang-5.0.0/include/c++/v1
         - LD_LIBRARY_PATH=/usr/local/clang-5.0.0/lib
+        # Trusty only provides libc++ installed for clang
+        - EXTRA_FLAGS="-stdlib=libc++"
 
     - os: osx
       osx_image: xcode9.4
@@ -53,6 +57,11 @@ matrix:
 
 script:
   - cmake --version
-  - cmake -H. -Bbuild -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DABSL_RUN_TESTS=ON -DABSL_USE_GOOGLETEST_HEAD=ON
+  - cmake -H. -Bbuild
+    -DCMAKE_CXX_FLAGS="${EXTRA_FLAGS}"
+    -DCMAKE_VERBOSE_MAKEFILE=ON
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+    -DABSL_RUN_TESTS=ON
+    -DABSL_USE_GOOGLETEST_HEAD=ON
   - cmake --build build --target all
   - CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# see https://docs.travis-ci.com/user/reference/trusty/#container-based-with-sudo-false
-sudo: false
-
 # see https://docs.travis-ci.com/user/languages/cpp/
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,12 @@ matrix:
         - EXTRA_FLAGS="-stdlib=libc++"
 
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_TYPE=Release
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_TYPE=Debug


### PR DESCRIPTION
# Introduction
This give us a minimal CI for **CMake-based** build on GNU/Linux (Xenial), osx (xcode10.1) and Windows (VS 2017, VS 2015).

Pro:
* Be able to share log and way to reproduce errors (e.g. #192, #193, #195, #198, #244 ...).
* Allow any user to test their branch(s) in their fork before sending a PR (github workflow)
* Travis-CI and Appveyor are fully integrated to github
* Google already pay for extra worker on Travis-CI (ed only for *google/** projects)
* kokoro jobs logs are not accessible from outside and are **useless** when user fork this repo...

Exhaustive jobs List:
* [x] Travis-CI `os:Xenial` `compiler:gcc5.4` `type:Release` `test:on`
* [x] Travis-CI `os:Xenial` `compiler:gcc5.4` `type:Debug` `test:on`
* [x] Travis-CI `os:Xenial` `compiler:clang7.0` `type:Release` `test:on`
* [x] Travis-CI `os:Xenial` `compiler:clang7.0` `type:Debug` `test:on`
* [x] Travis-CI `os:osx` `compiler:xcode10.1` `type:Release` `test:on` (broken cf #244)
* [x] Travis-CI `os:osx` `compiler:xcode10.1` `type:Debug` `test:on` (broken cf #244)
* [x] Appveyor-CI `img:VS 2017 v15.8`  `type:Release` **`test:off`**
* [x] Appveyor-CI `img:VS 2017 v15.8`  `type:Release` `test:on` (broken cf #192 #193 #198)
* [x] Appveyor-CI `img:VS 2017 v15.8`  `type:Debug` `test:on` (broken cf #192 #193 #198)
* [x] Appveyor-CI `img:VS 2015 v14.0`  `type:Release` **`test:off`**
* [x] Appveyor-CI `img:VS 2015 v14.0`  `type:Release` `test:on` (broken cf #192 #193 #198) 
* [x] Appveyor-CI `img:VS 2015 v14.0`  `type:Debug` `test:on` (broken cf #192 #193 #198) 

note: you can see the current job running here:
Travis-CI on my fork https://travis-ci.org/Mizux/abseil-cpp/branches (look at `cmake` branch)
Appveyor-CI on my fork https://ci.appveyor.com/project/Mizux/abseil-cpp/history  (look at `cmake` branch)

note: for Googler see **CL 221070196**