### PR TITLE
Fixes for conan + support for specifying C++ standard in conanfile

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,10 @@ class AbseilConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "CMake/*", "absl/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-
+    options = {"cxx_standard": {11, 14, 17}}
+    default_options = {"cxx_standard": 11}
+    version = "latest"
+    
     def configure(self):
         if self.settings.os == "Windows" and \
            self.settings.compiler == "Visual Studio" and \
@@ -30,9 +33,10 @@ class AbseilConan(ConanFile):
             raise ConanInvalidConfiguration("Abseil does not support MSVC < 14")
 
     def build(self):
-        tools.replace_in_file("CMakeLists.txt", "project(absl)", "project(absl)\ninclude(conanbuildinfo.cmake)\nconan_basic_setup()")
+        tools.replace_in_file("CMakeLists.txt", "project(absl CXX)", "project(absl CXX)\ninclude(conanbuildinfo.cmake)\nconan_basic_setup()")
         cmake = CMake(self)
         cmake.definitions["BUILD_TESTING"] = False
+        cmake.definitions["CMAKE_CXX_STANDARD"] = self.options.cxx_standard
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
1) The conanfile.py did not define a version, so attempting to create a conan package would fail. I added the version label of "latest" in an attempt to mimic the "live at head" philosophy of abseil (ideally, this would be a CI thing where a new commit would automatically generate a new conan package, but I don't think we're there yet). LTS branches should change this version to match the LTS version number

2) Added an option to specify the C++ standard version when creating the conan package. When using the current conan package to link against a project in C++17 mode, linker errors could occur. #218 is an example of what can happen if abseil is built with C++11 or C++14 support, but attempted to link against a c++ 17 project. 

I know google doesn't use conan, so it's difficult for you all to evaluate conan changes, so I've tagged some of the bincrafters team who have worked on the bincrafters version of an abseil package (I hope the tagging works--I'm not sure I did it right). 
@uilianries 
@SSE4
@danimtb
@solvingj