### PR TITLE
Improve example AbslUnparseFlag().

### DIFF
--- a/absl/flags/marshalling.h
+++ b/absl/flags/marshalling.h
@@ -109,7 +109,7 @@
 //      case kPlainText: return "plaintext";
 //      case kHtml: return "html";
 //    }
-//    return absl::SimpleItoa(mode);
+//    return absl::StrCat(mode);
 //  }
 //
 // Notice that neither `AbslParseFlag()` nor `AbslUnparseFlag()` are class

--- a/absl/flags/marshalling.h
+++ b/absl/flags/marshalling.h
@@ -106,10 +106,10 @@
 //  // Returns a textual flag value corresponding to the OutputMode `mode`.
 //  std::string AbslUnparseFlag(OutputMode mode) {
 //    switch (mode) {
-//     case kPlainText: return "plaintext";
-//     case kHtml: return "html";
-//     default: return SimpleItoa(mode);
+//      case kPlainText: return "plaintext";
+//      case kHtml: return "html";
 //    }
+//    return absl::SimpleItoa(mode);
 //  }
 //
 // Notice that neither `AbslParseFlag()` nor `AbslUnparseFlag()` are class


### PR DESCRIPTION
1. Move default case outside switch.  This is a good practice because it allows -Wswitch to warn about missing enum values.

2. Use absl::StrCat() instead of (nonexistent) SimpleItoa().