### PR TITLE
CMake: Rework to use absl_cc

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -153,7 +153,7 @@ function(absl_cc_library)
       target_compile_definitions(${_NAME} INTERFACE ${ABSL_CC_LIB_DEFINES})
     endif()
 
-    if(ABSL_CC_LIB_PUBLIC)
+    if(ABSL_CC_LIB_PUBLIC OR ABSL_CC_LIB_TESTONLY)
       add_library(absl::${ABSL_CC_LIB_NAME} ALIAS ${_NAME})
     endif()
   endif()

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -168,57 +168,6 @@ function(absl_cc_test)
   endif()
 endfunction()
 
-
-#
-# create an abseil unit_test and add it to the executed test list
-#
-# parameters
-# TARGET: target name prefix
-# SOURCES: sources files for the tests
-# PUBLIC_LIBRARIES: targets and flags for linking phase.
-# PRIVATE_COMPILE_FLAGS: compile flags for the test. Will not be exported.
-#
-# create a target associated to <NAME>_bin
-#
-# all tests will be register for execution with add_test()
-#
-# test compilation and execution is disable when ABSL_RUN_TESTS=OFF
-#
-function(absl_test)
-
-  cmake_parse_arguments(ABSL_TEST
-    ""
-    "TARGET"
-    "SOURCES;PUBLIC_LIBRARIES;PRIVATE_COMPILE_FLAGS;PUBLIC_INCLUDE_DIRS"
-    ${ARGN}
-  )
-
-
-  if(ABSL_RUN_TESTS)
-
-    set(_NAME ${ABSL_TEST_TARGET})
-    string(TOUPPER ${_NAME} _UPPER_NAME)
-
-    add_executable(${_NAME}_bin ${ABSL_TEST_SOURCES})
-
-    target_compile_options(${_NAME}_bin PRIVATE ${ABSL_COMPILE_CXXFLAGS} ${ABSL_TEST_PRIVATE_COMPILE_FLAGS})
-    target_link_libraries(${_NAME}_bin PUBLIC ${ABSL_TEST_PUBLIC_LIBRARIES} ${ABSL_TEST_COMMON_LIBRARIES})
-    target_include_directories(${_NAME}_bin
-      PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_TEST_PUBLIC_INCLUDE_DIRS}
-      PRIVATE ${GMOCK_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS}
-    )
-
-    # Add all Abseil targets to a a folder in the IDE for organization.
-    set_property(TARGET ${_NAME}_bin PROPERTY FOLDER ${ABSL_IDE_FOLDER})
-
-    add_test(${_NAME} ${_NAME}_bin)
-  endif(ABSL_RUN_TESTS)
-
-endfunction()
-
-
-
-
 function(check_target my_target)
 
   if(NOT TARGET ${my_target})

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -22,46 +22,6 @@ include(CMakeParseArguments)
 # For example, Visual Studio supports folders.
 set(ABSL_IDE_FOLDER Abseil)
 
-#
-# create a library in the absl namespace
-#
-# parameters
-# SOURCES : sources files for the library
-# PUBLIC_LIBRARIES: targets and flags for linking phase
-# PRIVATE_COMPILE_FLAGS: compile flags for the library. Will not be exported.
-# EXPORT_NAME: export name for the absl:: target export
-# TARGET: target name
-#
-# create a target associated to <NAME>
-# libraries are installed under CMAKE_INSTALL_FULL_LIBDIR by default
-#
-function(absl_library)
-  cmake_parse_arguments(ABSL_LIB
-    "DISABLE_INSTALL" # keep that in case we want to support installation one day
-    "TARGET;EXPORT_NAME"
-    "SOURCES;PUBLIC_LIBRARIES;PRIVATE_COMPILE_FLAGS"
-    ${ARGN}
-  )
-
-  set(_NAME ${ABSL_LIB_TARGET})
-  string(TOUPPER ${_NAME} _UPPER_NAME)
-
-  add_library(${_NAME} STATIC ${ABSL_LIB_SOURCES})
-
-  target_compile_options(${_NAME} PRIVATE ${ABSL_COMPILE_CXXFLAGS} ${ABSL_LIB_PRIVATE_COMPILE_FLAGS})
-  target_link_libraries(${_NAME} PUBLIC ${ABSL_LIB_PUBLIC_LIBRARIES})
-  target_include_directories(${_NAME}
-    PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_LIB_PUBLIC_INCLUDE_DIRS}
-    PRIVATE ${ABSL_LIB_PRIVATE_INCLUDE_DIRS}
-  )
-  # Add all Abseil targets to a a folder in the IDE for organization.
-  set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
-
-  if(ABSL_LIB_EXPORT_NAME)
-    add_library(absl::${ABSL_LIB_EXPORT_NAME} ALIAS ${_NAME})
-  endif()
-endfunction()
-
 # CMake function to imitate Bazel's cc_library rule.
 #
 # Parameters:

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -62,7 +62,6 @@ function(absl_library)
   endif()
 endfunction()
 
-#
 # CMake function to imitate Bazel's cc_library rule.
 #
 # Parameters:
@@ -77,26 +76,19 @@ endfunction()
 # TESTONLY: When added, this target will only be built if user passes -DABSL_RUN_TESTS=ON to CMake.
 #
 # Note:
-#
 # By default, absl_cc_library will always create a library named absl_internal_${NAME},
 # which means other targets can only depend this library as absl_internal_${NAME}, not ${NAME}.
 # This is to reduce namespace pollution.
 #
 # absl_cc_library(
-#   NAME
-#     awesome_lib
-#   HDRS
-#     "a.h"
-#   SRCS
-#     "a.cc"
+#   NAME awesome_lib
+#   HDRS "a.h"
+#   SRCS "a.cc"
 # )
 # absl_cc_library(
-#   NAME
-#     fantastic_lib
-#   SRCS
-#     "b.cc"
-#   DEPS
-#     absl_internal_awesome_lib # not "awesome_lib"!
+#   NAME fantastic_lib
+#   SRCS "b.cc"
+#   DEPS absl_internal_awesome_lib # not "awesome_lib"!
 # )
 #
 # If PUBLIC is set, absl_cc_library will instead create a target named
@@ -112,7 +104,6 @@ endfunction()
 # User can then use the library as absl::main_lib (although absl_main_lib is defined too).
 #
 # TODO: Implement "ALWAYSLINK"
-
 function(absl_cc_library)
   cmake_parse_arguments(ABSL_CC_LIB
     "DISABLE_INSTALL;PUBLIC;TESTONLY"
@@ -154,7 +145,8 @@ function(absl_cc_library)
     else()
       # Generating header-only library
       add_library(${_NAME} INTERFACE)
-      target_include_directories(${_NAME} INTERFACE ${ABSL_COMMON_INCLUDE_DIRS})
+      target_include_directories(${_NAME}
+        INTERFACE ${ABSL_COMMON_INCLUDE_DIRS})
       target_link_libraries(${_NAME}
         INTERFACE ${ABSL_CC_LIB_DEPS} ${ABSL_CC_LIB_LINKOPTS}
       )
@@ -211,7 +203,6 @@ function(absl_header_library)
   endif()
 
 endfunction()
-
 
 #
 # create an abseil unit_test and add it to the executed test list

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -168,50 +168,6 @@ function(absl_cc_test)
   endif()
 endfunction()
 
-#
-# header only virtual target creation
-#
-function(absl_header_library)
-  cmake_parse_arguments(ABSL_HO_LIB
-    "DISABLE_INSTALL"
-    "EXPORT_NAME;TARGET"
-    "PUBLIC_LIBRARIES;PRIVATE_COMPILE_FLAGS;PUBLIC_INCLUDE_DIRS;PRIVATE_INCLUDE_DIRS"
-    ${ARGN}
-  )
-
-  set(_NAME ${ABSL_HO_LIB_TARGET})
-
-  set(__dummy_header_only_lib_file "${CMAKE_CURRENT_BINARY_DIR}/${_NAME}_header_only_dummy.cc")
-
-  if(NOT EXISTS ${__dummy_header_only_lib_file})
-    file(WRITE ${__dummy_header_only_lib_file}
-      "/* generated file for header-only cmake target */
-
-      namespace absl {
-
-       // single meaningless symbol
-       void ${_NAME}__header_fakesym() {}
-      }  // namespace absl
-      "
-    )
-  endif()
-
-
-  add_library(${_NAME} ${__dummy_header_only_lib_file})
-  target_link_libraries(${_NAME} PUBLIC ${ABSL_HO_LIB_PUBLIC_LIBRARIES})
-  target_include_directories(${_NAME}
-    PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_HO_LIB_PUBLIC_INCLUDE_DIRS}
-    PRIVATE ${ABSL_HO_LIB_PRIVATE_INCLUDE_DIRS}
-  )
-
-  # Add all Abseil targets to a a folder in the IDE for organization.
-  set_property(TARGET ${_NAME} PROPERTY FOLDER ${ABSL_IDE_FOLDER})
-
-  if(ABSL_HO_LIB_EXPORT_NAME)
-    add_library(absl::${ABSL_HO_LIB_EXPORT_NAME} ALIAS ${_NAME})
-  endif()
-
-endfunction()
 
 #
 # create an abseil unit_test and add it to the executed test list

--- a/absl/algorithm/CMakeLists.txt
+++ b/absl/algorithm/CMakeLists.txt
@@ -14,50 +14,47 @@
 # limitations under the License.
 #
 
