### PR TITLE
#250 Fix library order for Conan package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -38,46 +38,14 @@ class AbseilConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", dst="licenses")
-        self.copy("*.h", dst="include", src="absl")
-        self.copy("*.inc", dst="include", src="absl")
+        self.copy("*.h", dst="include", src=".")
+        self.copy("*.inc", dst="include", src=".")
         self.copy("*.a", dst="lib", src=".", keep_path=False)
         self.copy("*.lib", dst="lib", src=".", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["absl_base",
-                              "absl_synchronization",
-                              "absl_strings",
-                              "absl_symbolize",
-                              "absl_malloc_internal",
-                              "absl_time",
-                              "absl_strings",
-                              "absl_base",
-                              "absl_dynamic_annotations",
-                              "absl_spinlock_wait",
-                              "absl_throw_delegate",
-                              "absl_stacktrace",
-                              "absl_int128",
-                              "absl_span",
-                              "test_instance_tracker_lib",
-                              "absl_stack_consumption",
-                              "absl_bad_any_cast",
-                              "absl_hash",
-                              "str_format_extension_internal",
-                              "absl_failure_signal_handler",
-                              "absl_str_format",
-                              "absl_numeric",
-                              "absl_any",
-                              "absl_optional",
-                              "absl_container",
-                              "absl_debugging",
-                              "absl_memory",
-                              "absl_leak_check",
-                              "absl_meta",
-                              "absl_utility",
-                              "str_format_internal",
-                              "absl_variant",
-                              "absl_examine_stack",
-                              "absl_bad_optional_access",
-                              "absl_algorithm"]
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("pthread")
+            self.cpp_info.libs = ["-Wl,--start-group"]
+        self.cpp_info.libs.extend(tools.collect_libs(self))
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.extend(["-Wl,--end-group", "pthread"])


### PR DESCRIPTION
This PR is related to #250. The idea here is forcing --start-group --end-group on Linux platform to fix possible wrong link order.

closes #250 