### PR TITLE
fix C4245 compiler warning of visual studio

### DIFF
--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -350,7 +350,7 @@ struct GroupSse2Impl {
     return BitMask<uint32_t, kWidth>(
         _mm_movemask_epi8(_mm_sign_epi8(ctrl, ctrl)));
 #else
-    return Match(kEmpty);
+    return Match(static_cast<h2_t>(kEmpty));
 #endif
   }
 


### PR DESCRIPTION
Allows to use abseil headers in code requiring strict warning settings.
(and makes the 'wanted' conversion here more explicit)