### PR TITLE
#187 Add Conan recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,7 @@ class AbseilConan(ConanFile):
     author = "Ashley Hedberg <ahedberg@google.com>"
     description = "Abseil Common Libraries (C++) from Google"
     license = "Apache-2.0"
+    topics = ("conan", "abseil", "abseil-cpp", "google", "common-libraries")
     exports = ["LICENSE"]
     exports_sources = ["CMakeLists.txt", "CMake/*", "absl/*"]
     generators = "cmake"

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+# Note: Conan is supported on a best-effort basis. Abseil doesn't use Conan
+# internally, so we won't know if it stops working. We may ask community
+# members to help us debug any problems that arise.
+
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 from conans.model.version import Version

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+from conans.model.version import Version
+
+
+class AbseilConan(ConanFile):
+    name = "abseil"
+    url = "https://github.com/abseil/abseil-cpp"
+    homepage = url
+    author = "Ashley Hedberg <ahedberg@google.com>"
+    description = "Abseil Common Libraries (C++) from Google"
+    license = "Apache-2.0"
+    exports = ["LICENSE"]
+    exports_sources = ["CMakeLists.txt", "CMake/*", "absl/*"]
+    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    requires = "cctz/2.2@bincrafters/stable"
+
+    def configure(self):
+        if self.settings.os == "Windows" and \
+           self.settings.compiler == "Visual Studio" and \
+           Version(self.settings.compiler.version.value) < "14":
+            raise ConanInvalidConfiguration("Abseil does not support MSVC < 14")
+
+    def build(self):
+        tools.replace_in_file("CMakeLists.txt", "project(absl)", "project(absl)\ninclude(conanbuildinfo.cmake)\nconan_basic_setup()")
+        cmake = CMake(self)
+        cmake.definitions["BUILD_TESTING"] = False
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses")
+        self.copy("*.h", dst="include", src="absl")
+        self.copy("*.inc", dst="include", src="absl")
+        self.copy("*.a", dst="lib", src=".", keep_path=False)
+        self.copy("*.lib", dst="lib", src=".", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["absl_base",
+                              "absl_synchronization",
+                              "absl_strings",
+                              "absl_symbolize",
+                              "absl_malloc_internal",
+                              "absl_time",
+                              "absl_strings",
+                              "absl_base",
+                              "absl_dynamic_annotations",
+                              "absl_spinlock_wait",
+                              "absl_throw_delegate",
+                              "absl_stacktrace",
+                              "absl_int128",
+                              "absl_span",
+                              "test_instance_tracker_lib",
+                              "absl_stack_consumption",
+                              "absl_bad_any_cast",
+                              "absl_hash",
+                              "str_format_extension_internal",
+                              "absl_failure_signal_handler",
+                              "absl_str_format",
+                              "absl_numeric",
+                              "absl_any",
+                              "absl_optional",
+                              "absl_container",
+                              "absl_debugging",
+                              "absl_memory",
+                              "absl_leak_check",
+                              "absl_meta",
+                              "absl_utility",
+                              "str_format_internal",
+                              "absl_variant",
+                              "absl_examine_stack",
+                              "absl_bad_optional_access",
+                              "absl_algorithm"]
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.append("pthread")

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class AbseilConan(ConanFile):
     name = "abseil"
     url = "https://github.com/abseil/abseil-cpp"
     homepage = url
-    author = "Ashley Hedberg <ahedberg@google.com>"
+    author = "Abseil <abseil-io@googlegroups.com>"
     description = "Abseil Common Libraries (C++) from Google"
     license = "Apache-2.0"
     topics = ("conan", "abseil", "abseil-cpp", "google", "common-libraries")

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,6 @@ class AbseilConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "CMake/*", "absl/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    requires = "cctz/2.2@bincrafters/stable"
 
     def configure(self):
         if self.settings.os == "Windows" and \


### PR DESCRIPTION
Hi!

This PR is related to #187 which provides Conan package support for Google Abseil.

The recipe included on this PR contains some metadata, as author, project url, license, and steps needed to create the package.
As [cctz](https://github.com/google/cctz) it's listed as requirement for Abseil and will be downloaded automatically when building Abseil using Conan.

How to build Abseil using Conan?

    $ conan create . abseil/latest@abseil/stable

Conan [create](https://docs.conan.io/en/latest/reference/commands/creator/create.html) will execute all steps, including download cctz and create a binary package for Abseil.

The PR https://github.com/abseil/abseil-cpp/pull/197 is related to CI support, which is awesome, because we could include Conan on CI build steps to distribute Abseil as pre-built binaries. Of course, this should be done in a next PR.

Regards!

closes #187 

I'm adding some Conan experts to review this PR:
/cc @danimtb @memsharded