-list(APPEND ALGORITHM_PUBLIC_HEADERS
-  "algorithm.h"
-  "container.h"
+absl_cc_library(
+  NAME algorithm
+  HDRS "algorithm.h"
+  PUBLIC
 )
 
+# Avoid collision with absl::container in absl/container/
+absl_cc_library(
+  NAME algorithm_container
+  HDRS "container.h"
+  DEPS
+    absl::algorithm
+    absl::core_headers
+    absl::type_traits
+  PUBLIC
+)
 
 #
 ## TESTS
 #
 
-# test algorithm_test
-list(APPEND ALGORITHM_TEST_SRC
-  "algorithm_test.cc"
-  ${ALGORITHM_PUBLIC_HEADERS}
-  ${ALGORITHM_INTERNAL_HEADERS}
-)
-
-absl_header_library(
-  TARGET
-    absl_algorithm
-  EXPORT_NAME
-    algorithm
-)
-
-absl_test(
-  TARGET
-    algorithm_test
-  SOURCES
-    ${ALGORITHM_TEST_SRC}
-  PUBLIC_LIBRARIES
+# algorithm test
+absl_cc_test(
+  NAME algorithm_test
+  SRCS "algorithm_test.cc"
+  DEPS
     absl::algorithm
+    gmock
+    gtest_main
 )
 
-
-
-
-# test container_test
-set(CONTAINER_TEST_SRC "container_test.cc")
-
-absl_test(
-  TARGET
-    container_test
-  SOURCES
-    ${CONTAINER_TEST_SRC}
-  PUBLIC_LIBRARIES
-    absl::algorithm
+# container test
+absl_cc_test(
+  NAME container_test
+  SRCS "container_test.cc"
+  DEPS
+    absl::algorithm_container
+    absl::base
+    absl::core_headers
+    absl::memory
+    absl::span
+    gmock
+    gtest_main
 )

--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -14,360 +14,394 @@
 # limitations under the License.
 #
 
-list(APPEND BASE_PUBLIC_HEADERS
-  "attributes.h"
-  "call_once.h"
-  "casts.h"
+# spinlock wait library
+set(SPINLOCK_WAIT_HDRS
+  "internal/scheduling_mode.h"
+  "internal/spinlock_wait.h"
+  "internal/spinlock_akaros.inc"
+  "internal/spinlock_linux.inc"
+  "internal/spinlock_posix.inc"
+  "internal/spinlock_win32.inc"
+)
+
+set(SPINLOCK_WAIT_SRCS
+  "internal/spinlock_wait.cc"
+)
+
+absl_cc_library(
+  NAME spinlock_wait
+  SRCS ${SPINLOCK_WAIT_SRCS}
+  HDRS ${SPINLOCK_WAIT_HDRS}
+  DEPS
+    absl::core_headers
+  PUBLIC
+)
+
+# config library
+set(CONFIG_PUBLIC_HDRS
   "config.h"
-  "dynamic_annotations.h"
-  "log_severity.h"
+  "policy_checks.h"
+)
+
+absl_cc_library(
+  NAME config
+  HDRS ${CONFIG_HDRS}
+  PUBLIC
+)
+
+# dynamic_annotations library
+absl_cc_library(
+  NAME dynamic_annotations
+  SRCS "dynamic_annotations.cc"
+  HDRS "dynamic_annotations.h"
+  PUBLIC
+)
+
+# core headers
+set(CORE_HEADERS_HDRS
+  "attributes.h"
   "macros.h"
   "optimization.h"
-  "policy_checks.h"
   "port.h"
   "thread_annotations.h"
 )
 
-
-list(APPEND BASE_INTERNAL_HEADERS
-  "internal/atomic_hook.h"
-  "internal/bits.h"
-  "internal/cycleclock.h"
-  "internal/direct_mmap.h"
-  "internal/endian.h"
-  "internal/exception_testing.h"
-  "internal/exception_safety_testing.h"
-  "internal/hide_ptr.h"
-  "internal/identity.h"
-  "internal/invoke.h"
-  "internal/inline_variable.h"
-  "internal/low_level_alloc.h"
-  "internal/low_level_scheduling.h"
-  "internal/per_thread_tls.h"
-  "internal/pretty_function.h"
-  "internal/raw_logging.h"
-  "internal/scheduling_mode.h"
-  "internal/spinlock.h"
-  "internal/spinlock_wait.h"
-  "internal/sysinfo.h"
-  "internal/thread_identity.h"
-  "internal/throw_delegate.h"
-  "internal/tsan_mutex_interface.h"
-  "internal/unaligned_access.h"
-  "internal/unscaledcycleclock.h"
+absl_cc_library(
+  NAME core_headers
+  HDRS ${CORE_HEADERS_HDRS}
+  DEPS
+    absl::config
+    absl::dynamic_annotations
+  PUBLIC
 )
 
+# malloc library
+set(MALLOC_INTERNAL_HDRS
+  "internal/direct_mmap.h"
+  "internal/low_level_alloc.h"
+)
 
-# absl_base main library
-list(APPEND BASE_SRC
+set(MALLOC_INTERNAL_SRCS
+  "internal/low_level_alloc.cc"
+)
+
+absl_cc_library(
+  NAME malloc_internal
+  SRCS ${MALLOC_INTERNAL_SRCS}
+  HDRS ${MALLOC_INTERNAL_HDRS}
+  DEPS
+    absl::base
+    absl::config
+    absl::core_headers
+    absl::dynamic_annotations
+    absl::spinlock_wait
+  PUBLIC
+)
+
+# base internal library
+list(APPEND BASE_INTERNAL_HDRS
+  "internal/hide_ptr.h"
+  "internal/identity.h"
+  "internal/inline_variable.h"
+  "internal/invoke.h"
+)
+
+absl_cc_library(
+  NAME base_internal
+  HDRS ${BASE_INTERNAL_HDRS}
+  PUBLIC
+)
+
+# base library
+set(BASE_HDRS
+  "call_once.h"
+  "casts.h"
+  "internal/atomic_hook.h"
+  "internal/cycleclock.h"
+  "internal/low_level_scheduling.h"
+  "internal/per_thread_tls.h"
+  "internal/raw_logging.h"
+  "internal/spinlock.h"
+  "internal/sysinfo.h"
+  "internal/thread_identity.h"
+  "internal/tsan_mutex_interface.h"
+  "internal/unscaledcycleclock.h"
+  "log_severity.h"
+)
+
+set(BASE_SRCS
   "internal/cycleclock.cc"
   "internal/raw_logging.cc"
   "internal/spinlock.cc"
   "internal/sysinfo.cc"
   "internal/thread_identity.cc"
   "internal/unscaledcycleclock.cc"
-  "internal/low_level_alloc.cc"
-  ${BASE_PUBLIC_HEADERS}
-  ${BASE_INTERNAL_HEADERS}
-)
-
-absl_library(
-  TARGET
-    absl_base
-  SOURCES
-    ${BASE_SRC}
-  PUBLIC_LIBRARIES
-    absl_dynamic_annotations
-    absl_internal_spinlock_wait
-  EXPORT_NAME
-    base
 )
 
 absl_cc_library(
-  NAME
-    throw_delegate
-  SRCS
-    "internal/throw_delegate.cc"
-  HDRS
-    "internal/throw_delegate.h"
-  COPTS
-    ${ABSL_EXCEPTIONS_FLAG}
+  NAME base
+  SRCS ${BASE_SRCS}
+  HDRS ${BASE_HDRS}
   DEPS
-    absl::base
+    absl::base_internal
+    absl::config
+    absl::core_headers
+    absl::dynamic_annotations
+    absl::spinlock_wait
+  PUBLIC
 )
 
+#
+## TESTS
+#
 
-# exception-safety testing library
-absl_cc_library(
-  NAME
-    exception_safety_testing
-  HDRS
-    "internal/exception_safety_testing.h"
-  SRCS
-    "internal/exception_safety_testing.cc"
-  COPTS
-    ${ABSL_EXCEPTIONS_FLAG}
+# atomic hook test
+absl_cc_test(
+  NAME atomic_hook_test
+  SRCS "internal/atomic_hook_test.cc"
   DEPS
     absl::base
+    absl::core_headers
+    gtest_main
+)
+
+# bit_cast_test
+absl_cc_test(
+  NAME bit_cast_test
+  SRCS "bit_cast_test.cc"
+  DEPS
+    absl::base
+    absl::core_headers
+    gtest_main
+)
+
+# throw delegate library
+absl_cc_library(
+  NAME throw_delegate
+  SRCS "internal/throw_delegate.cc"
+  HDRS "internal/throw_delegate.h"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::base
+    absl::config
+    absl::core_headers
+  PUBLIC
+)
+
+# throw_delegate_test
+absl_cc_test(
+  NAME throw_delegate_test
+  SRCS "throw_delegate_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::throw_delegate
+    gtest_main
+)
+
+# exception_testing library
+absl_cc_library(
+  NAME exception_testing
+  HDRS "internal/exception_testing.h"
+  DEPS
+    absl::config
+    gtest
+  TESTONLY
+)
+
+# pretty function library
+absl_cc_library(
+  NAME pretty_function
+  HDRS "internal/pretty_function.h"
+  PUBLIC
+)
+
+# exception_safety_testing library
+absl_cc_library(
+  NAME exception_safety_testing
+  HDRS "internal/exception_safety_testing.h"
+  SRCS "internal/exception_safety_testing.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::base
+    absl::config
+    absl::pretty_function
     absl::memory
-    absl::meta
+    absl::type_traits
     absl::strings
     absl::optional
     gtest
   TESTONLY
 )
 
-
-# dynamic_annotations library
-set(DYNAMIC_ANNOTATIONS_SRC "dynamic_annotations.cc")
-
-absl_library(
-  TARGET
-    absl_dynamic_annotations
-  SOURCES
-    ${DYNAMIC_ANNOTATIONS_SRC}
-)
-
-absl_cc_library(
-  NAME
-    spinlock_wait
-  SRCS
-    "internal/spinlock_wait.cc"
-  HDRS
-    "internal/scheduling_mode.h"
-    "internal/spinlock_wait.h"
-)
-
-absl_cc_library(
-  NAME
-    malloc_internal
-  SRCS
-    "internal/low_level_alloc.cc"
-  HDRS
-    "internal/direct_mmap.h"
-    "internal/low_level_alloc.h"
+# exceptions_safety_testing test
+absl_cc_test(
+  NAME exception_safety_testing_test
+  SRCS "exception_safety_testing_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
   DEPS
-    absl_dynamic_annotations
+    absl::exception_safety_testing
+    absl::memory
+    gtest_main
 )
 
-
-
-#
-## TESTS
-#
-
-# call once test
-set(ATOMIC_HOOK_TEST_SRC "internal/atomic_hook_test.cc")
-set(ATOMIC_HOOK_TEST_PUBLIC_LIBRARIES absl::base)
-
-absl_test(
-  TARGET
-    atomic_hook_test
-  SOURCES
-    ${ATOMIC_HOOK_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${ATOMIC_HOOK_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# call once test
-set(CALL_ONCE_TEST_SRC "call_once_test.cc")
-set(CALL_ONCE_TEST_PUBLIC_LIBRARIES absl::base absl::synchronization)
-
-absl_test(
-  TARGET
-    call_once_test
-  SOURCES
-    ${CALL_ONCE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${CALL_ONCE_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test bit_cast_test
-set(BIT_CAST_TEST_SRC "bit_cast_test.cc")
-
-absl_test(
-  TARGET
-    bit_cast_test
-  SOURCES
-    ${BIT_CAST_TEST_SRC}
-)
-
-
-# test absl_throw_delegate_test
-set(THROW_DELEGATE_TEST_SRC "throw_delegate_test.cc")
-set(THROW_DELEGATE_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate)
-
-absl_test(
-  TARGET
-    throw_delegate_test
-  SOURCES
-    ${THROW_DELEGATE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${THROW_DELEGATE_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test invoke_test
-set(INVOKE_TEST_SRC "invoke_test.cc")
-set(INVOKE_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    invoke_test
-  SOURCES
-    ${INVOKE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${INVOKE_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test inline_variable_test
-list(APPEND INLINE_VARIABLE_TEST_SRC
-  "internal/inline_variable_testing.h"
+# inline_variable test
+set(INLINE_VARIABLE_TEST_SRCS
   "inline_variable_test.cc"
   "inline_variable_test_a.cc"
   "inline_variable_test_b.cc"
+  "internal/inline_variable_testing.h"
 )
 
-set(INLINE_VARIABLE_TEST_PUBLIC_LIBRARIES absl::base)
-
-absl_test(
-  TARGET
-    inline_variable_test
-  SOURCES
-    ${INLINE_VARIABLE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${INLINE_VARIABLE_TEST_PUBLIC_LIBRARIES}
+absl_cc_test(
+  NAME inline_variable_test
+  SRCS ${INLINE_VARIABLE_TEST_SRCS}
+  DEPS
+    absl::base_internal
+    gtest_main
 )
 
-
-# test spinlock_test_common
-set(SPINLOCK_TEST_COMMON_SRC "spinlock_test_common.cc")
-set(SPINLOCK_TEST_COMMON_PUBLIC_LIBRARIES absl::base absl::synchronization)
-
-absl_test(
-  TARGET
-    spinlock_test_common
-  SOURCES
-    ${SPINLOCK_TEST_COMMON_SRC}
-  PUBLIC_LIBRARIES
-    ${SPINLOCK_TEST_COMMON_PUBLIC_LIBRARIES}
+# invoke test
+absl_cc_test(
+  NAME invoke_test
+  SRCS "invoke_test.cc"
+  DEPS
+    absl::base_internal
+    absl::memory
+    absl::strings
+    gmock
+    gtest_main
 )
 
-
-# test spinlock_test
-set(SPINLOCK_TEST_SRC "spinlock_test_common.cc")
-set(SPINLOCK_TEST_PUBLIC_LIBRARIES absl::base absl::synchronization)
-
-absl_test(
-  TARGET
-    spinlock_test
-  SOURCES
-    ${SPINLOCK_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${SPINLOCK_TEST_PUBLIC_LIBRARIES}
+# spinlock_test_common library
+absl_cc_library(
+  NAME  spinlock_test_common
+  SRCS "spinlock_test_common.cc"
+  DEPS
+    absl::base
+    absl::core_headers
+    absl::spinlock_wait
+    absl::synchronization
+    gtest
+  TESTONLY
 )
 
-
-# test endian_test
-set(ENDIAN_TEST_SRC "internal/endian_test.cc")
-
-absl_test(
-  TARGET
-    endian_test
-  SOURCES
-    ${ENDIAN_TEST_SRC}
+# spinlock test
+absl_cc_test(
+  NAME spinlock_test
+  SRCS "spinlock_test_common.cc"
+  DEPS
+    absl::base
+    absl::core_headers
+    absl::spinlock_wait
+    absl::synchronization
+    gtest_main
 )
 
-
-# test config_test
-set(CONFIG_TEST_SRC "config_test.cc")
-set(CONFIG_TEST_PUBLIC_LIBRARIES absl::base absl::synchronization)
-absl_test(
-  TARGET
-    config_test
-  SOURCES
-    ${CONFIG_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${CONFIG_TEST_PUBLIC_LIBRARIES}
+# endian library
+set(ENDIAN_HDRS
+  "internal/endian.h"
+  "internal/unaligned_access.h"
 )
 
-
-# test raw_logging_test
-set(RAW_LOGGING_TEST_SRC "raw_logging_test.cc")
-set(RAW_LOGGING_TEST_PUBLIC_LIBRARIES absl::base absl::strings)
-
-absl_test(
-  TARGET
-    raw_logging_test
-  SOURCES
-    ${RAW_LOGGING_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${RAW_LOGGING_TEST_PUBLIC_LIBRARIES}
+absl_cc_library(
+  NAME endian
+  HDRS ${ENDIAN_HDRS}
+  DEPS
+    absl::config
+    absl::core_headers
+  PUBLIC
 )
 
-
-# test sysinfo_test
-set(SYSINFO_TEST_SRC "internal/sysinfo_test.cc")
-set(SYSINFO_TEST_PUBLIC_LIBRARIES absl::base absl::synchronization)
-
-absl_test(
-  TARGET
-    sysinfo_test
-  SOURCES
-    ${SYSINFO_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${SYSINFO_TEST_PUBLIC_LIBRARIES}
+# endian test
+absl_cc_test(
+  NAME endian_test
+  SRCS "internal/endian_test.cc"
+  DEPS
+    absl::base
+    absl::config
+    absl::endian
+    gtest_main
 )
 
-
-# test low_level_alloc_test
-set(LOW_LEVEL_ALLOC_TEST_SRC "internal/low_level_alloc_test.cc")
-set(LOW_LEVEL_ALLOC_TEST_PUBLIC_LIBRARIES absl::base)
-
-absl_test(
-  TARGET
-    low_level_alloc_test
-  SOURCES
-    ${LOW_LEVEL_ALLOC_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${LOW_LEVEL_ALLOC_TEST_PUBLIC_LIBRARIES}
+# config test
+absl_cc_test(
+  NAME config_test
+  SRCS "config_test.cc"
+  DEPS
+    absl::config
+    absl::synchronization
+    gtest_main
 )
 
-
-# test thread_identity_test
-set(THREAD_IDENTITY_TEST_SRC "internal/thread_identity_test.cc")
-set(THREAD_IDENTITY_TEST_PUBLIC_LIBRARIES absl::base absl::synchronization)
-
-absl_test(
-  TARGET
-    thread_identity_test
-  SOURCES
-    ${THREAD_IDENTITY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${THREAD_IDENTITY_TEST_PUBLIC_LIBRARIES}
+# call_once test
+absl_cc_test(
+  NAME call_once_test
+  SRCS "call_once_test.cc"
+  DEPS
+    absl::base
+    absl::core_headers
+    absl::synchronization
+    gtest_main
 )
 
-#test exceptions_safety_testing_test
-set(EXCEPTION_SAFETY_TESTING_TEST_SRC "exception_safety_testing_test.cc")
-set(EXCEPTION_SAFETY_TESTING_TEST_PUBLIC_LIBRARIES
-  absl::base
-  absl_internal_exception_safety_testing
-  absl::memory
-  absl::meta
-  absl::strings
-  absl::optional
+# raw_logging test
+absl_cc_test(
+  NAME raw_logging_test
+  SRCS "raw_logging_test.cc"
+  DEPS
+    absl::base
+    absl::strings
+    gtest_main
 )
 
-absl_test(
-  TARGET
-    absl_exception_safety_testing_test
-  SOURCES
-    ${EXCEPTION_SAFETY_TESTING_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${EXCEPTION_SAFETY_TESTING_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
+# sysinfo test
+absl_cc_test(
+  NAME sysinfo_test
+  SRCS "internal/sysinfo_test.cc"
+  DEPS
+    absl::base
+    absl::synchronization
+    gtest_main
+)
+
+# low_level_alloc test
+absl_cc_test(
+  NAME low_level_alloc_test
+  SRCS "internal/low_level_alloc_test.cc"
+  DEPS
+    absl::malloc_internal
+    gtest_main
+)
+
+# thread_identity test
+absl_cc_test(
+  NAME thread_identity_test
+  SRCS "internal/thread_identity_test.cc"
+  DEPS
+    absl::base
+    absl::core_headers
+    absl::synchronization
+    gtest_main
+)
+
+# bits library
+absl_cc_library(
+  NAME bits
+  HDRS "internal/bits.h"
+  DEPS
+    absl::core_headers
+  PUBLIC
+)
+
+# bits test
+absl_cc_test(
+  NAME bits_test
+  SRCS "internal/bits_test.cc"
+  DEPS
+    absl::bits
+    gtest_main
 )

--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -14,151 +14,534 @@
 # limitations under the License.
 #
 
-
-list(APPEND CONTAINER_PUBLIC_HEADERS
-  "fixed_array.h"
-  "flat_hash_map.h"
-  "flat_hash_set.h"
-  "inlined_vector.h"
-  "node_hash_map.h"
-  "node_hash_set.h"
+# compressed_tuple library
+absl_cc_library(
+  NAME compressed_tuple
+  HDRS "internal/compressed_tuple.h"
+  DEPS
+    absl::utility
+  PUBLIC
 )
 
-
-list(APPEND CONTAINER_INTERNAL_HEADERS
-  "internal/compressed_tuple.h"
-  "internal/container_memory.h"
-  "internal/hash_function_defaults.h"
-  "internal/hash_generator_testing.h"
-  "internal/hash_policy_testing.h"
-  "internal/hash_policy_traits.h"
-  "internal/hashtable_debug.h"
-  "internal/layout.h"
-  "internal/node_hash_policy.h"
-  "internal/raw_hash_map.h"
-  "internal/raw_hash_set.h"
-  "internal/test_instance_tracker.h"
-  "internal/tracked.h"
-  "internal/unordered_map_constructor_test.h"
-  "internal/unordered_map_lookup_test.h"
-  "internal/unordered_map_modifiers_test.h"
-  "internal/unordered_set_constructor_test.h"
-  "internal/unordered_set_lookup_test.h"
-  "internal/unordered_set_modifiers_test.h"
+# compressed_tuple test
+absl_cc_test(
+  NAME compressed_tuple_test
+  SRCS "internal/compressed_tuple_test.cc"
+  DEPS
+    absl::compressed_tuple
+    gmock
+    gtest_main
 )
 
-
-absl_header_library(
-  TARGET
-    absl_container
-  EXPORT_NAME
-    container
+# fixed array library
+absl_cc_library(
+  NAME fixed_array
+  HDRS "fixed_array.h"
+  DEPS
+    absl::compressed_tuple
+    absl::algorithm
+    absl::core_headers
+    absl::dynamic_annotations
+    absl::throw_delegate
+    absl::memory
+  PUBLIC
 )
 
-
-#
-## TESTS
-#
-
-list(APPEND TEST_INSTANCE_TRACKER_LIB_SRC
-  "internal/test_instance_tracker.cc"
-  ${CONTAINER_PUBLIC_HEADERS}
-  ${CONTAINER_INTERNAL_HEADERS}
+# fixed_array test
+absl_cc_test(
+  NAME fixed_array_test
+  SRCS "fixed_array_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::fixed_array
+    absl::exception_testing
+    absl::hash_testing
+    absl::memory
+    gmock
+    gtest_main
 )
 
-
-absl_library(
-  TARGET
-    test_instance_tracker_lib
-  SOURCES
-    ${TEST_INSTANCE_TRACKER_LIB_SRC}
-  PUBLIC_LIBRARIES
-    absl::container
+# fixed_array_test_noexceptions test
+absl_cc_test(
+  NAME fixed_array_test_noexceptions
+  SRCS "fixed_array_test.cc"
+  DEPS
+    absl::fixed_array
+    absl::exception_testing
+    absl::hash_testing
+    absl::memory
+    gmock
+    gtest_main
 )
 
-
-
-# test fixed_array_test
-set(FIXED_ARRAY_TEST_SRC "fixed_array_test.cc")
-set(FIXED_ARRAY_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate test_instance_tracker_lib)
-
-absl_test(
-  TARGET
-    fixed_array_test
-  SOURCES
-    ${FIXED_ARRAY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${FIXED_ARRAY_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
+# fixed_array_exception_safety test
+absl_cc_test(
+  NAME fixed_array_exception_safety_test
+  SRCS "fixed_array_exception_safety_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::fixed_array
+    absl::exception_safety_testing
+    gtest_main
 )
 
-
-
-absl_test(
-  TARGET
-    fixed_array_test_noexceptions
-  SOURCES
-    ${FIXED_ARRAY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${FIXED_ARRAY_TEST_PUBLIC_LIBRARIES}
+# inlined_vector library
+absl_cc_library(
+  NAME inlined_vector
+  HDRS "inlined_vector.h"
+  DEPS
+    absl::algorithm
+    absl::core_headers
+    absl::throw_delegate
+    absl::memory
+  PUBLIC
 )
 
-
-# test fixed_array_exception_safety_test
-set(FIXED_ARRAY_EXCEPTION_SAFETY_TEST_SRC "fixed_array_exception_safety_test.cc")
-set(FIXED_ARRAY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
-  absl::container
-  absl_internal_exception_safety_testing
+# inlined_vector test
+absl_cc_test(
+  NAME inlined_vector_test
+  SRCS "inlined_vector_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::inlined_vector
+    absl::test_instance_tracker
+    absl::base
+    absl::core_headers
+    absl::exception_testing
+    absl::hash_testing
+    absl::memory
+    absl::strings
+    gmock
+    gtest_main
 )
 
-absl_test(
-  TARGET
-    fixed_array_exception_safety_test
-  SOURCES
-    ${FIXED_ARRAY_EXCEPTION_SAFETY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${FIXED_ARRAY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
+# inlined_vector_test_noexceptions test
+absl_cc_test(
+  NAME inlined_vector_test_noexceptions
+  SRCS "inlined_vector_test.cc"
+  DEPS
+    absl::inlined_vector
+    absl::test_instance_tracker
+    absl::base
+    absl::core_headers
+    absl::exception_testing
+    absl::hash_testing
+    absl::memory
+    absl::strings
+    gmock
+    gtest_main
 )
 
-
-# test inlined_vector_test
-set(INLINED_VECTOR_TEST_SRC "inlined_vector_test.cc")
-set(INLINED_VECTOR_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate test_instance_tracker_lib)
-
-absl_test(
-  TARGET
-    inlined_vector_test
-  SOURCES
-    ${INLINED_VECTOR_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${INLINED_VECTOR_TEST_PUBLIC_LIBRARIES}
+# test_instance library
+absl_cc_library(
+  NAME test_instance_tracker
+  SRCS "internal/test_instance_tracker.cc"
+  HDRS "internal/test_instance_tracker.h"
+  TESTONLY
 )
 
-absl_test(
-  TARGET
-    inlined_vector_test_noexceptions
-  SOURCES
-    ${INLINED_VECTOR_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${INLINED_VECTOR_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_NOEXCEPTION_CXXFLAGS}
+absl_cc_test(
+  NAME test_instance_tracker_test
+  SRCS "internal/test_instance_tracker_test.cc"
+  DEPS
+    absl::test_instance_tracker
+    gtest_main
 )
 
+# flat_hash_map library
+absl_cc_library(
+  NAME flat_hash_map
+  HDRS "flat_hash_map.h"
+  DEPS
+    absl::container_memory
+    absl::hash_function_defaults
+    absl::raw_hash_map
+    absl::memory
+  PUBLIC
+)
 
-# test test_instance_tracker_test
-set(TEST_INSTANCE_TRACKER_TEST_SRC "internal/test_instance_tracker_test.cc")
-set(TEST_INSTANCE_TRACKER_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate test_instance_tracker_lib)
+absl_cc_test(
+  NAME flat_hash_map_test
+  SRCS "flat_hash_map_test.cc"
+  COPTS "-DUNORDERED_MAP_CXX17"
+  DEPS
+    absl::flat_hash_map
+    absl::hash_generator_testing
+    absl::unordered_map_constructor_test
+    absl::unordered_map_lookup_test
+    absl::unordered_map_modifiers_test
+    absl::any
+    gmock
+    gtest_main
+)
 
+# flat_hash_set library
+absl_cc_library(
+  NAME flat_hash_set
+  HDRS "flat_hash_set.h"
+  DEPS
+    absl::container_memory
+    absl::hash_function_defaults
+    absl::raw_hash_set
+    absl::core_headers
+    absl::memory
+  PUBLIC
+)
 
-absl_test(
-  TARGET
-    test_instance_tracker_test
-  SOURCES
-    ${TEST_INSTANCE_TRACKER_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${TEST_INSTANCE_TRACKER_TEST_PUBLIC_LIBRARIES}
+absl_cc_test(
+  NAME flat_hash_set_test
+  SRCS "flat_hash_set_test.cc"
+  COPTS "-DUNORDERED_SET_CXX17"
+  DEPS
+    absl::flat_hash_set
+    absl::hash_generator_testing
+    absl::unordered_map_constructor_test
+    absl::unordered_map_lookup_test
+    absl::unordered_map_modifiers_test
+    absl::memory
+    absl::strings
+    gmock
+    gtest_main
+)
+
+# node_hash_map library
+absl_cc_library(
+  NAME node_hash_map
+  HDRS "node_hash_map.h"
+  DEPS
+    absl::container_memory
+    absl::hash_function_defaults
+    absl::node_hash_policy
+    absl::raw_hash_map
+    absl::memory
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME node_hash_map_test
+  SRCS "node_hash_map_test.cc"
+  COPTS "-DUNORDERED_MAP_CXX17"
+  DEPS
+    absl::node_hash_map
+    absl::hash_generator_testing
+    absl::tracked
+    absl::unordered_map_constructor_test
+    absl::unordered_map_lookup_test
+    absl::unordered_map_modifiers_test
+    gmock
+    gtest_main
+)
+
+# node_hash_set library
+absl_cc_library(
+  NAME node_hash_set
+  HDRS "node_hash_set.h"
+  DEPS
+    absl::container_memory
+    absl::hash_function_defaults
+    absl::node_hash_policy
+    absl::raw_hash_set
+    absl::memory
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME node_hash_set_test
+  SRCS "node_hash_set_test.cc"
+  COPTS "-DUNORDERED_SET_CXX17"
+  DEPS
+    absl::node_hash_set
+    absl::hash_generator_testing
+    absl::unordered_set_constructor_test
+    absl::unordered_set_lookup_test
+    absl::unordered_set_modifiers_test
+    gtest_main
+)
+
+# container_memory library
+absl_cc_library(
+  NAME container_memory
+  HDRS "internal/container_memory.h"
+  DEPS
+    absl::memory
+    absl::utility
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME container_memory_test
+  SRCS "internal/container_memory_test.cc"
+  DEPS
+    absl::container_memory
+    absl::strings
+    gmock
+    gtest_main
+)
+
+# hash_function_defaults library
+absl_cc_library(
+  NAME hash_function_defaults
+  HDRS "internal/hash_function_defaults.h"
+  DEPS
+    absl::config
+    absl::hash
+    absl::strings
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME hash_function_defaults_test
+  SRCS "internal/hash_function_defaults_test.cc"
+  DEPS
+    absl::hash_function_defaults
+    absl::hash
+    absl::strings
+    gtest_main
+)
+
+absl_cc_library(
+  NAME hash_generator_testing
+  SRCS "internal/hash_generator_testing.cc"
+  HDRS "internal/hash_generator_testing.h"
+  DEPS
+    absl::hash_policy_testing
+    absl::type_traits
+    absl::strings
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME hash_policy_testing
+  HDRS "internal/hash_policy_testing.h"
+  DEPS
+    absl::hash
+    absl::strings
+  TESTONLY
+)
+
+absl_cc_test(
+  NAME hash_policy_testing_test
+  SRCS "internal/hash_policy_testing_test.cc"
+  DEPS
+    absl::hash_policy_testing
+    gtest_main
+)
+
+absl_cc_library(
+  NAME hash_policy_traits
+  HDRS "internal/hash_policy_traits.h"
+  DEPS
+    absl::type_traits
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME hash_policy_traits_test
+  SRCS "internal/hash_policy_traits_test.cc"
+  DEPS
+    absl::hash_policy_traits
+    gmock
+    gtest_main
+)
+
+absl_cc_library(
+  NAME hashtable_debug
+  HDRS "internal/hashtable_debug.h"
+  DEPS
+    absl::hashtable_debug_hooks
+  PUBLIC
+)
+
+absl_cc_library(
+  NAME hashtable_debug_hooks
+  HDRS "internal/hashtable_debug_hooks.h"
+  PUBLIC
+)
+
+absl_cc_library(
+  NAME node_hash_policy
+  HDRS "internal/node_hash_policy.h"
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME node_hash_policy_test
+  SRCS "internal/node_hash_policy_test.cc"
+  DEPS
+    absl::hash_policy_traits
+    absl::node_hash_policy
+    gmock
+    gtest_main
+)
+
+absl_cc_library(
+  NAME raw_hash_map
+  HDRS "internal/raw_hash_map.h"
+  DEPS
+    absl::container_memory
+    absl::raw_hash_set
+  PUBLIC
+)
+
+absl_cc_library(
+  NAME raw_hash_set
+  SRCS "internal/raw_hash_set.cc"
+  HDRS "internal/raw_hash_set.h"
+  DEPS
+    absl::compressed_tuple
+    absl::container_memory
+    absl::hash_policy_traits
+    absl::hashtable_debug_hooks
+    absl::layout
+    absl::bits
+    absl::config
+    absl::core_headers
+    absl::endian
+    absl::memory
+    absl::type_traits
+    absl::optional
+    absl::utility
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME raw_hash_set_test
+  SRCS "internal/raw_hash_set_test.cc"
+  DEPS
+    absl::container_memory
+    absl::hash_function_defaults
+    absl::hash_policy_testing
+    absl::hashtable_debug
+    absl::raw_hash_set
+    absl::base
+    absl::core_headers
+    absl::strings
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME raw_hash_set_allocator_test
+  SRCS "internal/raw_hash_set_allocator_test.cc"
+  DEPS
+    absl::raw_hash_set
+    absl::tracked
+    absl::core_headers
+    gtest_main
+)
+
+absl_cc_library(
+  NAME layout
+  HDRS "internal/layout.h"
+  DEPS
+    absl::core_headers
+    absl::type_traits
+    absl::strings
+    absl::span
+    absl::utility
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME layout_test
+  SRCS "internal/layout_test.cc"
+  DEPS
+    absl::layout
+    absl::base
+    absl::core_headers
+    absl::span
+    gmock
+    gtest_main
+  PUBLIC
+)
+
+absl_cc_library(
+  NAME tracked
+  HDRS "internal/tracked.h"
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME unordered_map_constructor_test
+  HDRS "internal/unordered_map_constructor_test.h"
+  DEPS
+    absl::hash_generator_testing
+    absl::hash_policy_testing
+    gtest
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME unordered_map_lookup_test
+  HDRS "internal/unordered_map_lookup_test.h"
+  DEPS
+    absl::hash_generator_testing
+    absl::hash_policy_testing
+    gtest
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME unordered_map_modifiers_test
+  HDRS "internal/unordered_map_modifiers_test.h"
+  DEPS
+    absl::hash_generator_testing
+    absl::hash_policy_testing
+    gtest
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME unordered_set_constructor_test
+  HDRS "internal/unordered_set_constructor_test.h"
+  DEPS
+    absl::hash_generator_testing
+    absl::hash_policy_testing
+    gmock
+    gtest
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME unordered_set_lookup_test
+  HDRS "internal/unordered_set_lookup_test.h"
+  DEPS
+    absl::hash_generator_testing
+    absl::hash_policy_testing
+    gtest
+  TESTONLY
+)
+
+absl_cc_library(
+  NAME unordered_set_modifiers_test
+  HDRS "internal/unordered_set_modifiers_test.h"
+  DEPS
+    absl::hash_generator_testing
+    absl::hash_policy_testing
+    gtest
+  TESTONLY
+)
+
+absl_cc_test(
+  NAME unordered_set_test
+  SRCS "internal/unordered_set_test.cc"
+  DEPS
+    absl::unordered_set_constructor_test
+    absl::unordered_set_lookup_test
+    absl::unordered_set_modifiers_test
+    gtest_main
+)
+
+absl_cc_test(
+  NAME unordered_map_test
+  SRCS "internal/unordered_map_test.cc"
+  DEPS
+    absl::unordered_map_constructor_test
+    absl::unordered_map_lookup_test
+    absl::unordered_map_modifiers_test
+    gmock
+    gtest_main
 )

--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -14,204 +14,233 @@
 # limitations under the License.
 #
 
-list(APPEND DEBUGGING_PUBLIC_HEADERS
-  "failure_signal_handler.h"
-  "leak_check.h"
-  "stacktrace.h"
-  "symbolize.h"
+# stacktrace library
+absl_cc_library(
+  NAME stacktrace
+  SRCS "stacktrace.cc"
+  HDRS "stacktrace.h"
+  DEPS
+    absl::base
+    absl::core_headers
+    absl::debugging_internal
+  PUBLIC
 )
 
-# TODO(cohenjon) The below is all kinds of wrong.  Make this match what we do in
-# Bazel
-list(APPEND DEBUGGING_INTERNAL_HEADERS
-  "internal/address_is_readable.h"
-  "internal/demangle.h"
-  "internal/elf_mem_image.h"
-  "internal/examine_stack.h"
-  "internal/stacktrace_config.h"
+# symbolize library
+set(SYMBOLIZE_HDRS
+  "symbolize.h"
   "internal/symbolize.h"
+)
+
+set(SYMBOLIZE_SRCS
+  "symbolize.cc"
+  "symbolize_elf.inc"
+  "symbolize_unimplemented.inc"
+  "symbolize_win32.inc"
+)
+
+absl_cc_library(
+  NAME symbolize
+  SRCS ${SYMBOLIZE_SRCS}
+  HDRS ${SYMBOLIZE_HDRS}
+  DEPS
+    absl::debugging_internal
+    absl::demangle_internal
+    absl::base
+    absl::core_headers
+    absl::malloc_internal
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME symbolize_test
+  SRCS "symbolize_test.cc"
+  DEPS
+    absl::stack_consumption
+    absl::symbolize
+    absl::base
+    absl::core_headers
+    absl::memory
+    gmock
+    gtest
+)
+
+# examine_stack library
+absl_cc_library(
+  NAME examine_stack
+  SRCS "internal/examine_stack.cc"
+  HDRS "internal/examine_stack.h"
+  DEPS
+    absl::stacktrace
+    absl::symbolize
+    absl::base
+    absl::core_headers
+  PUBLIC
+)
+
+# signal_handler library
+absl_cc_library(
+  NAME failure_signal_handler
+  SRCS "failure_signal_handler.cc"
+  HDRS "failure_signal_handler.h"
+  DEPS
+    absl::examine_stack
+    absl::stacktrace
+    absl::base
+    absl::config
+    absl::core_headers
+  PUBLIC
+)
+
+absl_cc_test(
+  NAME failure_signal_handler_test
+  SRCS "failure_signal_handler_test.cc"
+  DEPS
+    absl::failure_signal_handler
+    absl::stacktrace
+    absl::symbolize
+    absl::base
+    absl::strings
+    gtest
+)
+
+# debugging_internal library
+set(DEBUGGING_INTERNAL_HRDS
+  "internal/address_is_readable.h"
+  "internal/elf_mem_image.h"
+  "internal/stacktrace_aarch64-inl.inc"
+  "internal/stacktrace_arm-inl.inc"
+  "internal/stacktrace_config.h"
+  "internal/stacktrace_generic-inl.inc"
+  "internal/stacktrace_powerpc-inl.inc"
+  "internal/stacktrace_unimplemented-inl.inc"
+  "internal/stacktrace_win32-inl.inc"
+  "internal/stacktrace_x86-inl.inc"
   "internal/vdso_support.h"
 )
 
-list(APPEND DEBUGGING_INTERNAL_SRC
+set(DEBUGGING_INTERNAL_SRCS
   "internal/address_is_readable.cc"
   "internal/elf_mem_image.cc"
   "internal/vdso_support.cc"
 )
 
-
-list(APPEND STACKTRACE_SRC
-  "stacktrace.cc"
-  ${DEBUGGING_INTERNAL_SRC}
-  ${DEBUGGING_PUBLIC_HEADERS}
-  ${DEBUGGING_INTERNAL_HEADERS}
-)
-
-list(APPEND SYMBOLIZE_SRC
-  "symbolize.cc"
-  "symbolize_elf.inc"
-  "symbolize_unimplemented.inc"
-  "symbolize_win32.inc"
-  "internal/demangle.cc"
-  ${DEBUGGING_PUBLIC_HEADERS}
-  ${DEBUGGING_INTERNAL_HEADERS}
-  ${DEBUGGING_INTERNAL_SRC}
-)
-
-list(APPEND FAILURE_SIGNAL_HANDLER_SRC
-  "failure_signal_handler.cc"
-  ${DEBUGGING_PUBLIC_HEADERS}
-)
-
-list(APPEND EXAMINE_STACK_SRC
-  "internal/examine_stack.cc"
-  ${DEBUGGING_PUBLIC_HEADERS}
-  ${DEBUGGING_INTERNAL_HEADERS}
-)
-
-absl_library(
-  TARGET
-    absl_stacktrace
-  SOURCES
-    ${STACKTRACE_SRC}
-  EXPORT_NAME
-    stacktrace
-)
-
-absl_library(
-  TARGET
-    absl_symbolize
-  SOURCES
-    ${SYMBOLIZE_SRC}
-  PUBLIC_LIBRARIES
+absl_cc_library(
+  NAME debugging_internal
+  SRCS ${DEBUGGING_INTERNAL_SRCS}
+  HDRS ${DEBUGGING_INTERNAL_HRDS}
+  DEPS
     absl::base
-    absl_internal_malloc_internal
-  EXPORT_NAME
-    symbolize
+    absl::dynamic_annotations
+  PUBLIC
 )
 
-absl_library(
-  TARGET
-    absl_failure_signal_handler
-  SOURCES
-    ${FAILURE_SIGNAL_HANDLER_SRC}
-  PUBLIC_LIBRARIES
-    absl_base absl::examine_stack absl::stacktrace absl_synchronization
-  EXPORT_NAME
-    failure_signal_handler
+# demangle_internal library
+absl_cc_library(
+  NAME demangle_internal
+  SRCS "internal/demangle.cc"
+  HDRS "internal/demangle.h"
+  DEPS
+    absl::base
+    absl::core_headers
+  PUBLIC
 )
 
-# Internal-only. Projects external to Abseil should not depend
-# directly on this library.
-absl_library(
-  TARGET
-    absl_examine_stack
-  SOURCES
-    ${EXAMINE_STACK_SRC}
-  EXPORT_NAME
-    examine_stack
+absl_cc_test(
+  NAME demangle_test
+  SRCS "internal/demangle_test.cc"
+  DEPS
+    absl::demangle_internal
+    absl::stack_consumption
+    absl::base
+    absl::core_headers
+    absl::memory
+    gtest_main
 )
-
-list(APPEND LEAK_CHECK_SRC
-  "leak_check.cc"
-)
-
 
 # leak_check library
-absl_library(
-  TARGET
-    absl_leak_check
-  SOURCES
-    ${LEAK_CHECK_SRC}
-  PUBLIC_LIBRARIES
-    absl_base
-  EXPORT_NAME
-    leak_check
+absl_cc_library(
+  NAME leak_check
+  SRCS "leak_check.cc"
+  HDRS "leak_check.h"
+  DEPS
+    absl::core_headers
+  PUBLIC
 )
 
-
-# component target
-absl_header_library(
-  TARGET
-    absl_debugging
-  PUBLIC_LIBRARIES
-    absl_stacktrace absl_leak_check
-  EXPORT_NAME
-    debugging
+absl_cc_library(
+  NAME leak_check_disable
+  SRCS "leak_check_disable.cc"
+  PUBLIC
 )
 
-#
-## TESTS
-#
-
-list(APPEND STACK_CONSUMPTION_SRC
-  "internal/stack_consumption.cc"
-  "internal/stack_consumption.h"
+absl_cc_library(
+  NAME leak_check_api_enabled_for_testing
+  SRCS "leak_check.cc"
+  HDRS "leak_check.h"
+  COPTS "-DLEAK_SANITIZER"
+  TESTONLY
 )
 
-absl_library(
-  TARGET
-    absl_stack_consumption
-  SOURCES
-    ${STACK_CONSUMPTION_SRC}
+absl_cc_library(
+  NAME leak_check_api_disabled_for_testing
+  SRCS "leak_check.cc"
+  HDRS "leak_check.h"
+  COPTS "-ULEAK_SANITIZER"
+  TESTONLY
 )
 
-absl_test(
-  TARGET
-    absl_stack_consumption_test
-  SOURCES
-    "internal/stack_consumption_test.cc"
-  PUBLIC_LIBRARIES
-    absl_stack_consumption
+# TODO Define ABSL_LSAN_LINKOPTS
+#absl_cc_test(
+#  NAME leak_check_test
+#  SRCS "leak_check_test.cc"
+#  COPTS "-DABSL_EXPECT_LEAK_SANITIZER"
+#  LINKOPTS ${ABSL_LSAN_LINKOPTS}
+#  DEPS
+#    absl::leak_check_api_enabled_for_testing
+#    absl::base
+#    gtest_main
+#)
+
+absl_cc_test(
+  NAME leak_check_no_lsan_test
+  SRCS "leak_check_test.cc"
+  COPTS "-UABSL_EXPECT_LEAK_SANITIZER"
+  DEPS
+    absl::leak_check_api_disabled_for_testing
     absl::base
+    gtest_main
 )
 
-list(APPEND DEMANGLE_TEST_SRC "internal/demangle_test.cc")
+# TODO Define ABSL_LSAN_LINKOPTS
+#absl_cc_test(
+#  NAME disabled_leak_check_test
+#  SRCS "leak_check_fail_test.cc"
+#  LINKOPTS ${ABSL_LSAN_LINKOPTS}
+#  DEPS
+#    absl::leak_check_api_enabled_for_testing
+#    absl::leak_check_disable
+#    absl::base
+#    gtest_main
+#)
 
-absl_test(
-  TARGET
-    demangle_test
-  SOURCES
-    ${DEMANGLE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    absl_symbolize absl_stack_consumption
-)
-
-list(APPEND SYMBOLIZE_TEST_SRC "symbolize_test.cc")
-
-absl_test(
-  TARGET
-    symbolize_test
-  SOURCES
-    ${SYMBOLIZE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    absl::base absl::memory absl_symbolize absl_stack_consumption
-)
-
-list(APPEND FAILURE_SIGNAL_HANDLER_TEST_SRC "failure_signal_handler_test.cc")
-
-absl_test(
-  TARGET
-    failure_signal_handler_test
-  SOURCES
-    ${FAILURE_SIGNAL_HANDLER_TEST_SRC}
-  PUBLIC_LIBRARIES
-    absl_examine_stack
-    absl_failure_signal_handler
-    absl_stacktrace
-    absl_symbolize
+# stack_consumption library
+absl_cc_library(
+  NAME stack_consumption
+  SRCS "internal/stack_consumption.cc"
+  HDRS "internal/stack_consumption.h"
+  DEPS
     absl::base
-    absl::strings
+    absl::core_headers
+  PUBLIC
 )
 
-# test leak_check_test
-list(APPEND LEAK_CHECK_TEST_SRC "leak_check_test.cc")
-
-absl_test(
-  TARGET
-    leak_check_test
-  SOURCES
-    ${LEAK_CHECK_TEST_SRC}
-  PUBLIC_LIBRARIES
-    absl_leak_check
+absl_cc_test(
+  NAME stack_consumption_test
+  SRCS "internal/stack_consumption_test.cc"
+  DEPS
+    absl::stack_consumption
+    absl::base
+    absl::core_headers
+    gtest_main
 )

--- a/absl/hash/CMakeLists.txt
+++ b/absl/hash/CMakeLists.txt
@@ -14,66 +14,78 @@
 # limitations under the License.
 #
 
-list(APPEND HASH_PUBLIC_HEADERS
-  "hash.h"
+absl_cc_library(
+  NAME hash
+  SRCS
+    "internal/hash.h"
+    "internal/hash.cc"
+  HDRS "hash.h"
+  DEPS
+    absl::city
+    absl::core_headers
+    absl::endian
+    absl::fixed_array
+    absl::type_traits
+    absl::int128
+    absl::strings
+    absl::optional
+    absl::variant
+    absl::utility
+  PUBLIC
 )
 
-list(APPEND HASH_INTERNAL_HEADERS
-  "internal/city.h"
-  "internal/hash.h"
+absl_cc_library(
+  NAME hash_testing
+  HDRS "hash_testing.h"
+  DEPS
+    absl::spy_hash_state
+    absl::type_traits
+    absl::strings
+    absl::variant
+    gtest
+  TESTONLY
 )
 
-# absl_hash library
-list(APPEND HASH_SRC
-  "internal/city.cc"
-  "internal/hash.cc"
-  ${HASH_PUBLIC_HEADERS}
-  ${HASH_INTERNAL_HEADERS}
+absl_cc_test(
+  NAME hash_test
+  SRCS "hash_test.cc"
+  DEPS
+    absl::hash
+    absl::hash_testing
+    absl::core_headers
+    absl::flat_hash_set
+    absl::spy_hash_state
+    absl::type_traits
+    absl::int128
+    gmock
+    gtest_main
 )
 
-set(HASH_PUBLIC_LIBRARIES absl::hash absl::container absl::strings absl::str_format absl::utility)
-
-absl_library(
-  TARGET
-    absl_hash
-  SOURCES
-    ${HASH_SRC}
-  PUBLIC_LIBRARIES
-    ${HASH_PUBLIC_LIBRARIES}
-  EXPORT_NAME
-    hash
+absl_cc_library(
+  NAME spy_hash_state
+  HDRS "internal/spy_hash_state.h"
+  DEPS
+    absl::hash
+    absl::strings
+    absl::str_format
+  TESTONLY
 )
 
-#
-## TESTS
-#
-
-# testing support
-set(HASH_TEST_HEADERS hash_testing.h internal/spy_hash_state.h)
-set(HASH_TEST_PUBLIC_LIBRARIES absl::hash absl::container absl::numeric absl::strings absl::str_format)
-
-# hash_test
-set(HASH_TEST_SRC "hash_test.cc" ${HASH_TEST_HEADERS})
-
-absl_test(
-  TARGET
-    hash_test
-  SOURCES
-    ${HASH_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${HASH_TEST_PUBLIC_LIBRARIES}
+absl_cc_library(
+  NAME city
+  SRCS "internal/city.cc"
+  HDRS "internal/city.h"
+  DEPS
+    absl::config
+    absl::core_headers
+    absl::endian
+  PUBLIC
 )
 
-# hash_test
-set(CITY_TEST_SRC "internal/city_test.cc")
-
-absl_test(
-  TARGET
-    city_test
-  SOURCES
-    ${CITY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${HASH_TEST_PUBLIC_LIBRARIES}
+absl_cc_test(
+  NAME city_test
+  SRCS "internal/city_test.cc"
+  DEPS
+    absl::city
+    gtest_main
 )
-
-

--- a/absl/memory/CMakeLists.txt
+++ b/absl/memory/CMakeLists.txt
@@ -14,55 +14,34 @@
 # limitations under the License.
 #
 
-list(APPEND MEMORY_PUBLIC_HEADERS
-  "memory.h"
+absl_cc_library(
+  NAME memory
+  HDRS "memory.h"
+  DEPS
+    absl::core_headers
+    absl::type_traits
+  PUBLIC
 )
 
-
-absl_header_library(
-  TARGET
-    absl_memory
-  EXPORT_NAME
-    memory
+absl_cc_test(
+  NAME memory_test
+  SRCS "memory_test.cc"
+  DEPS
+    absl::memory
+    absl::base
+    absl::core_headers
+    gmock
+    gtest_main
 )
 
-#
-## TESTS
-#
-
-# test memory_test
-list(APPEND MEMORY_TEST_SRC
-  "memory_test.cc"
-  ${MEMORY_PUBLIC_HEADERS}
-)
-set(MEMORY_TEST_PUBLIC_LIBRARIES absl::base absl::memory)
-
-
-
-absl_test(
-  TARGET
-    memory_test
-  SOURCES
-    ${MEMORY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${MEMORY_TEST_PUBLIC_LIBRARIES}
+absl_cc_test(
+  NAME memory_exception_safety_test
+  SRCS "memory_exception_safety_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::memory
+    absl::exception_safety_testing
+    gtest_main
 )
 
-
-# test memory_exception_safety_test
-set(MEMORY_EXCEPTION_SAFETY_TEST_SRC "memory_exception_safety_test.cc")
-set(MEMORY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
-  absl::memory
-  absl_internal_exception_safety_testing
-)
-
-absl_test(
-  TARGET
-    memory_exception_safety_test
-  SOURCES
-    ${MEMORY_EXCEPTION_SAFETY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${MEMORY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
-)

--- a/absl/meta/CMakeLists.txt
+++ b/absl/meta/CMakeLists.txt
@@ -14,39 +14,20 @@
 # limitations under the License.
 #
 
-list(APPEND META_PUBLIC_HEADERS
-  "type_traits.h"
+absl_cc_library(
+  NAME type_traits
+  HDRS "type_traits.h"
+  DEPS
+    absl::config
+  PUBLIC
 )
 
-
-#
-## TESTS
-#
-
-# test type_traits_test
-list(APPEND TYPE_TRAITS_TEST_SRC
-  "type_traits_test.cc"
-  ${META_PUBLIC_HEADERS}
+absl_cc_test(
+  NAME type_traits_test
+  SRCS "type_traits_test.cc"
+  DEPS
+    absl::type_traits
+    absl::core_headers
+    gtest_main
 )
-
-absl_header_library(
-  TARGET
-    absl_meta
-  PUBLIC_LIBRARIES
-    absl::base
-  EXPORT_NAME
-    meta
- )
-
-absl_test(
-  TARGET
-    type_traits_test
-  SOURCES
-    ${TYPE_TRAITS_TEST_SRC}
-  PUBLIC_LIBRARIES
-    absl::base
-    absl::meta
-)
-
-
 

--- a/absl/numeric/CMakeLists.txt
+++ b/absl/numeric/CMakeLists.txt
@@ -14,49 +14,34 @@
 # limitations under the License.
 #
 
-list(APPEND NUMERIC_PUBLIC_HEADERS
-  "int128.h"
-)
-
-
-# library 128
-list(APPEND INT128_SRC
+set(INT128_SRCS
   "int128.cc"
-  ${NUMERIC_PUBLIC_HEADERS}
-)
-absl_library(
-  TARGET
-    absl_int128
-  SOURCES
-    ${INT128_SRC}
-  PUBLIC_LIBRARIES
-    ${INT128_PUBLIC_LIBRARIES}
-  EXPORT_NAME
-    int128
+  "int128_have_intrinsic.inc"
+  "int128_no_intrinsic.inc"
 )
 
+absl_cc_library(
+  NAME int128
+  SRCS ${INT128_SRCS}
+  HDRS "int128.h"
+  DEPS
+    absl::config
+    absl::core_headers
+  PUBLIC
+)
 
-absl_header_library(
-  TARGET
-    absl_numeric
-  PUBLIC_LIBRARIES
+absl_cc_test(
+  NAME int128_test
+  SRCS
+    "int128_stream_test.cc"
+    "int128_test.cc"
+  DEPS
     absl::int128
-  EXPORT_NAME
-    numeric
+    absl::base
+    absl::core_headers
+    absl::hash_testing
+    absl::type_traits
+    gmock
+    gtest_main
 )
-
-# test int128_test
-set(INT128_TEST_SRC "int128_test.cc")
-set(INT128_TEST_PUBLIC_LIBRARIES absl::numeric absl::base)
-
-absl_test(
-  TARGET
-    int128_test
-  SOURCES
-    ${INT128_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${INT128_TEST_PUBLIC_LIBRARIES}
-)
-
-
 

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -14,49 +14,34 @@
 # limitations under the License.
 #
 
-
-list(APPEND STRINGS_PUBLIC_HEADERS
+set(STRINGS_HDRS
   "ascii.h"
   "charconv.h"
   "escaping.h"
   "match.h"
   "numbers.h"
   "str_cat.h"
-  "string_view.h"
-  "strip.h"
   "str_join.h"
   "str_replace.h"
   "str_split.h"
+  "string_view.h"
+  "strip.h"
   "substitute.h"
 )
 
-
-list(APPEND STRINGS_INTERNAL_HEADERS
-  "internal/char_map.h"
-  "internal/charconv_bigint.h"
-  "internal/charconv_parse.h"
-  "internal/memutil.h"
-  "internal/ostringstream.h"
-  "internal/resize_uninitialized.h"
-  "internal/stl_type_traits.h"
-  "internal/str_join_internal.h"
-  "internal/str_split_internal.h"
-  "internal/utf8.h"
-)
-
-
-
-# add string library
-list(APPEND STRINGS_SRC
+set(STRINGS_SRCS
   "ascii.cc"
   "charconv.cc"
   "escaping.cc"
   "internal/charconv_bigint.cc"
+  "internal/charconv_bigint.h"
   "internal/charconv_parse.cc"
+  "internal/charconv_parse.h"
   "internal/memutil.cc"
   "internal/memutil.h"
-  "internal/utf8.cc"
-  "internal/ostringstream.cc"
+  "internal/stl_type_traits.h"
+  "internal/str_join_internal.h"
+  "internal/str_split_internal.h"
   "match.cc"
   "numbers.cc"
   "str_cat.cc"
@@ -64,43 +49,267 @@ list(APPEND STRINGS_SRC
   "str_split.cc"
   "string_view.cc"
   "substitute.cc"
-  ${STRINGS_PUBLIC_HEADERS}
-  ${STRINGS_INTERNAL_HEADERS}
-)
-set(STRINGS_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate)
-
-absl_library(
-  TARGET
-    absl_strings
-  SOURCES
-    ${STRINGS_SRC}
-  PUBLIC_LIBRARIES
-    ${STRINGS_PUBLIC_LIBRARIES}
-  EXPORT_NAME
-    strings
 )
 
-# add str_format library
-absl_header_library(
-  TARGET
-    absl_str_format
-  PUBLIC_LIBRARIES
-    str_format_internal
-  EXPORT_NAME
-    str_format
+absl_cc_library(
+  NAME strings
+  SRCS ${STRINGS_SRCS}
+  HDRS ${STRINGS_HDRS}
+  DEPS
+    absl::strings_internal
+    absl::base
+    absl::bits
+    absl::config
+    absl::core_headers
+    absl::endian
+    absl::throw_delegate
+    absl::memory
+    absl::type_traits
+    absl::int128
+  PUBLIC
 )
 
-# str_format_internal
-absl_library(
-  TARGET
-    str_format_internal
-  SOURCES
+# strings_internal library
+set(STRINGS_INTERNAL_HDRS
+  "internal/char_map.h"
+  "internal/ostringstream.h"
+  "internal/resize_uninitialized.h"
+  "internal/utf8.h"
+)
+
+set(STRINGS_INTERNAL_SRCS
+  "internal/ostringstream.cc"
+  "internal/utf8.cc"
+)
+
+absl_cc_library(
+  NAME strings_internal
+  SRCS ${STRINGS_INTERNAL_SRCS}
+  HDRS ${STRINGS_INTERNAL_HDRS}
+  DEPS
+    absl::core_headers
+    absl::endian
+    absl::type_traits
+  PUBLIC
+)
+
+# match test
+absl_cc_test(
+  NAME match_test
+  SRCS "match_test.cc"
+  DEPS
+    absl::strings
+    gtest_main
+)
+
+# escaping test
+absl_cc_test(
+  NAME escaping_test
+  SRCS
+    "escaping_test.cc"
+    "internal/escaping_test_common.h"
+  DEPS
+    absl::strings
+    absl::core_headers
+    absl::fixed_array
+    gmock
+    gtest_main
+)
+
+# ascii test
+absl_cc_test(
+  NAME ascii_test
+  SRCS "ascii_test.cc"
+  DEPS
+    absl::strings
+    absl::core_headers
+    gtest_main
+)
+
+# memutil test
+absl_cc_test(
+  NAME memutil_test
+  SRCS
+    "internal/memutil.h"
+    "internal/memutil_test.cc"
+  DEPS
+    absl::strings
+    absl::core_headers
+    gtest_main
+)
+
+# utf8 test
+absl_cc_test(
+  NAME utf8_test
+  SRCS "internal/utf8_test.cc"
+  DEPS
+    absl::strings_internal
+    absl::core_headers
+    gtest_main
+)
+
+absl_cc_test(
+  NAME string_view_test
+  SRCS "string_view_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::strings
+    absl::config
+    absl::core_headers
+    absl::dynamic_annotations
+    gtest_main
+)
+
+absl_cc_test(
+  NAME substitute_test
+  SRCS "substitute_test.cc"
+  DEPS
+    absl::strings
+    absl::core_headers
+    gtest_main
+  )
+
+absl_cc_test(
+  NAME str_replace_test
+  SRCS "str_replace_test.cc"
+  DEPS
+    absl::strings
+    gtest_main
+)
+
+absl_cc_test(
+  NAME str_split_test
+  SRCS "str_split_test.cc"
+  DEPS
+    absl::strings
+    absl::core_headers
+    absl::dynamic_annotations
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME ostringstream_test
+  SRCS "internal/ostringstream_test.cc"
+  DEPS
+    absl::strings_internal
+    gtest_main
+)
+
+absl_cc_test(
+  NAME resize_uninitialized_test
+  SRCS
+    "internal/resize_uninitialized.h"
+    "internal/resize_uninitialized_test.cc"
+  DEPS
+    absl::core_headers
+    absl::type_traits
+    gtest_main
+)
+
+absl_cc_test(
+  NAME str_join_test
+  SRCS "str_join_test.cc"
+  DEPS
+    absl::strings
+    absl::core_headers
+    absl::memory
+    gtest_main
+)
+
+absl_cc_test(
+  NAME str_cat_test
+  SRCS "str_cat_test.cc"
+  DEPS
+    absl::strings
+    absl::core_headers
+    gtest_main
+)
+
+absl_cc_test(
+  NAME numbers_test
+  SRCS
+    "internal/numbers_test_common.h"
+    "numbers_test.cc"
+  DEPS
+    absl::strings
+    absl::base
+    absl::core_headers
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME strip_test
+  SRCS "strip_test.cc"
+  DEPS
+    absl::strings
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME char_map_test
+  SRCS "internal/char_map_test.cc"
+  DEPS
+    absl::strings_internal
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME charconv_test
+  SRCS "charconv_test.cc"
+  DEPS
+    absl::strings
+    absl::base
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME charconv_parse_test
+  SRCS
+    "internal/charconv_parse.h"
+    "internal/charconv_parse_test.cc"
+  DEPS
+    absl::strings
+    absl::base
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME charconv_bigint_test
+  SRCS
+    "internal/charconv_bigint.h"
+    "internal/charconv_bigint_test.cc"
+    "internal/charconv_parse.h"
+  DEPS
+    absl::strings
+    absl::base
+    gtest_main
+)
+
+absl_cc_library(
+  NAME str_format
+  HDRS "str_format.h"
+  DEPS
+    absl::str_format_internal
+  PUBLIC
+)
+
+absl_cc_library(
+  NAME str_format_internal
+  SRCS
     "internal/str_format/arg.cc"
     "internal/str_format/bind.cc"
     "internal/str_format/extension.cc"
     "internal/str_format/float_conversion.cc"
     "internal/str_format/output.cc"
     "internal/str_format/parser.cc"
+  HDRS
     "internal/str_format/arg.h"
     "internal/str_format/bind.h"
     "internal/str_format/checker.h"
@@ -108,355 +317,85 @@ absl_library(
     "internal/str_format/float_conversion.h"
     "internal/str_format/output.h"
     "internal/str_format/parser.h"
-  PUBLIC_LIBRARIES
-    str_format_extension_internal
+  DEPS
     absl::strings
-    absl::base
-    absl::numeric
-    absl::container
+    absl::core_headers
+    absl::inlined_vector
+    absl::type_traits
+    absl::int128
     absl::span
+  PUBLIC
 )
 
-# str_format_extension_internal
-absl_library(
-  TARGET
-    str_format_extension_internal
-  SOURCES
-    "internal/str_format/extension.cc"
-    "internal/str_format/extension.h"
-    "internal/str_format/output.cc"
-    "internal/str_format/output.h"
-  PUBLIC_LIBRARIES
-    absl::base
-    absl::strings
-)
-
-#
-## TESTS
-#
-
-# test match_test
-set(MATCH_TEST_SRC "match_test.cc")
-set(MATCH_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    match_test
-  SOURCES
-    ${MATCH_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${MATCH_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test escaping_test
-set(ESCAPING_TEST_SRC "escaping_test.cc")
-set(ESCAPING_TEST_PUBLIC_LIBRARIES absl::strings absl::base)
-
-absl_test(
-  TARGET
-    escaping_test
-  SOURCES
-    ${ESCAPING_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${ESCAPING_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test ascii_test
-set(ASCII_TEST_SRC "ascii_test.cc")
-set(ASCII_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    ascii_test
-  SOURCES
-    ${ASCII_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${ASCII_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test memutil_test
-set(MEMUTIL_TEST_SRC "internal/memutil_test.cc")
-set(MEMUTIL_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    memutil_test
-  SOURCES
-    ${MEMUTIL_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${MEMUTIL_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test utf8_test
-set(UTF8_TEST_SRC "internal/utf8_test.cc")
-set(UTF8_TEST_PUBLIC_LIBRARIES absl::strings absl::base)
-
-absl_test(
-  TARGET
-    utf8_test
-  SOURCES
-    ${UTF8_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${UTF8_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test string_view_test
-set(STRING_VIEW_TEST_SRC "string_view_test.cc")
-set(STRING_VIEW_TEST_PUBLIC_LIBRARIES absl::strings absl_internal_throw_delegate absl::base)
-
-absl_test(
-  TARGET
-    string_view_test
-  SOURCES
-    ${STRING_VIEW_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${STRING_VIEW_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test substitute_test
-set(SUBSTITUTE_TEST_SRC "substitute_test.cc")
-set(SUBSTITUTE_TEST_PUBLIC_LIBRARIES absl::strings absl::base)
-
-absl_test(
-  TARGET
-    substitute_test
-  SOURCES
-    ${SUBSTITUTE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${SUBSTITUTE_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test str_replace_test
-set(STR_REPLACE_TEST_SRC "str_replace_test.cc")
-set(STR_REPLACE_TEST_PUBLIC_LIBRARIES absl::strings absl::base absl_internal_throw_delegate)
-
-absl_test(
-  TARGET
-    str_replace_test
-  SOURCES
-    ${STR_REPLACE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${STR_REPLACE_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test str_split_test
-set(STR_SPLIT_TEST_SRC "str_split_test.cc")
-set(STR_SPLIT_TEST_PUBLIC_LIBRARIES absl::strings absl::base absl_internal_throw_delegate)
-
-absl_test(
-  TARGET
-    str_split_test
-  SOURCES
-    ${STR_SPLIT_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${STR_SPLIT_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test ostringstream_test
-set(OSTRINGSTREAM_TEST_SRC "internal/ostringstream_test.cc")
-set(OSTRINGSTREAM_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    ostringstream_test
-  SOURCES
-    ${OSTRINGSTREAM_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${OSTRINGSTREAM_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test resize_uninitialized_test
-set(RESIZE_UNINITIALIZED_TEST_SRC "internal/resize_uninitialized_test.cc")
-
-absl_test(
-  TARGET
-    resize_uninitialized_test
-  SOURCES
-    ${RESIZE_UNINITIALIZED_TEST_SRC}
-)
-
-
-# test str_join_test
-set(STR_JOIN_TEST_SRC "str_join_test.cc")
-set(STR_JOIN_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    str_join_test
-  SOURCES
-    ${STR_JOIN_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${STR_JOIN_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test str_cat_test
-set(STR_CAT_TEST_SRC "str_cat_test.cc")
-set(STR_CAT_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    str_cat_test
-  SOURCES
-    ${STR_CAT_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${STR_CAT_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test numbers_test
-set(NUMBERS_TEST_SRC "numbers_test.cc")
-set(NUMBERS_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    numbers_test
-  SOURCES
-    ${NUMBERS_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${NUMBERS_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test strip_test
-set(STRIP_TEST_SRC "strip_test.cc")
-set(STRIP_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    strip_test
-  SOURCES
-    ${STRIP_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${STRIP_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test char_map_test
-set(CHAR_MAP_TEST_SRC "internal/char_map_test.cc")
-set(CHAR_MAP_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    char_map_test
-  SOURCES
-    ${CHAR_MAP_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${CHAR_MAP_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test charconv_test
-set(CHARCONV_TEST_SRC "charconv_test.cc")
-set(CHARCONV_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    charconv_test
-  SOURCES
-    ${CHARCONV_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${CHARCONV_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test charconv_parse_test
-set(CHARCONV_PARSE_TEST_SRC "internal/charconv_parse_test.cc")
-set(CHARCONV_PARSE_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    charconv_parse_test
-  SOURCES
-    ${CHARCONV_PARSE_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${CHARCONV_PARSE_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test charconv_bigint_test
-set(CHARCONV_BIGINT_TEST_SRC "internal/charconv_bigint_test.cc")
-set(CHARCONV_BIGINT_TEST_PUBLIC_LIBRARIES absl::strings)
-
-absl_test(
-  TARGET
-    charconv_bigint_test
-  SOURCES
-    ${CHARCONV_BIGINT_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${CHARCONV_BIGINT_TEST_PUBLIC_LIBRARIES}
-)
-# test str_format_test
-absl_test(
-  TARGET
-    str_format_test
-  SOURCES
-    "str_format_test.cc"
-  PUBLIC_LIBRARIES
-    absl::base
+absl_cc_test(
+  NAME str_format_test
+  SRCS "str_format_test.cc"
+  DEPS
     absl::str_format
     absl::strings
+    absl::core_headers
+    gmock
+    gtest_main
 )
 
-# test str_format_bind_test
-absl_test(
-  TARGET
-    str_format_bind_test
-  SOURCES
-    "internal/str_format/bind_test.cc"
-  PUBLIC_LIBRARIES
-    str_format_internal
-)
-
-# test str_format_checker_test
-absl_test(
-  TARGET
-    str_format_checker_test
-  SOURCES
-    "internal/str_format/checker_test.cc"
-  PUBLIC_LIBRARIES
+absl_cc_test(
+  NAME str_format_extension_test
+  SRCS "internal/str_format/extension_test.cc"
+  DEPS
     absl::str_format
+    absl::str_format_internal
+    gtest_main
 )
 
-# test str_format_convert_test
-absl_test(
-  TARGET
-    str_format_convert_test
-  SOURCES
-    "internal/str_format/convert_test.cc"
-  PUBLIC_LIBRARIES
-    str_format_internal
-    absl::numeric
+absl_cc_test(
+  NAME str_format_arg_test
+  SRCS "internal/str_format/arg_test.cc"
+  DEPS
+    absl::str_format
+    absl::str_format_internal
+    gtest_main
 )
 
-# test str_format_output_test
-absl_test(
-  TARGET
-    str_format_output_test
-  SOURCES
-    "internal/str_format/output_test.cc"
-  PUBLIC_LIBRARIES
-    str_format_extension_internal
+absl_cc_test(
+  NAME str_format_bind_test
+  SRCS "internal/str_format/bind_test.cc"
+  DEPS
+    absl::str_format_internal
+    gtest_main
 )
 
-# test str_format_parser_test
-absl_test(
-  TARGET
-    str_format_parser_test
-  SOURCES
-    "internal/str_format/parser_test.cc"
-  PUBLIC_LIBRARIES
-    str_format_internal
-    absl::base
+absl_cc_test(
+  NAME str_format_checker_test
+  SRCS "internal/str_format/checker_test.cc"
+  DEPS
+    absl::str_format
+    gmock
+    gtest_main
 )
 
+absl_cc_test(
+  NAME str_format_convert_test
+  SRCS "internal/str_format/convert_test.cc"
+  DEPS
+    absl::str_format_internal
+    absl::int128
+    gtest_main
+)
+
+absl_cc_test(
+  NAME str_format_output_test
+  SRCS "internal/str_format/output_test.cc"
+  DEPS
+    absl::str_format_internal
+    gmock
+    gtest_main
+)
+
+absl_cc_test(
+  NAME str_format_parser_test
+  SRCS "internal/str_format/parser_test.cc"
+  DEPS
+    absl::str_format_internal
+    absl::core_headers
+    gtest_main
+)

--- a/absl/synchronization/CMakeLists.txt
+++ b/absl/synchronization/CMakeLists.txt
@@ -14,142 +14,147 @@
 # limitations under the License.
 #
 
-list(APPEND SYNCHRONIZATION_PUBLIC_HEADERS
+absl_cc_library(
+  NAME graphcycles_internal
+  SRCS "internal/graphcycles.cc"
+  HDRS "internal/graphcycles.h"
+  DEPS
+    absl::base
+    absl::base_internal
+    absl::core_headers
+    absl::malloc_internal
+  PUBLIC
+)
+
+# synchronization library
+set(SYNCHRONIZATION_HDRS
   "barrier.h"
   "blocking_counter.h"
+  "internal/create_thread_identity.h"
+  "internal/kernel_timeout.h"
+  "internal/mutex_nonprod.inc"
+  "internal/per_thread_sem.h"
+  "internal/waiter.h"
   "mutex.h"
   "notification.h"
 )
 
-
-list(APPEND SYNCHRONIZATION_INTERNAL_HEADERS
-  "internal/create_thread_identity.h"
-  "internal/graphcycles.h"
-  "internal/kernel_timeout.h"
-  "internal/per_thread_sem.h"
-  "internal/thread_pool.h"
-  "internal/waiter.h"
-)
-
-
-
-# synchronization library
-list(APPEND SYNCHRONIZATION_SRC
+set(SYNCHRONIZATION_SRCS
   "barrier.cc"
   "blocking_counter.cc"
   "internal/create_thread_identity.cc"
   "internal/per_thread_sem.cc"
   "internal/waiter.cc"
-  "internal/graphcycles.cc"
   "notification.cc"
   "mutex.cc"
 )
 
-set(SYNCHRONIZATION_PUBLIC_LIBRARIES absl::base absl::stacktrace absl::symbolize absl::time)
-
-absl_library(
-  TARGET
-    absl_synchronization
-  SOURCES
-    ${SYNCHRONIZATION_SRC}
-  PUBLIC_LIBRARIES
-    ${SYNCHRONIZATION_PUBLIC_LIBRARIES}
-  EXPORT_NAME
-    synchronization
+absl_cc_library(
+  NAME synchronization
+  SRCS ${SYNCHRONIZATION_SRCS}
+  HDRS ${SYNCHRONIZATION_HDRS}
+  DEPS
+    absl::graphcycles_internal
+    absl::base
+    absl::base_internal
+    absl::config
+    absl::core_headers
+    absl::dynamic_annotations
+    absl::malloc_internal
+    absl::stacktrace
+    absl::symbolize
+    absl::time
+    Threads::Threads
+  PUBLIC
 )
-
 
 #
 ## TESTS
 #
 
-
-# test barrier_test
-set(BARRIER_TEST_SRC "barrier_test.cc")
-set(BARRIER_TEST_PUBLIC_LIBRARIES absl::synchronization)
-
-absl_test(
-  TARGET
-    barrier_test
-  SOURCES
-    ${BARRIER_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${BARRIER_TEST_PUBLIC_LIBRARIES}
+# barrier test
+absl_cc_test(
+  NAME barrier_test
+  SRCS "barrier_test.cc"
+  DEPS
+    absl::synchronization
+    absl::time
+    gtest_main
 )
 
-
-# test blocking_counter_test
-set(BLOCKING_COUNTER_TEST_SRC "blocking_counter_test.cc")
-set(BLOCKING_COUNTER_TEST_PUBLIC_LIBRARIES absl::synchronization)
-
-absl_test(
-  TARGET
-    blocking_counter_test
-  SOURCES
-    ${BLOCKING_COUNTER_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${BLOCKING_COUNTER_TEST_PUBLIC_LIBRARIES}
+# blocking_counter test
+absl_cc_test(
+  NAME blocking_counter_test
+  SRCS "blocking_counter_test.cc"
+  DEPS
+    absl::synchronization
+    absl::time
+    gtest_main
 )
 
-
-# test graphcycles_test
-set(GRAPHCYCLES_TEST_SRC "internal/graphcycles_test.cc")
-set(GRAPHCYCLES_TEST_PUBLIC_LIBRARIES absl::synchronization)
-
-absl_test(
-  TARGET
-    graphcycles_test
-  SOURCES
-    ${GRAPHCYCLES_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${GRAPHCYCLES_TEST_PUBLIC_LIBRARIES}
+# graphcycles test
+absl_cc_test(
+  NAME graphcycles_test
+  SRCS "internal/graphcycles_test.cc"
+  DEPS
+    absl::graphcycles_internal
+    absl::base
+    absl::core_headers
+    gtest_main
 )
 
-
-# test mutex_test
-set(MUTEX_TEST_SRC "mutex_test.cc")
-set(MUTEX_TEST_PUBLIC_LIBRARIES absl::synchronization)
-
-absl_test(
-  TARGET
-    mutex_test
-  SOURCES
-    ${MUTEX_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${MUTEX_TEST_PUBLIC_LIBRARIES}
+# thread_pool library
+absl_cc_library(
+  NAME thread_pool
+  HDRS "internal/thread_pool.h"
+  DEPS
+    absl::synchronization
+    absl::core_headers
+  TESTONLY
 )
 
-
-# test notification_test
-set(NOTIFICATION_TEST_SRC "notification_test.cc")
-set(NOTIFICATION_TEST_PUBLIC_LIBRARIES absl::synchronization)
-
-absl_test(
-  TARGET
-    notification_test
-  SOURCES
-    ${NOTIFICATION_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${NOTIFICATION_TEST_PUBLIC_LIBRARIES}
+# mutex test
+absl_cc_test(
+  NAME mutex_test
+  SRCS "mutex_test.cc"
+  DEPS
+    absl::synchronization
+    absl::thread_pool
+    absl::base
+    absl::core_headers
+    absl::memory
+    absl::time
+    gtest_main
 )
 
-
-# test per_thread_sem_test_common
-set(PER_THREAD_SEM_TEST_COMMON_SRC "internal/per_thread_sem_test.cc")
-set(PER_THREAD_SEM_TEST_COMMON_PUBLIC_LIBRARIES absl::synchronization absl::strings)
-
-absl_test(
-  TARGET
-    per_thread_sem_test_common
-  SOURCES
-    ${PER_THREAD_SEM_TEST_COMMON_SRC}
-  PUBLIC_LIBRARIES
-    ${PER_THREAD_SEM_TEST_COMMON_PUBLIC_LIBRARIES}
+# notification test
+absl_cc_test(
+  NAME notification_test
+  SRCS "notification_test.cc"
+  DEPS
+    absl::synchronization
+    absl::time
+    gtest_main
 )
 
+absl_cc_test(
+  NAME per_thread_sem_test
+  SRCS "internal/per_thread_sem_test.cc"
+  DEPS
+    absl::synchronization
+    absl::base
+    absl::strings
+    absl::time
+    gtest_main
+)
 
-
-
-
-
+absl_cc_test(
+  NAME lifetime_test
+  SRCS "lifetime_test.cc"
+  DEPS
+    absl::synchronization
+    absl::base
+    absl::core_headers
+    Threads::Threads
+)
 

--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -14,27 +14,24 @@
 # limitations under the License.
 #
 
-list(APPEND TIME_PUBLIC_HEADERS
+set(TIME_HDRS
   "civil_time.h"
   "clock.h"
   "time.h"
-)
-
-
-list(APPEND TIME_INTERNAL_HEADERS
-  "internal/test_util.h"
   "internal/cctz/include/cctz/civil_time.h"
   "internal/cctz/include/cctz/civil_time_detail.h"
   "internal/cctz/include/cctz/time_zone.h"
   "internal/cctz/include/cctz/zone_info_source.h"
 )
 
-list(APPEND TIME_SRC
+set(TIME_SRCS
   "civil_time.cc"
-  "time.cc"
   "clock.cc"
   "duration.cc"
   "format.cc"
+  "internal/get_current_time_chrono.inc"
+  "internal/get_current_time_posix.inc"
+  "time.cc"
   "internal/cctz/src/civil_time_detail.cc"
   "internal/cctz/src/time_zone_fixed.cc"
   "internal/cctz/src/time_zone_fixed.h"
@@ -52,47 +49,57 @@ list(APPEND TIME_SRC
   "internal/cctz/src/time_zone_posix.h"
   "internal/cctz/src/tzfile.h"
   "internal/cctz/src/zone_info_source.cc"
-  ${TIME_PUBLIC_HEADERS}
-  ${TIME_INTERNAL_HEADERS}
-)
-set(TIME_PUBLIC_LIBRARIES absl::base absl::stacktrace absl::int128 absl::strings)
-
-absl_library(
-  TARGET
-    absl_time
-  SOURCES
-    ${TIME_SRC}
-  PUBLIC_LIBRARIES
-    ${TIME_PUBLIC_LIBRARIES}
-  EXPORT_NAME
-    time
 )
 
-
+absl_cc_library(
+  NAME time
+  SRCS ${TIME_SRCS}
+  HDRS ${TIME_HDRS}
+  DEPS
+    absl::base
+    absl::core_headers
+    absl::int128
+    absl::strings
+  PUBLIC
+)
 
 #
 ## TESTS
 #
 
+absl_cc_library(
+  NAME test_util
+  SRCS
+    "internal/test_util.cc"
+    "internal/zoneinfo.inc"
+  HDRS "internal/test_util.h"
+  DEPS
+    absl::time
+    absl::base
+    gtest
+  TESTONLY
+)
+
 # test time_test
-list(APPEND TIME_TEST_SRC
+set(TIME_TEST_SRCS
   "civil_time_test.cc"
-  "time_test.cc"
   "clock_test.cc"
   "duration_test.cc"
   "format_test.cc"
   "time_test.cc"
   "time_zone_test.cc"
-  "internal/test_util.cc"
 )
-set(TIME_TEST_PUBLIC_LIBRARIES absl::time)
 
-absl_test(
-  TARGET
-    time_test
-  SOURCES
-    ${TIME_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${TIME_TEST_PUBLIC_LIBRARIES}
+absl_cc_test(
+  NAME time_test
+  SRCS ${TIME_TEST_SRCS}
+  DEPS
+    absl::test_util
+    absl::time
+    absl::base
+    absl::config
+    absl::core_headers
+    gmock
+    gtest_main
 )
 

--- a/absl/types/CMakeLists.txt
+++ b/absl/types/CMakeLists.txt
@@ -14,215 +14,235 @@
 # limitations under the License.
 #
 
-list(APPEND TYPES_PUBLIC_HEADERS
-  "any.h"
-  "bad_any_cast.h"
-  "bad_optional_access.h"
-  "optional.h"
-  "span.h"
-  "variant.h"
+# any library
+absl_cc_library(
+  NAME any
+  HDRS "any.h"
+  DEPS
+    absl::bad_any_cast
+    absl::config
+    absl::core_headers
+    absl::type_traits
+    absl::utility
+  PUBLIC
 )
 
+# bad_any_cast library
+absl_cc_library(
+  NAME bad_any_cast
+  HDRS "bad_any_cast.h"
+  DEPS
+    absl::bad_any_cast_impl
+    absl::config
+  PUBLIC
+)
 
-# any library
-absl_header_library(
-  TARGET
-    absl_any
-  PUBLIC_LIBRARIES
-    absl::bad_any_cast
+absl_cc_library(
+  NAME bad_any_cast_impl
+  SRCS
+    "bad_any_cast.cc"
+    "bad_any_cast.h"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
     absl::base
-    absl::meta
-    absl::utility
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
-  EXPORT_NAME
-    any
+    absl::config
+  PUBLIC
+)
+
+# any test
+absl_cc_test(
+  NAME any_test
+  SRCS "any_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::any
+    absl::base
+    absl::config
+    absl::exception_testing
+    absl::test_instance_tracker
+    gtest_main
+)
+
+# any_test_noexceptions test
+absl_cc_test(
+  NAME any_test_noexceptions
+  SRCS "any_test.cc"
+  DEPS
+    absl::any
+    absl::base
+    absl::config
+    absl::exception_testing
+    absl::test_instance_tracker
+    gtest_main
+)
+
+# any_exception_safety_test
+absl_cc_test(
+  NAME any_exception_safety_test
+  SRCS "any_exception_safety_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::any
+    absl::exception_safety_testing
+    gtest_main
 )
 
 # span library
-absl_header_library(
-  TARGET
-    absl_span
-  PUBLIC_LIBRARIES
-    absl::utility
-  EXPORT_NAME
-    span
+absl_cc_library(
+  NAME span
+  HDRS "span.h"
+  DEPS
+    absl::algorithm
+    absl::core_headers
+    absl::throw_delegate
+    absl::type_traits
+  PUBLIC
 )
 
-
-# bad_any_cast library
-list(APPEND BAD_ANY_CAST_SRC
-  "bad_any_cast.cc"
-  ${TYPES_PUBLIC_HEADERS}
+absl_cc_test(
+  NAME span_test
+  SRCS "span_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::span
+    absl::config
+    absl::core_headers
+    absl::exception_testing
+    absl::fixed_array
+    absl::inlined_vector
+    absl::hash_testing
+    absl::strings
+    gmock
+    gtest_main
 )
 
-absl_library(
-  TARGET
-    absl_bad_any_cast
-  SOURCES
-    ${BAD_ANY_CAST_SRC}
-  PUBLIC_LIBRARIES
-  EXPORT_NAME
-    bad_any_cast
+# test span_test_noexceptions
+absl_cc_test(
+  NAME span_test_noexceptions
+  SRCS "span_test.cc"
+  DEPS
+    absl::span
+    absl::config
+    absl::core_headers
+    absl::exception_testing
+    absl::fixed_array
+    absl::inlined_vector
+    absl::hash_testing
+    absl::strings
+    gmock
+    gtest_main
 )
-
 
 # optional library
-list(APPEND OPTIONAL_SRC
-  "optional.cc"
-)
-
-absl_library(
-  TARGET
-    absl_optional
-  SOURCES
-    ${OPTIONAL_SRC}
-  PUBLIC_LIBRARIES
+absl_cc_library(
+  NAME optional
+  SRCS "optional.cc"
+  HDRS "optional.h"
+  DEPS
     absl::bad_optional_access
-    absl::base
+    absl::config
     absl::memory
-    absl::meta
+    absl::type_traits
     absl::utility
-  EXPORT_NAME
-    optional
+  PUBLIC
 )
 
+absl_cc_library(
+  NAME bad_optional_access
+  SRCS "bad_optional_access.cc"
+  HDRS "bad_optional_access.h"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::base
+    absl::config
+  PUBLIC
+)
 
-set(BAD_OPTIONAL_ACCESS_SRC "bad_optional_access.cc")
-set(BAD_OPTIONAL_ACCESS_LIBRARIES absl::base)
+absl_cc_library(
+  NAME bad_variant_access
+  SRCS "bad_variant_access.cc"
+  HDRS "bad_variant_access.h"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::base
+    absl::config
+  PUBLIC
+)
 
-absl_library(
-  TARGET
-    absl_bad_optional_access
-  SOURCES
-    ${BAD_OPTIONAL_ACCESS_SRC}
-  PUBLIC_LIBRARIES
-    ${BAD_OPTIONAL_ACCESS_PUBLIC_LIBRARIES}
-  EXPORT_NAME
-    bad_optional_access
+# optional test
+absl_cc_test(
+  NAME optional_test
+  SRCS "optional_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::optional
+    absl::base
+    absl::config
+    absl::type_traits
+    absl::strings
+    gtest_main
+)
+
+absl_cc_test(
+  NAME optional_exception_safety_test
+  SRCS "optional_exception_safety_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::optional
+    absl::exception_safety_testing
+    gtest_main
 )
 
 # variant library
-absl_library(
-  TARGET
-    absl_variant
-  SOURCES
-    "bad_variant_access.h" "bad_variant_access.cc" "variant.h" "internal/variant.h"
-  PUBLIC_LIBRARIES
-    absl::base absl::meta absl::utility
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
-  EXPORT_NAME
-    variant
+absl_cc_library(
+  NAME variant
+  HDRS
+    "variant.h"
+    "internal/variant.h"
+  DEPS
+    absl::bad_variant_access
+    absl::base_internal
+    absl::config
+    absl::core_headers
+    absl::type_traits
+    absl::utility
+  PUBLIC
 )
 
-#
-## TESTS
-#
-
-
-# test any_test
-set(ANY_TEST_SRC "any_test.cc")
-set(ANY_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate absl::any absl::bad_any_cast test_instance_tracker_lib)
-
-absl_test(
-  TARGET
-    any_test
-  SOURCES
-    ${ANY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${ANY_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
+# variant test
+absl_cc_test(
+  NAME variant_test
+  SRCS "variant_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::variant
+    absl::config
+    absl::core_headers
+    absl::memory
+    absl::type_traits
+    absl::strings
+    gmock
+    gtest_main
 )
 
-
-# test any_test_noexceptions
-absl_test(
-  TARGET
-    any_test_noexceptions
-  SOURCES
-    ${ANY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${ANY_TEST_PUBLIC_LIBRARIES}
-)
-
-# test any_exception_safety_test
-set(ANY_EXCEPTION_SAFETY_TEST_SRC "any_exception_safety_test.cc")
-set(ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
-  absl::any
-  absl::base
-  absl_internal_exception_safety_testing
-)
-
-absl_test(
-  TARGET
-    any_exception_safety_test
-  SOURCES
-    ${ANY_EXCEPTION_SAFETY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${ANY_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
-)
-
-
-# test span_test
-set(SPAN_TEST_SRC "span_test.cc")
-set(SPAN_TEST_PUBLIC_LIBRARIES absl::base absl::strings absl_internal_throw_delegate absl::span test_instance_tracker_lib)
-
-absl_test(
-  TARGET
-    span_test
-  SOURCES
-    ${SPAN_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${SPAN_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
-)
-
-
-# test span_test_noexceptions
-absl_test(
-  TARGET
-    span_test_noexceptions
-  SOURCES
-    ${SPAN_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${SPAN_TEST_PUBLIC_LIBRARIES}
-)
-
-
-
-# test optional_test
-set(OPTIONAL_TEST_SRC "optional_test.cc")
-set(OPTIONAL_TEST_PUBLIC_LIBRARIES absl::base absl_internal_throw_delegate absl::optional absl_bad_optional_access)
-
-absl_test(
-  TARGET
-    optional_test
-  SOURCES
-    ${OPTIONAL_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${OPTIONAL_TEST_PUBLIC_LIBRARIES}
-)
-
-
-# test optional_exception_safety_test
-set(OPTIONAL_EXCEPTION_SAFETY_TEST_SRC "optional_exception_safety_test.cc")
-set(OPTIONAL_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES
-  absl::optional
-  absl_internal_exception_safety_testing
-)
-
-absl_test(
-  TARGET
-    optional_exception_safety_test
-  SOURCES
-    ${OPTIONAL_EXCEPTION_SAFETY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${OPTIONAL_EXCEPTION_SAFETY_TEST_PUBLIC_LIBRARIES}
-  PRIVATE_COMPILE_FLAGS
-    ${ABSL_EXCEPTIONS_FLAG}
+absl_cc_test(
+  NAME variant_exception_safety_test
+  SRCS "variant_exception_safety_test.cc"
+  COPTS ${ABSL_EXCEPTIONS_FLAG}
+  LINKOPTS ${ABSL_EXCEPTIONS_FLAG_LINKOPTS}
+  DEPS
+    absl::variant
+    absl::exception_safety_testing
+    absl::memory
+    gmock
+    gtest_main
 )

--- a/absl/utility/CMakeLists.txt
+++ b/absl/utility/CMakeLists.txt
@@ -14,39 +14,25 @@
 # limitations under the License.
 #
 
-
-list(APPEND UTILITY_PUBLIC_HEADERS
-  "utility.h"
+absl_cc_library(
+  NAME utility
+  HDRS "utility.h"
+  DEPS
+    absl::base_internal
+    absl::config
+    absl::type_traits
+  PUBLIC
 )
 
-absl_header_library(
-  TARGET
-    absl_utility
-  PUBLIC_LIBRARIES
-    absl::base
-  EXPORT_NAME
-    utility
-)
-
-
-#
-## TESTS
-#
-
-# test utility_test
-set(UTILITY_TEST_SRC "utility_test.cc")
-set(UTILITY_TEST_PUBLIC_LIBRARIES
-  absl::base
-  absl::memory
-  absl::strings
-  absl::utility
-)
-
-absl_test(
-  TARGET
-    utility_test
-  SOURCES
-    ${UTILITY_TEST_SRC}
-  PUBLIC_LIBRARIES
-    ${UTILITY_TEST_PUBLIC_LIBRARIES}
+# utility test
+absl_cc_test(
+  NAME utility_test
+  SRCS "utility_test.cc"
+  DEPS
+    absl::utility
+    absl::core_headers
+    absl::memory
+    absl::strings
+    gmock
+    gtest_main
 )


### PR DESCRIPTION
Use `absl_cc_test` and `absl_cc_library` everywhere

# Tasks list
* [X] Add `absl_cc_test()`
* [X] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/base`
  * Add missing `pretty_function` library
  * Add missing `bits` library and `bits_test` test
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/algorithm`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/container`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/debugging`
  * `leak_check_test` comment out since it depends on `ABSL_LSAN_LINKOPTS`
  * `disabled_leak_check_test` comment out since it depends on `ABSL_LSAN_LINKOPTS`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/hash`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/memory`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/meta`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/numeric`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/strings`
  * rename bazel `internal` to `strings_internal` target i.e. (absl::strings_internal ALIAS)
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/synchronization`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/time`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/types`
* [x] Migrate to `absl_cc_library()` and `absl_cc_test()` in `absl/utility`
* [x] Remove deprecated function `absl_library()`
* [x] Remove deprecated function `absl_header_library()`
* [x] Remove deprecated function `absl_test()`

# Issues
 * Some tests (which were not compiled at all before !!!) are broken if using gcc4.8 (cf below comment).
   workaround: Bump Travis-CI job to gcc-7 seems to fix compilation/link issue
* Same issue with Travis-CI `clang-5.0.0`

# Note
* I would be more confident if we have PR #197 first so we can check with CI that it's working.
  note: my `absl_cc_ci` branch contains this PR #199 and PR #197 -> Travis log [here](https://travis-ci.org/Mizux/abseil-cpp/branches) -> so we can more or less run "CI" on this PR
* This PR is mandatory for #182
* In Bazel world "target" contains the directory e.g. `"//absl/strings:internal"`,
  While in CMake we have `absl_internal` (with `ALIAS` to `absl::internal`)
  note: `absl_` is a prefix added by `absl_cc_library` function.
* With this rework we move from [74](https://travis-ci.org/Mizux/abseil-cpp/jobs/446032682) to 94 tests.
  * I still didn't port "benchmark" tests (like current HEAD)
* `gtest_main` doesn't do a `target_link_library(gtest_main PUBLIC gmock)` so you need to explicitly list both dependencies contrary to BUILD.bazel rules where gtest_main seems sufficient
