### PR TITLE
UWP doesn't allow reading regkeys

### DIFF
--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -76,7 +76,12 @@ static int GetNumCPUs() {
 #if defined(_WIN32)
 
 static double GetNominalCPUFrequency() {
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+// UWP apps don't have access to the registry and currently don't provide an
+// API informing about CPU nominal frequency.
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+    !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+  return 1.0;
+#else
 #pragma comment(lib, "advapi32.lib")  // For Reg* functions.
   HKEY key;
   // Use the Reg* functions rather than the SH functions because shlwapi.dll
@@ -95,8 +100,9 @@ static double GetNominalCPUFrequency() {
       return data * 1e6;  // Value is MHz.
     }
   }
-#endif
   return 1.0;
+#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+          !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
 }
 
 #elif defined(CTL_HW) && defined(HW_CPU_FREQ)

--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -76,6 +76,7 @@ static int GetNumCPUs() {
 #if defined(_WIN32)
 
 static double GetNominalCPUFrequency() {
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_APP)
 #pragma comment(lib, "advapi32.lib")  // For Reg* functions.
   HKEY key;
   // Use the Reg* functions rather than the SH functions because shlwapi.dll
@@ -94,6 +95,7 @@ static double GetNominalCPUFrequency() {
       return data * 1e6;  // Value is MHz.
     }
   }
+#endif
   return 1.0;
 }
 

--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -101,8 +101,7 @@ static double GetNominalCPUFrequency() {
     }
   }
   return 1.0;
-#endif /* WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-          !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) */
+#endif // WINAPI_PARTITION_APP && !WINAPI_PARTITION_DESKTOP
 }
 
 #elif defined(CTL_HW) && defined(HW_CPU_FREQ)


### PR DESCRIPTION
UWP doesn't allow reading regkeys. Unfortunately, UWP also doesn't offer an API for returning nominal processor frequency at this moment. Other options would require apps depending on abseil-cpp to be packaged with extra manifest data or libraries for bridging platforms.

This change pushes the unsupported APIs accessing the registry behind a define guard. This define guard makes GetNominalCPUFrequency to compile and run as usual on desktop, but it will return the value 1.0 on UWP Apps (Store).

Fixes: #593 