### PR TITLE
_umul128 intrinsic is x64 only and not available on Windows ARM64

### DIFF
--- a/absl/numeric/int128.h
+++ b/absl/numeric/int128.h
@@ -43,10 +43,10 @@
 // builtin type.  We need to make sure not to define operator wchar_t()
 // alongside operator unsigned short() in these instances.
 #define ABSL_INTERNAL_WCHAR_T __wchar_t
-#if defined(_WIN64)
+#if defined(_M_X64)
 #include <intrin.h>
 #pragma intrinsic(_umul128)
-#endif  // defined(_WIN64)
+#endif  // defined(_M_X64)
 #else   // defined(_MSC_VER)
 #define ABSL_INTERNAL_WCHAR_T wchar_t
 #endif  // defined(_MSC_VER)
@@ -675,7 +675,7 @@ inline uint128 operator*(uint128 lhs, uint128 rhs) {
   // can be used for uint128 storage.
   return static_cast<unsigned __int128>(lhs) *
          static_cast<unsigned __int128>(rhs);
-#elif defined(_MSC_VER) && defined(_WIN64)
+#elif defined(_MSC_VER) && defined(_M_X64)
   uint64_t carry;
   uint64_t low = _umul128(Uint128Low64(lhs), Uint128Low64(rhs), &carry);
   return MakeUint128(Uint128Low64(lhs) * Uint128High64(rhs) +


### PR DESCRIPTION
Intrinsic `_umul128` is only available on Windows X64, and not available on Windows ARM64, even both defined `_WIN64`.

This issue is exposed when building abseil library in Chromium for Windows ARM64.

EDIT: Resend the PR using the email account I registered with corporate CLA.