### PR TITLE
Fix ABSL_WAITER_MODE detection for mingw

### DIFF
--- a/absl/synchronization/internal/waiter.h
+++ b/absl/synchronization/internal/waiter.h
@@ -19,9 +19,9 @@
 #include "absl/base/config.h"
 
 #ifdef _WIN32
-#include <pthread.h>
-#else
 #include <SdkDdkVer.h>
+#else
+#include <pthread.h>
 #endif
 
 #ifdef ABSL_HAVE_SEMAPHORE_H

--- a/absl/synchronization/internal/waiter.h
+++ b/absl/synchronization/internal/waiter.h
@@ -20,6 +20,7 @@
 
 #ifndef _WIN32
 #include <pthread.h>
+#include <SdkDdkVer.h>
 #endif
 
 #ifdef ABSL_HAVE_SEMAPHORE_H
@@ -40,7 +41,7 @@
 
 #if defined(ABSL_FORCE_WAITER_MODE)
 #define ABSL_WAITER_MODE ABSL_FORCE_WAITER_MODE
-#elif defined(_WIN32) && _WIN32_WINNT >= 0x0600
+#elif defined(_WIN32) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_WIN32
 #elif defined(__linux__)
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_FUTEX

--- a/absl/synchronization/internal/waiter.h
+++ b/absl/synchronization/internal/waiter.h
@@ -40,7 +40,7 @@
 
 #if defined(ABSL_FORCE_WAITER_MODE)
 #define ABSL_WAITER_MODE ABSL_FORCE_WAITER_MODE
-#elif defined(_WIN32)
+#elif defined(_WIN32) && _WIN32_WINNT >= 0x0600
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_WIN32
 #elif defined(__linux__)
 #define ABSL_WAITER_MODE ABSL_WAITER_MODE_FUTEX

--- a/absl/synchronization/internal/waiter.h
+++ b/absl/synchronization/internal/waiter.h
@@ -18,8 +18,9 @@
 
 #include "absl/base/config.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
 #include <pthread.h>
+#else
 #include <SdkDdkVer.h>
 #endif
 


### PR DESCRIPTION
The synchronization APIs used in ABSL_WAITER_MODE_WIN32 are only available starting in Windows Vista.  By default, mingw sets `_WIN32_WINNT` to Windows XP causing compilation to fail.  This PR addresses this issue by adding an additional check.