### PR TITLE
fix CMakeLists.txt in absl/container

### DIFF
--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -30,7 +30,7 @@ absl_cc_library(
 absl_cc_library(
   NAME
     compressed_tuple
-  SRCS
+  HDRS
    "internal/compressed_tuple.h"
   DEPS
     absl::utility


### PR DESCRIPTION
absl_compressed_tuple is a header only library. use absl_cc_library properly to make the build work