### PR TITLE
Fix build on FreeBSD/powerpc

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -21,13 +21,13 @@
 #endif
 
 #if defined(__powerpc__) || defined(__ppc__)
-+#ifdef __GLIBC__
+#ifdef __GLIBC__
 #include <sys/platform/ppc.h>
-+#elif defined(__FreeBSD__)
-+#include <sys/types.h>
-+#include <sys/sysctl.h>
+#elif defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
 #endif
-+#endif
+#endif
 
 #include "absl/base/internal/sysinfo.h"
 
@@ -62,34 +62,34 @@ double UnscaledCycleClock::Frequency() {
 #elif defined(__powerpc__) || defined(__ppc__)
 
 int64_t UnscaledCycleClock::Now() {
-+#ifdef __GLIBC__
+#ifdef __GLIBC__
   return __ppc_get_timebase();
-  +#elif defined(__FreeBSD__)
-+  union { long long complete; unsigned int part[2]; } ticks;
-+  unsigned int tmp;
-+  asm volatile(
-+    "0:\n"
-+    "mftbu %[hi32]\n"
-+    "mftb %[lo32]\n"
-+    "mftbu %[tmp]\n"
-+    "cmpw %[tmp],%[hi32]\n"
-+    "bne 0b\n"
-+    : [hi32] "=r"(ticks.part[0]), [lo32] "=r"(ticks.part[1]),
-+    [tmp] "=r"(tmp)
-+  );
-+  return ticks.complete;
-+#endif
+#elif defined(__FreeBSD__)
+  union { long long complete; unsigned int part[2]; } ticks;
+  unsigned int tmp;
+  asm volatile(
+    "0:\n"
+    "mftbu %[hi32]\n"
+    "mftb %[lo32]\n"
+    "mftbu %[tmp]\n"
+    "cmpw %[tmp],%[hi32]\n"
+    "bne 0b\n"
+    : [hi32] "=r"(ticks.part[0]), [lo32] "=r"(ticks.part[1]),
+    [tmp] "=r"(tmp)
+  );
+  return ticks.complete;
+#endif
 }
 
 double UnscaledCycleClock::Frequency() {
-+#ifdef __GLIBC__
+#ifdef __GLIBC__
   return __ppc_get_timebase_freq();
- +#elif defined(__FreeBSD__)
-+  double timebaseFrequency = 0;
-+  size_t length = sizeof(timebaseFrequency);
-+  sysctlbyname("kern.timecounter.tc.timebase.frequency", &timebaseFrequency, &length, NULL, 0);
-+  return timebaseFrequency;
-+#endif
+ #elif defined(__FreeBSD__)
+  double timebaseFrequency = 0;
+  size_t length = sizeof(timebaseFrequency);
+  sysctlbyname("kern.timecounter.tc.timebase.frequency", &timebaseFrequency, &length, NULL, 0);
+  return timebaseFrequency;
+#endif
 }
 
 #elif defined(__aarch64__)

--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -21,8 +21,13 @@
 #endif
 
 #if defined(__powerpc__) || defined(__ppc__)
++#ifdef __GLIBC__
 #include <sys/platform/ppc.h>
++#elif defined(__FreeBSD__)
++#include <sys/types.h>
++#include <sys/sysctl.h>
 #endif
++#endif
 
 #include "absl/base/internal/sysinfo.h"
 
@@ -57,11 +62,34 @@ double UnscaledCycleClock::Frequency() {
 #elif defined(__powerpc__) || defined(__ppc__)
 
 int64_t UnscaledCycleClock::Now() {
++#ifdef __GLIBC__
   return __ppc_get_timebase();
+  +#elif defined(__FreeBSD__)
++  union { long long complete; unsigned int part[2]; } ticks;
++  unsigned int tmp;
++  asm volatile(
++    "0:\n"
++    "mftbu %[hi32]\n"
++    "mftb %[lo32]\n"
++    "mftbu %[tmp]\n"
++    "cmpw %[tmp],%[hi32]\n"
++    "bne 0b\n"
++    : [hi32] "=r"(ticks.part[0]), [lo32] "=r"(ticks.part[1]),
++    [tmp] "=r"(tmp)
++  );
++  return ticks.complete;
++#endif
 }
 
 double UnscaledCycleClock::Frequency() {
++#ifdef __GLIBC__
   return __ppc_get_timebase_freq();
+ +#elif defined(__FreeBSD__)
++  double timebaseFrequency = 0;
++  size_t length = sizeof(timebaseFrequency);
++  sysctlbyname("kern.timecounter.tc.timebase.frequency", &timebaseFrequency, &length, NULL, 0);
++  return timebaseFrequency;
++#endif
 }
 
 #elif defined(__aarch64__)


### PR DESCRIPTION
Only glibc has __ppc_get_timebase(), __ppc_get_timebase_freq() and sys/platform/ppc.h. For TBR and TBR frequency, FreeBSD doesn't have equivalent functions.