### PR TITLE
Adding linking of CoreFoundation to CMakeLists in absl/time

### DIFF
--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -53,6 +53,10 @@ absl_cc_library(
     ${ABSL_DEFAULT_COPTS}
 )
 
+if(APPLE)
+  find_library(CoreFoundation CoreFoundation)
+endif()
+
 absl_cc_library(
   NAME
     time_zone
@@ -78,6 +82,8 @@ absl_cc_library(
     "internal/cctz/src/zone_info_source.cc"
   COPTS
     ${ABSL_DEFAULT_COPTS}
+  DEPS
+    $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>
 )
 
 absl_cc_library(


### PR DESCRIPTION
Abseil fails to build properly on mac using CMake as time_zone_lookup.cc includes CoreFoundation but the corresponding CMakeLists.txt in absl/time does not link against it.