### PR TITLE
Fix pointer format specifier in documentation

### DIFF
--- a/absl/debugging/symbolize.h
+++ b/absl/debugging/symbolize.h
@@ -89,7 +89,7 @@ void InitializeSymbolizer(const char* argv0);
 //     if (absl::Symbolize(pc, tmp, sizeof(tmp))) {
 //       symbol = tmp;
 //     }
-//     absl::PrintF("%*p  %s\n", pc, symbol);
+//     absl::PrintF("%p  %s\n", pc, symbol);
 //  }
 bool Symbolize(const void *pc, char *out, int out_size);
 


### PR DESCRIPTION
The format specifier `%*p` is invalid. As specified here https://abseil.io/docs/cpp/guides/format#conversion-specifiers, the `%p` specifier allows printing out the address of the pointer; which is what we want to do with the program counter.