### PR TITLE
Solve GCC warnings introduced in commit 968a34ffdaadd7db062a9621dfbdf8b2d16e05af

### DIFF
--- a/absl/synchronization/internal/create_thread_identity.cc
+++ b/absl/synchronization/internal/create_thread_identity.cc
@@ -67,7 +67,7 @@ static intptr_t RoundUp(intptr_t addr, intptr_t align) {
   return (addr + align - 1) & ~(align - 1);
 }
 
-static void ResetThreadIdetity(base_internal::ThreadIdentity* identity) {
+static void ResetThreadIdentity(base_internal::ThreadIdentity* identity) {
   base_internal::PerThreadSynch* pts = &identity->per_thread_synch;
   pts->next = nullptr;
   pts->skip = nullptr;
@@ -114,7 +114,7 @@ static base_internal::ThreadIdentity* NewThreadIdentity() {
         RoundUp(reinterpret_cast<intptr_t>(allocation),
                 base_internal::PerThreadSynch::kAlignment));
   }
-  ResetThreadIdetity(identity);
+  ResetThreadIdentity(identity);
 
   return identity;
 }

--- a/absl/synchronization/internal/create_thread_identity.cc
+++ b/absl/synchronization/internal/create_thread_identity.cc
@@ -67,6 +67,30 @@ static intptr_t RoundUp(intptr_t addr, intptr_t align) {
   return (addr + align - 1) & ~(align - 1);
 }
 
+static void ResetThreadIdetity(base_internal::ThreadIdentity* identity) {
+  base_internal::PerThreadSynch* pts = &identity->per_thread_synch;
+  pts->next = nullptr;
+  pts->skip = nullptr;
+  pts->may_skip = false;
+  pts->waitp = nullptr;
+  pts->suppress_fatal_errors = false;
+  pts->readers = 0;
+  pts->priority = 0;
+  pts->next_priority_read_cycles = 0;
+  pts->state.store(base_internal::PerThreadSynch::State::kAvailable,
+                   std::memory_order_relaxed);
+  pts->maybe_unlocking = false;
+  pts->wake = false;
+  pts->cond_waiter = false;
+  pts->all_locks = nullptr;
+  identity->waiter_state = {};
+  identity->blocked_count_ptr = nullptr;
+  identity->ticker.store(0, std::memory_order_relaxed);
+  identity->wait_start.store(0, std::memory_order_relaxed);
+  identity->is_idle.store(false, std::memory_order_relaxed);
+  identity->next = nullptr;
+}
+
 static base_internal::ThreadIdentity* NewThreadIdentity() {
   base_internal::ThreadIdentity* identity = nullptr;
 
@@ -90,7 +114,7 @@ static base_internal::ThreadIdentity* NewThreadIdentity() {
         RoundUp(reinterpret_cast<intptr_t>(allocation),
                 base_internal::PerThreadSynch::kAlignment));
   }
-  memset(identity, 0, sizeof(*identity));
+  ResetThreadIdetity(identity);
 
   return identity;
 }


### PR DESCRIPTION
With GCC 8 the commit of the above hash causes `-Wclass-memaccess` in `create_thread_identity.cc`, `-Wunused-parameter` in `time_zone_info.cc` and `-Wmissing-field-initializers` in `time_zone_libc.cc` which are problematic for projects that use `-Werror` in CI environments.

GCC8 output while compiling abseil:
```
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc: In member function ‘virtual bool absl::time_internal::cctz::TimeZoneLibC::NextTransition(absl::time_
internal::cctz::time_point<std::chrono::duration<long int> >&, absl::time_internal::cctz::time_zone::civil_transition*) const’:
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc:270:62: warning: unused parameter ‘tp’ [-Wunused-parameter]
 bool TimeZoneLibC::NextTransition(const time_point<seconds>& tp,
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc:271:64: warning: unused parameter ‘trans’ [-Wunused-parameter]
                                   time_zone::civil_transition* trans) const {
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc: In member function ‘virtual bool absl::time_internal::cctz::TimeZoneLibC::PrevTransition(absl::time_
internal::cctz::time_point<std::chrono::duration<long int> >&, absl::time_internal::cctz::time_zone::civil_transition*) const’:
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc:275:62: warning: unused parameter ‘tp’ [-Wunused-parameter]
 bool TimeZoneLibC::PrevTransition(const time_point<seconds>& tp,
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc:276:64: warning: unused parameter ‘trans’ [-Wunused-parameter]
                                   time_zone::civil_transition* trans) const {
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc: In member function ‘virtual bool absl::time_internal::cctz::TimeZoneInfo::NextTransition(absl::time_
internal::cctz::time_point<std::chrono::duration<long int> >&, absl::time_internal::cctz::time_zone::civil_transition*) const’:
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:924:41: warning: missing initializer for member ‘absl::time_internal::cctz::Transition::type_index’ [
-Wmissing-field-initializers]
   const Transition target = { unix_time };
                                         ^
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:924:41: warning: missing initializer for member ‘absl::time_internal::cctz::Transition::civil_sec’ [-
Wmissing-field-initializers]
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:924:41: warning: missing initializer for member ‘absl::time_internal::cctz::Transition::prev_civil_se
c’ [-Wmissing-field-initializers]
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc: In member function ‘virtual bool absl::time_internal::cctz::TimeZoneInfo::PrevTransition(absl::time_
internal::cctz::time_point<std::chrono::duration<long int> >&, absl::time_internal::cctz::time_zone::civil_transition*) const’:
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:959:41: warning: missing initializer for member ‘absl::time_internal::cctz::Transition::type_index’ [
-Wmissing-field-initializers]
   const Transition target = { unix_time };
                                         ^
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:959:41: warning: missing initializer for member ‘absl::time_internal::cctz::Transition::civil_sec’ [-
Wmissing-field-initializers]
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc:959:41: warning: missing initializer for member ‘absl::time_internal::cctz::Transition::prev_civil_se
c’ [-Wmissing-field-initializers]
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/synchronization/internal/create_thread_identity.cc: In function ‘absl::base_internal::ThreadIdentity* absl::synchronization_internal::NewThrea
dIdentity()’:
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/synchronization/internal/create_thread_identity.cc:93:40: warning: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct absl:
:base_internal::ThreadIdentity’ with no trivial copy-assignment; use value-initialization instead [-Wclass-memaccess]
   memset(identity, 0, sizeof(*identity));
                                        ^
In file included from /home/bstaletic/Temp/abseil_test/abseil-cpp/absl/synchronization/internal/create_thread_identity.cc:26:
/home/bstaletic/Temp/abseil_test/abseil-cpp/absl/base/internal/thread_identity.h:136:8: note: ‘struct absl::base_internal::ThreadIdentity’ declared here
 struct ThreadIdentity {
        ^~~~~~~~~~~~~~
```

Reason for introducing `ResetThreadIdentity` is because not only does `absl::base_internal::ThreadIdentity` have no trivial copy assignment operator, it has no copy assignment operator at all, because it uses `std::atomic`s, so, considering that both `memset` and `operator=` are not allowed, I went for C style "assign every member separately" approach.