### PR TITLE
Always initialize raw_hash_set::iterator::slot_

### DIFF
--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -784,7 +784,7 @@ class raw_hash_set {
     }
 
     ctrl_t* ctrl_ = nullptr;
-    slot_type* slot_;
+    slot_type* slot_ = nullptr;
   };
 
   class const_iterator {


### PR DESCRIPTION
Without initializing this field, GCC 8 with `-fsanitize=undefined` may see a RUI during compilation of `raw_hash_set::end`:

```
abseil-cpp/absl/container/internal/raw_hash_set.h: In static member function ...
abseil-cpp/absl/container/internal/raw_hash_set.h:1017:45: error: '*((void*)&<anonymous> +8)' is used uninitialized in this function [-Werror=uninitialized]
   iterator end() { return {ctrl_ + capacity_}; }
```

Default initializing `slot_` to `nullptr` appears to fix the issue.