### PR TITLE
Fix ABSL_HAVE_ALARM check on mingw

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -334,6 +334,8 @@
 #define ABSL_HAVE_ALARM 1
 #elif defined(_MSC_VER)
 // feature tests for Microsoft's library
+#elif defined(__MINGW32__)
+// feature tests for mingw
 #elif defined(__EMSCRIPTEN__)
 // emscripten doesn't support signals
 #elif defined(__native_client__)

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -335,7 +335,10 @@
 #elif defined(_MSC_VER)
 // feature tests for Microsoft's library
 #elif defined(__MINGW32__)
-// feature tests for mingw
+// mingw32 doesn't provide alarm(2):
+// https://osdn.net/projects/mingw/scm/git/mingw-org-wsl/blobs/5.2-trunk/mingwrt/include/unistd.h
+// mingw-w64 provides a no-op implementation:
+// https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/misc/alarm.c
 #elif defined(__EMSCRIPTEN__)
 // emscripten doesn't support signals
 #elif defined(__native_client__)


### PR DESCRIPTION
mingw compilers don't support alarm()