### PR TITLE
Support build on RHEL 5 Linux

### DIFF
--- a/absl/base/policy_checks.h
+++ b/absl/base/policy_checks.h
@@ -82,13 +82,10 @@
 // Standard Library Check
 // -----------------------------------------------------------------------------
 
-// We have chosen glibc 2.12 as the minimum as it was tagged for release
-// in May, 2010 and includes some functionality used in Google software
-// (for instance pthread_setname_np):
-// https://sourceware.org/ml/libc-alpha/2010-05/msg00000.html
+// Tests passing with glibc 2.5
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if !__GLIBC_PREREQ(2, 12)
-#error "Minimum required version of glibc is 2.12."
+#if !__GLIBC_PREREQ(2, 5)
+#error "Minimum required version of glibc is 2.5."
 #endif
 #endif
 

--- a/absl/synchronization/internal/waiter.h
+++ b/absl/synchronization/internal/waiter.h
@@ -38,11 +38,15 @@
 #define ABSL_WAITER_MODE_CONDVAR 2
 #define ABSL_WAITER_MODE_WIN32 3
 
+#if defined(__linux__) // Get linux kernel version
+#include <linux/version.h>
+#endif
+
 #if defined(ABSL_FORCE_WAITER_MODE)
 #define ABSL_WAITER_MODE ABSL_FORCE_WAITER_MODE
 #elif defined(_WIN32)
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_WIN32
-#elif defined(__linux__)
+#elif defined(__linux__) && LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,28) // According to "man 2 futex" Futexes need 2.6.28 kernel
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_FUTEX
 #elif defined(ABSL_HAVE_SEMAPHORE_H)
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_SEM


### PR DESCRIPTION
I have been able to build Abseil on RHEL 5 and tests passing.
It has lower glibc version when specified minimal.
Also Futexes are not fully supported. I put a check to swtich them off.