### PR TITLE
The order of the operators in the struct should match the order of th…

### DIFF
--- a/absl/types/variant_test.cc
+++ b/absl/types/variant_test.cc
@@ -1793,8 +1793,8 @@ TEST(VariantTest, VisitSimple) {
   EXPECT_EQ("B", piece);
 
   struct StrLen {
-    int operator()(const std::string& s) const { return s.size(); }
     int operator()(const char* s) const { return strlen(s); }
+    int operator()(const std::string& s) const { return s.size(); }
   };
 
   v = "SomeStr";


### PR DESCRIPTION
…e test cases

This makes it a bit easier to follow the logic for anyone reading the tests as docs.