### PR TITLE
supppress unused variable warning for recent gcc

### DIFF
--- a/absl/debugging/internal/stacktrace_generic-inl.inc
+++ b/absl/debugging/internal/stacktrace_generic-inl.inc
@@ -16,6 +16,7 @@
 #include <cstring>
 
 #include "absl/debugging/stacktrace.h"
+#include "absl/base/attributes.h"
 
 // Sometimes, we can try to get a stack trace from within a stack
 // trace, because we don't block signals inside this code (which would be too
@@ -35,7 +36,7 @@ static __thread int recursive = 0;
 static std::atomic<bool> disable_stacktraces(true);  // Disabled until healthy.
 // Waiting until static initializers run seems to be late enough.
 // This file is included into stacktrace.cc so this will only run once.
-static int stacktraces_enabler = []() {
+ABSL_ATTRIBUTE_UNUSED static int stacktraces_enabler = []() {
   void* unused_stack[1];
   // Force the first backtrace to happen early to get the one-time shared lib
   // loading (allocation) out of the way. After the first call it is much safer


### PR DESCRIPTION
gcc7.2 complains with: 
```
'stacktraces_enabler' defined but not used [-Wunused-variable] 
static int stacktraces_enabler = []() { 
```