### PR TITLE
Always enable proper symbolize implementation on Windows

### DIFF
--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -70,8 +70,14 @@ cc_library(
 cc_test(
     name = "symbolize_test",
     srcs = ["symbolize_test.cc"],
-    copts = ABSL_TEST_COPTS,
-    linkopts = ABSL_DEFAULT_LINKOPTS,
+    copts = ABSL_TEST_COPTS + select({
+        "//absl:windows": ["/Z7"],
+        "//conditions:default": [],
+    }),
+    linkopts = ABSL_DEFAULT_LINKOPTS + select({
+        "//absl:windows": ["/DEBUG"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":stack_consumption",
         ":symbolize",

--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -62,6 +62,9 @@ absl_cc_test(
     "symbolize_test.cc"
   COPTS
     ${ABSL_TEST_COPTS}
+    $<$<BOOL:${MSVC}>:-Z7>
+  LINKOPTS
+    $<$<BOOL:${MSVC}>:-DEBUG>
   DEPS
     absl::stack_consumption
     absl::symbolize

--- a/absl/debugging/symbolize.cc
+++ b/absl/debugging/symbolize.cc
@@ -16,12 +16,9 @@
 
 #if defined(ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE)
 #include "absl/debugging/symbolize_elf.inc"
-#elif defined(_WIN32) && defined(_DEBUG)
-// The Windows Symbolizer only works in debug mode. Note that _DEBUG
-// is the macro that defines whether or not MS C-Runtime debug info is
-// available. Note that the PDB files containing the debug info must
-// also be available to the program at runtime for the symbolizer to
-// work.
+#elif defined(_WIN32)
+// The Windows Symbolizer only works if PDB files containing the debug info
+// are available to the program at runtime.
 #include "absl/debugging/symbolize_win32.inc"
 #else
 #include "absl/debugging/symbolize_unimplemented.inc"

--- a/absl/debugging/symbolize_test.cc
+++ b/absl/debugging/symbolize_test.cc
@@ -448,44 +448,74 @@ void ABSL_ATTRIBUTE_NOINLINE TestWithReturnAddress() {
   std::cout << "TestWithReturnAddress passed" << std::endl;
 #endif
 }
+#elif defined(_WIN32)
 
-#elif defined(_WIN32) && defined(_DEBUG)
+// Functions to symbolize. Use C linkage to avoid mangled names.
+extern "C" {
+
+__declspec(noinline) void win32_nonstatic_func() {
+  volatile int x = __LINE__;
+  static_cast<void>(x);
+  ABSL_BLOCK_TAIL_CALL_OPTIMIZATION();
+}
+
+__declspec(noinline) static void win32_static_func() {
+  volatile int x = __LINE__;
+  static_cast<void>(x);
+  ABSL_BLOCK_TAIL_CALL_OPTIMIZATION();
+}
+
+}  // extern "C"
+
+struct Win32Foo {
+  static void func(int x);
+};
+
+// A C++ method that should have a mangled name.
+__declspec(noinline) void Win32Foo::func(int) {
+  volatile int x = __LINE__;
+  static_cast<void>(x);
+  ABSL_BLOCK_TAIL_CALL_OPTIMIZATION();
+}
 
 TEST(Symbolize, Basics) {
-  EXPECT_STREQ("nonstatic_func", TrySymbolize((void *)(&nonstatic_func)));
+  EXPECT_STREQ("win32_nonstatic_func",
+               TrySymbolize((void *)(&win32_nonstatic_func)));
 
   // The name of an internal linkage symbol is not specified; allow either a
   // mangled or an unmangled name here.
-  const char* static_func_symbol = TrySymbolize((void *)(&static_func));
+  const char* static_func_symbol = TrySymbolize((void *)(&win32_static_func));
   ASSERT_TRUE(static_func_symbol != nullptr);
-  EXPECT_TRUE(strstr(static_func_symbol, "static_func") != nullptr);
+  EXPECT_TRUE(strstr(static_func_symbol, "win32_static_func") != nullptr);
 
   EXPECT_TRUE(nullptr == TrySymbolize(nullptr));
 }
 
 TEST(Symbolize, Truncation) {
-  constexpr char kNonStaticFunc[] = "nonstatic_func";
-  EXPECT_STREQ("nonstatic_func",
-               TrySymbolizeWithLimit((void *)(&nonstatic_func),
+  constexpr char kNonStaticFunc[] = "win32_nonstatic_func";
+  EXPECT_STREQ("win32_nonstatic_func",
+               TrySymbolizeWithLimit((void *)(&win32_nonstatic_func),
                                      strlen(kNonStaticFunc) + 1));
-  EXPECT_STREQ("nonstatic_...",
-               TrySymbolizeWithLimit((void *)(&nonstatic_func),
+  EXPECT_STREQ("win32_nonstatic_...",
+               TrySymbolizeWithLimit((void *)(&win32_nonstatic_func),
                                      strlen(kNonStaticFunc) + 0));
-  EXPECT_STREQ("nonstatic...",
-               TrySymbolizeWithLimit((void *)(&nonstatic_func),
+  EXPECT_STREQ("win32_nonstatic...",
+               TrySymbolizeWithLimit((void *)(&win32_nonstatic_func),
                                      strlen(kNonStaticFunc) - 1));
-  EXPECT_STREQ("n...", TrySymbolizeWithLimit((void *)(&nonstatic_func), 5));
-  EXPECT_STREQ("...", TrySymbolizeWithLimit((void *)(&nonstatic_func), 4));
-  EXPECT_STREQ("..", TrySymbolizeWithLimit((void *)(&nonstatic_func), 3));
-  EXPECT_STREQ(".", TrySymbolizeWithLimit((void *)(&nonstatic_func), 2));
-  EXPECT_STREQ("", TrySymbolizeWithLimit((void *)(&nonstatic_func), 1));
-  EXPECT_EQ(nullptr, TrySymbolizeWithLimit((void *)(&nonstatic_func), 0));
+  EXPECT_STREQ("w...",
+               TrySymbolizeWithLimit((void *)(&win32_nonstatic_func), 5));
+  EXPECT_STREQ("...",
+               TrySymbolizeWithLimit((void *)(&win32_nonstatic_func), 4));
+  EXPECT_STREQ("..", TrySymbolizeWithLimit((void *)(&win32_nonstatic_func), 3));
+  EXPECT_STREQ(".", TrySymbolizeWithLimit((void *)(&win32_nonstatic_func), 2));
+  EXPECT_STREQ("", TrySymbolizeWithLimit((void *)(&win32_nonstatic_func), 1));
+  EXPECT_EQ(nullptr, TrySymbolizeWithLimit((void *)(&win32_nonstatic_func), 0));
 }
 
 TEST(Symbolize, SymbolizeWithDemangling) {
-  const char* result = TrySymbolize((void *)(&Foo::func));
+  const char* result = TrySymbolize((void *)(&Win32Foo::func));
   ASSERT_TRUE(result != nullptr);
-  EXPECT_TRUE(strstr(result, "Foo::func") != nullptr) << result;
+  EXPECT_TRUE(strstr(result, "Win32Foo::func") != nullptr) << result;
 }
 
 #else  // Symbolizer unimplemented

--- a/absl/debugging/symbolize_win32.inc
+++ b/absl/debugging/symbolize_win32.inc
@@ -57,9 +57,8 @@ bool Symbolize(const void *pc, char *out, int out_size) {
   if (out_size <= 0) {
     return false;
   }
-  std::aligned_storage<sizeof(SYMBOL_INFO) + MAX_SYM_NAME,
-                       alignof(SYMBOL_INFO)>::type buf;
-  SYMBOL_INFO *symbol = reinterpret_cast<SYMBOL_INFO *>(&buf);
+  alignas(SYMBOL_INFO) char buf[sizeof(SYMBOL_INFO) + MAX_SYM_NAME];
+  SYMBOL_INFO *symbol = reinterpret_cast<SYMBOL_INFO *>(buf);
   symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
   symbol->MaxNameLen = MAX_SYM_NAME;
   if (!SymFromAddr(process, reinterpret_cast<DWORD64>(pc), nullptr, symbol)) {


### PR DESCRIPTION
`Sym*` APIs only rely on PDB files, there is no need to link to debug libraries to use `Sym*` APIs.

`_DEBUG` macro only means the binary is compiled and linked to debug libraries (`/MTd`, `/MDd`, `/LDd`) [0]. Generation of PDB file is controlled by `/Zi` or `/Z7` in compile time and `/debug` in link time. This has no predefined macro for us to detect.

[0]: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2017

/cc @derekmauro 