### PR TITLE
[WIP] cmake: Allow shared linking and installation

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -46,7 +46,24 @@ function(absl_library)
   set(_NAME ${ABSL_LIB_TARGET})
   string(TOUPPER ${_NAME} _UPPER_NAME)
 
-  add_library(${_NAME} STATIC ${ABSL_LIB_SOURCES})
+  if(BUILD_SHARED_LIBS)
+    add_library(${_NAME} SHARED ${ABSL_LIB_SOURCES})
+    set_target_properties(${_NAME} PROPERTIES
+      SOVERSION ${absl_SOVERSION})
+    install(TARGETS ${_NAME} EXPORT ${_NAME}-targets
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    target_include_directories(${_NAME} INTERFACE
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+  endif()
+
+  if(BUILD_STATIC_LIBS)
+    add_library(${_NAME}-static STATIC ${ABSL_LIB_SOURCES})
+    set_target_properties(${_NAME}-static PROPERTIES
+      OUTPUT_NAME ${_NAME})
+  endif()
 
   target_compile_options(${_NAME} PRIVATE ${ABSL_LIB_PRIVATE_COMPILE_FLAGS})
   target_link_libraries(${_NAME} PUBLIC ${ABSL_LIB_PUBLIC_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(absl)
 
+set(absl_SOVERSION 0)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(BUILD_STATIC_LIBS "Build static libraries" ON)
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake)
 
 include(GNUInstallDirs)

--- a/absl/hash/CMakeLists.txt
+++ b/absl/hash/CMakeLists.txt
@@ -31,7 +31,7 @@ list(APPEND HASH_SRC
   ${HASH_INTERNAL_HEADERS}
 )
 
-set(HASH_PUBLIC_LIBRARIES absl::hash absl::container absl::strings absl::str_format absl::utility)
+set(HASH_PUBLIC_LIBRARIES absl::container absl::strings absl::str_format absl::utility)
 
 absl_library(
   TARGET


### PR DESCRIPTION
Allow shared linking by providing the BUILD_SHARED_LIBS option.
Provide a possibility to install Abseil headers and libraries.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>