### PR TITLE
Add linking of CoreFoundation to CMakeLists in absl/time

### DIFF
--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -78,6 +78,8 @@ absl_cc_library(
     "internal/cctz/src/zone_info_source.cc"
   COPTS
     ${ABSL_DEFAULT_COPTS}
+  DEPS
+    "-framework CoreFoundation"
 )
 
 absl_cc_library(


### PR DESCRIPTION
Abseil fails to build properly on mac using CMake as time_zone_lookup.cc includes CoreFoundation but the corresponding CMakeLists.txt in absl/time does not link against it