### PR TITLE
Fix CMakeLists.txt for container library

### DIFF
--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -48,9 +48,16 @@ list(APPEND CONTAINER_INTERNAL_HEADERS
 )
 
 
-absl_header_library(
+list(APPEND CONTAINER_LIB_SRC
+  "internal/raw_hash_set.cc"
+)
+
+
+absl_library(
   TARGET
     absl_container
+  SOURCES
+    ${CONTAINER_LIB_SRC}
   EXPORT_NAME
     container
 )


### PR DESCRIPTION
Symbols defined in ``raw_hash_set.cc`` are missing from `absl::container``.