### PR TITLE
avoid use of undefined ABSL_HAVE_ELF_MEM_IMAGE

### DIFF
--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -34,7 +34,7 @@
 #define ABSL_HAVE_ELF_MEM_IMAGE 1
 #endif
 
-#if ABSL_HAVE_ELF_MEM_IMAGE
+#ifdef ABSL_HAVE_ELF_MEM_IMAGE
 
 #include <link.h>  // for ElfW
 


### PR DESCRIPTION
this avoids e.g. on macOS:

In file included from abseil-cpp/absl/debugging/internal/elf_mem_image.cc:18:
abseil-cpp/absl/debugging/internal/elf_mem_image.h:37:5: error: 'ABSL_HAVE_ELF_MEM_IMAGE' is not defined, evaluates to 0 [-Werror,-Wundef]
    ^
1 error generated.