### PR TITLE
AlphaNum adds a char32_t constructor to support rune

### DIFF
--- a/absl/strings/str_cat.cc
+++ b/absl/strings/str_cat.cc
@@ -21,6 +21,7 @@
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/internal/resize_uninitialized.h"
+#include "absl/strings/internal/utf8.h"
 
 namespace absl {
 
@@ -74,6 +75,11 @@ AlphaNum::AlphaNum(Dec dec) {
   }
 
   piece_ = absl::string_view(writer, end - writer);
+}
+
+AlphaNum::AlphaNum(char32_t rune) {
+  piece_ = absl::string_view(
+      digits_, absl::strings_internal::EncodeUTF8Char(digits_, rune));
 }
 
 // ----------------------------------------------------------------------

--- a/absl/strings/str_cat.h
+++ b/absl/strings/str_cat.h
@@ -235,8 +235,9 @@ class AlphaNum {
   AlphaNum(double f)  // NOLINT(runtime/explicit)
       : piece_(digits_, numbers_internal::SixDigitsToBuffer(f, digits_)) {}
 
-  AlphaNum(Hex hex);  // NOLINT(runtime/explicit)
-  AlphaNum(Dec dec);  // NOLINT(runtime/explicit)
+  AlphaNum(Hex hex);        // NOLINT(runtime/explicit)
+  AlphaNum(Dec dec);        // NOLINT(runtime/explicit)
+  AlphaNum(char32_t rune);  // NOTLINT(runtime/explicit)
 
   template <size_t size>
   AlphaNum(  // NOLINT(runtime/explicit)


### PR DESCRIPTION
When using absl::StrCat, we can add more interesting features, such as using it to connect to rune. When we know the Unicode code point of a character, we can easily connect it to the string.

Code Example:

```cpp
#include <absl/strings/str_cat.h>
#include <absl/strings/str_format.h>

int main() {
  char32_t sparkling_heart = 0x1F496;
  auto s = absl::StrCat("I have a ", sparkling_heart, " !");
  absl::FPrintF(stderr, "Tom say: %s\n", s);
  return 0;
}

```
Snapshot:
![2019-05-24 09-40-01屏幕截图](https://user-images.githubusercontent.com/6904176/58296834-02017980-7e08-11e9-827a-2348faf6fd9b.png)

