### PR TITLE
Ignore ctags files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build
 CMakeLists.txt.user
 # Ignore VS Code files
 .vscode/*
+# Ignore ctags files
+tags


### PR DESCRIPTION
This is mostly because tools like ag and rg use .gitignore and it was annoying having the tags file pollute the results every time I grepped the codebase


Do you need a CLA for this?