### PR TITLE
Use _umul128 on Windows to improve performance of Mix() on MSVC.

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -764,6 +764,7 @@ class CityHashState : public HashStateBase<CityHashState> {
   }
 
   ABSL_ATTRIBUTE_ALWAYS_INLINE static uint64_t Mix(uint64_t state, uint64_t v) {
+#if !defined(_MSC_VER) && !defined(_WIN64)
     using MultType =
         absl::conditional_t<sizeof(size_t) == 4, uint64_t, uint128>;
     // We do the addition in 64-bit space to make sure the 128-bit
@@ -773,6 +774,11 @@ class CityHashState : public HashStateBase<CityHashState> {
     MultType m = state + v;
     m *= kMul;
     return static_cast<uint64_t>(m ^ (m >> (sizeof(m) * 8 / 2)));
+#else
+    uint64_t high;
+    uint64_t low = _umul128(state + v, kMul, &high);
+    return low ^ high;
+#endif
   }
 
   // Seed()


### PR DESCRIPTION
I was doing performance measurements (http://bannalia.blogspot.com/2013/11/measuring-lookup-times-for-c-unordered.html as a base) and noticed a significant difference on the new swiss hash tables when compiled with MSVC compared to GCC/Clang on Linux. For simple integer keys find() took a little more than double the time. In practice absl ended up slower than std::unordered until approx. 0.5M elements.

Because MSVC is lacking __int128 intrinsic the code ended up doing uint128 * uint128 multiplication instead of uint64 * uint64 = uint128 which is the behavior we get with __int128 intrinsic on GCC/Clang.

Perhaps for clarity this code should always use _umul128 when available, but I haven't written that detection logic. 

With this the performance on MSVC is on par with GCC and Clang in my testing.