### PR TITLE
s/ParseFlag/AbslParseFlag

### DIFF
--- a/absl/time/duration.cc
+++ b/absl/time/duration.cc
@@ -910,6 +910,12 @@ bool ParseFlag(const std::string& text, Duration* dst, std::string* ) {
   return ParseDuration(text, dst);
 }
 
+bool AbslParseFlag(absl::string_view text, Duration* dst, std::string* error) {
+  return ParseFlag(std::string(text), dst, error);
+}
+
 std::string UnparseFlag(Duration d) { return FormatDuration(d); }
+
+std::string AbslUnparseFlag(const Duration& d) { return UnparseFlag(d); }
 
 }  // namespace absl

--- a/absl/time/format.cc
+++ b/absl/time/format.cc
@@ -133,8 +133,14 @@ bool ParseFlag(const std::string& text, absl::Time* t, std::string* error) {
   return absl::ParseTime(RFC3339_full, text, absl::UTCTimeZone(), t, error);
 }
 
+bool AbslParseFlag(absl::string_view text, absl::Time* t, std::string* error) {
+  return ParseFlag(std::string(text), t, error);
+}
+
 std::string UnparseFlag(absl::Time t) {
   return absl::FormatTime(RFC3339_full, t, absl::UTCTimeZone());
 }
+
+std::string AbslUnparseFlag(const absl::Time& t) { return UnparseFlag(t); }
 
 }  // namespace absl

--- a/absl/time/time.h
+++ b/absl/time/time.h
@@ -546,7 +546,9 @@ bool ParseDuration(const std::string& dur_string, Duration* d);
 // Support for flag values of type Duration. Duration flags must be specified
 // in a format that is valid input for absl::ParseDuration().
 bool ParseFlag(const std::string& text, Duration* dst, std::string* error);
+bool AbslParseFlag(absl::string_view text, Duration* dst, std::string* error);
 std::string UnparseFlag(Duration d);
+std::string AbslUnparseFlag(const Duration& d);
 
 // Time
 //
@@ -816,7 +818,9 @@ std::chrono::system_clock::time_point ToChronoTime(Time);
 // seconds/milliseconds/etc from the Unix epoch, use an absl::Duration flag
 // and add that duration to absl::UnixEpoch() to get an absl::Time.
 bool ParseFlag(const std::string& text, Time* t, std::string* error);
+bool AbslParseFlag(absl::string_view text, Time* t, std::string* error);
 std::string UnparseFlag(Time t);
+std::string AbslUnparseFlag(const Time& t);
 
 // TimeZone
 //


### PR DESCRIPTION
[ Context ]

`absl::Duration` + `absl::Time` are unusable as a `ABSL_FLAG` because
the Parse/Unparse function hooks are named incorrectly. Perhaps this
was caused by naming changes over time? In either case, I've added the
corrent hooks as per https://abseil.io/docs/cpp/guides/flags#custom

Note that I haven't remove or changed the already existing Parse/Unparse
functions so that any existing clients that use these do not break as a
result of this change.