### PR TITLE
Use the implicitly defaulted constructor

### DIFF
--- a/absl/container/flat_hash_map.h
+++ b/absl/container/flat_hash_map.h
@@ -150,7 +150,7 @@ class flat_hash_map : public absl::container_internal::raw_hash_map<
   //
   //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
   //   absl::flat_hash_map<int, std::string> map7(v.begin(), v.end());
-  flat_hash_map() {}
+  flat_hash_map() = default;
   using Base::Base;
 
   // flat_hash_map::begin()

--- a/absl/container/flat_hash_set.h
+++ b/absl/container/flat_hash_set.h
@@ -143,7 +143,7 @@ class flat_hash_set
   //
   //   std::vector<std::string> v = {"a", "b"};
   //   absl::flat_hash_set<std::string> set7(v.begin(), v.end());
-  flat_hash_set() {}
+  flat_hash_set() = default;
   using Base::Base;
 
   // flat_hash_set::begin()

--- a/absl/container/internal/common.h
+++ b/absl/container/internal/common.h
@@ -55,7 +55,7 @@ class node_handle_base {
  public:
   using allocator_type = Alloc;
 
-  constexpr node_handle_base() {}
+  constexpr node_handle_base() = default;
   node_handle_base(node_handle_base&& other) noexcept {
     *this = std::move(other);
   }
@@ -114,7 +114,7 @@ class node_handle : public node_handle_base<PolicyTraits, Alloc> {
  public:
   using value_type = typename PolicyTraits::value_type;
 
-  constexpr node_handle() {}
+  constexpr node_handle() = default;
 
   value_type& value() const { return PolicyTraits::element(this->slot()); }
 
@@ -135,7 +135,7 @@ class node_handle<Policy, PolicyTraits, Alloc,
   using key_type = typename Policy::key_type;
   using mapped_type = typename Policy::mapped_type;
 
-  constexpr node_handle() {}
+  constexpr node_handle() = default;
 
   auto key() const -> decltype(PolicyTraits::key(this->slot())) {
     return PolicyTraits::key(this->slot());

--- a/absl/container/internal/raw_hash_map.h
+++ b/absl/container/internal/raw_hash_map.h
@@ -56,7 +56,7 @@ class raw_hash_map : public raw_hash_set<Policy, Hash, Eq, Alloc> {
   using iterator = typename raw_hash_map::raw_hash_set::iterator;
   using const_iterator = typename raw_hash_map::raw_hash_set::const_iterator;
 
-  raw_hash_map() {}
+  raw_hash_map() = default;
   using raw_hash_map::raw_hash_set::raw_hash_set;
 
   // The last two template parameters ensure that both arguments are rvalues

--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -611,7 +611,7 @@ class raw_hash_set {
     using pointer = absl::remove_reference_t<reference>*;
     using difference_type = typename raw_hash_set::difference_type;
 
-    iterator() {}
+    iterator() = default;
 
     // PRECONDITION: not an end() iterator.
     reference operator*() const { return PolicyTraits::element(slot_); }
@@ -674,7 +674,7 @@ class raw_hash_set {
     using pointer = typename raw_hash_set::const_pointer;
     using difference_type = typename raw_hash_set::difference_type;
 
-    const_iterator() {}
+    const_iterator() = default;
     // Implicit construction from iterator.
     const_iterator(iterator i) : inner_(std::move(i)) {}
 
@@ -704,10 +704,7 @@ class raw_hash_set {
   using node_type = node_handle<Policy, hash_policy_traits<Policy>, Alloc>;
   using insert_return_type = InsertReturnType<iterator, node_type>;
 
-  raw_hash_set() noexcept(
-      std::is_nothrow_default_constructible<hasher>::value&&
-          std::is_nothrow_default_constructible<key_equal>::value&&
-              std::is_nothrow_default_constructible<allocator_type>::value) {}
+  raw_hash_set() = default;
 
   explicit raw_hash_set(size_t bucket_count, const hasher& hash = hasher(),
                         const key_equal& eq = key_equal(),

--- a/absl/container/node_hash_map.h
+++ b/absl/container/node_hash_map.h
@@ -145,7 +145,7 @@ class node_hash_map
   //
   //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
   //   absl::node_hash_map<int, std::string> map7(v.begin(), v.end());
-  node_hash_map() {}
+  node_hash_map() = default;
   using Base::Base;
 
   // node_hash_map::begin()

--- a/absl/container/node_hash_set.h
+++ b/absl/container/node_hash_set.h
@@ -137,7 +137,7 @@ class node_hash_set
   //
   //   std::vector<std::string> v = {"a", "b"};
   //   absl::node_hash_set<std::string> set7(v.begin(), v.end());
-  node_hash_set() {}
+  node_hash_set() = default;
   using Base::Base;
 
   // node_hash_set::begin()

--- a/absl/strings/internal/char_map.h
+++ b/absl/strings/internal/char_map.h
@@ -32,17 +32,17 @@ namespace strings_internal {
 
 class Charmap {
  public:
-  constexpr Charmap() : m_() {}
+  constexpr Charmap() = default;
 
   // Initializes with a given char*.  Note that NUL is not treated as
   // a terminator, but rather a char to be flicked.
-  Charmap(const char* str, int len) : m_() {
+  Charmap(const char* str, int len) {
     while (len--) SetChar(*str++);
   }
 
   // Initializes with a given char*.  NUL is treated as a terminator
   // and will not be in the charmap.
-  explicit Charmap(const char* str) : m_() {
+  explicit Charmap(const char* str) {
     while (*str) SetChar(*str++);
   }
 
@@ -127,7 +127,7 @@ class Charmap {
     m_[c / 64] |= static_cast<uint64_t>(1) << (c % 64);
   }
 
-  uint64_t m_[4];
+  uint64_t m_[4] = {};
 };
 
 // Mirror the char-classifying predicates in <cctype>


### PR DESCRIPTION
Defining an empty default constructor is worse than using the compiler generated constructor.

Note that the compiler generated constructor requires that constexpr as well as exception specifiers are correctly considered. See Chapter 15.1 [class.ctor] paragraph 7