### PR TITLE
Candidate fix for issue #337

### DIFF
--- a/absl/container/inlined_vector_test.cc
+++ b/absl/container/inlined_vector_test.cc
@@ -1787,4 +1787,16 @@ TEST(InlinedVectorTest, AbslHashValueWorks) {
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(cases));
 }
 
+struct HasVector {
+  absl::InlinedVector<int, 1> foo;
+};
+
+// This code used to trigger memset with `nullptr` as starting address in builds that do not have NDEBUG set.
+// This is undefined behavior with UBSan.
+TEST(CopyAssignmentOperator, AvoidsMemsetWithNullptr) {
+    HasVector foo;
+    HasVector bar;
+    bar.foo.push_back(2);
+    foo = bar;
+}
 }  // anonymous namespace

--- a/absl/container/internal/inlined_vector.h
+++ b/absl/container/internal/inlined_vector.h
@@ -52,13 +52,15 @@ void DestroyElements(AllocatorType* alloc_ptr, ValueType* destroy_first,
   }
 
 #ifndef NDEBUG
-  // Overwrite unused memory with `0xab` so we can catch uninitialized usage.
-  //
-  // Cast to `void*` to tell the compiler that we don't care that we might be
-  // scribbling on a vtable pointer.
-  void* memory = reinterpret_cast<void*>(destroy_first);
-  size_t memory_size = sizeof(ValueType) * destroy_size;
-  std::memset(memory, 0xab, memory_size);
+  if (destroy_size > 0) {
+    // Overwrite unused memory with `0xab` so we can catch uninitialized usage.
+    //
+    // Cast to `void*` to tell the compiler that we don't care that we might be
+    // scribbling on a vtable pointer.
+    void* memory = reinterpret_cast<void*>(destroy_first);
+    size_t memory_size = sizeof(ValueType) * destroy_size;
+    std::memset(memory, 0xab, memory_size);
+  }
 #endif  // NDEBUG
 }
 


### PR DESCRIPTION
There seem to be cases when `DestroyElements` gets called for `0` elements with `nullptr` as `destroy_first`.
Currently, this triggers ubsan failure in debug builds-only(optimized builds define NDEBUG and thus don't observe ASAN failure).