### PR TITLE
Fixed ABSL_INTERNAL_MACOS_CXX17_TYPES_UNAVAILABLE check

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -375,7 +375,7 @@
 // https://github.com/abseil/abseil-cpp/issues/207 and
 // https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes
 #if defined(__APPLE__) && defined(_LIBCPP_VERSION) && \
-    defined(__MAC_OS_X_VERSION_MIN_REQUIRED__) &&     \
+    defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
     __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101400
 #define ABSL_INTERNAL_MACOS_CXX17_TYPES_UNAVAILABLE 1
 #else


### PR DESCRIPTION
The `__MAC_OS_X_VERSION_MIN_REQUIRED__` macro no longer seems to be present on my system (macOS 10.14.5) with the latest xcode command line tools.  This PR fixes the check to allow proper detection of the unavailable C++17 types with Xcode 10.

You can test this by compiling with MACOSX_DEPLOYMENT_TARGET=10.13 environment variable on a 10.14 system.