### PR TITLE
Support testing with a local googletest checkout

### DIFF
--- a/CMake/Googletest/CMakeLists.txt.in
+++ b/CMake/Googletest/CMakeLists.txt.in
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           master
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  SOURCE_DIR        "${absl_gtest_src_dir}"
+  BINARY_DIR        "${absl_gtest_build_dir}"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/CMake/Googletest/CMakeLists.txt.in
+++ b/CMake/Googletest/CMakeLists.txt.in
@@ -3,13 +3,24 @@ cmake_minimum_required(VERSION 2.8.2)
 project(googletest-download NONE)
 
 include(ExternalProject)
-ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
-  SOURCE_DIR        "${absl_gtest_src_dir}"
-  BINARY_DIR        "${absl_gtest_build_dir}"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
-)
+if(${ABSL_USE_GOOGLETEST_HEAD})
+  ExternalProject_Add(googletest
+    GIT_REPOSITORY    https://github.com/google/googletest.git
+    GIT_TAG           master
+    SOURCE_DIR        "${absl_gtest_src_dir}"
+    BINARY_DIR        "${absl_gtest_build_dir}"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+  )
+else()
+  ExternalProject_Add(googletest
+    SOURCE_DIR        "${absl_gtest_src_dir}"
+    BINARY_DIR        "${absl_gtest_build_dir}"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+  )
+endif()

--- a/CMake/Googletest/CMakeLists.txt.in
+++ b/CMake/Googletest/CMakeLists.txt.in
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.2)
 
-project(googletest-download NONE)
+project(googletest-external NONE)
 
 include(ExternalProject)
 if(${ABSL_USE_GOOGLETEST_HEAD})

--- a/CMake/Googletest/DownloadGTest.cmake
+++ b/CMake/Googletest/DownloadGTest.cmake
@@ -1,7 +1,8 @@
-# Downloads and unpacks googletest at configure time.  Based on the instructions
-# at https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
+# Integrates googletest at configure time.  Based on the instructions at
+# https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
 
-# Download the latest googletest from Github master
+# Set up the external googletest project, downloading the latest from Github
+# master if requested.
 configure_file(
   ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in
   ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt
@@ -14,7 +15,7 @@ if (BUILD_SHARED_LIBS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_CREATE_SHARED_LIBRARY=1")
 endif()
 
-# Configure and build the downloaded googletest source
+# Configure and build the googletest source.
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )

--- a/CMake/Googletest/DownloadGTest.cmake
+++ b/CMake/Googletest/DownloadGTest.cmake
@@ -5,7 +5,7 @@
 # master if requested.
 configure_file(
   ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in
-  ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt
+  ${CMAKE_BINARY_DIR}/googletest-external/CMakeLists.txt
 )
 
 set(ABSL_SAVE_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
@@ -18,14 +18,14 @@ endif()
 # Configure and build the googletest source.
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-external )
 if(result)
   message(FATAL_ERROR "CMake step for googletest failed: ${result}")
 endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
   RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download)
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-external)
 if(result)
   message(FATAL_ERROR "Build step for googletest failed: ${result}")
 endif()

--- a/CMake/Googletest/DownloadGTest.cmake
+++ b/CMake/Googletest/DownloadGTest.cmake
@@ -37,6 +37,4 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Add googletest directly to our build. This defines the gtest and gtest_main
 # targets.
-add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
-                 ${CMAKE_BINARY_DIR}/googletest-build
-                 EXCLUDE_FROM_ALL)
+add_subdirectory(${absl_gtest_src_dir} ${absl_gtest_build_dir} EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ find_package(Threads REQUIRED)
 option(ABSL_USE_GOOGLETEST_HEAD
   "If ON, abseil will download HEAD from googletest at config time." OFF)
 
+set(ABSL_LOCAL_GOOGLETEST_DIR "/usr/src/googletest" CACHE PATH
+  "If ABSL_USE_GOOGLETEST_HEAD is OFF, specifies the directory of a local googletest checkout."
+  )
+
 option(ABSL_RUN_TESTS "If ON, Abseil tests will be run." OFF)
 
 if(${ABSL_RUN_TESTS})
@@ -96,11 +100,13 @@ endif()
 ## check targets
 if(BUILD_TESTING)
 
+  set(absl_gtest_build_dir ${CMAKE_BINARY_DIR}/googletest-build)
   if(${ABSL_USE_GOOGLETEST_HEAD})
     set(absl_gtest_src_dir ${CMAKE_BINARY_DIR}/googletest-src)
-    set(absl_gtest_build_dir ${CMAKE_BINARY_DIR}/googletest-build)
-    include(CMake/Googletest/DownloadGTest.cmake)
+  else()
+    set(absl_gtest_src_dir ${ABSL_LOCAL_GOOGLETEST_DIR})
   endif()
+  include(CMake/Googletest/DownloadGTest.cmake)
 
   check_target(gtest)
   check_target(gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,9 @@ endif()
 if(BUILD_TESTING)
 
   if(${ABSL_USE_GOOGLETEST_HEAD})
-    include(CMake/Googletest/DownloadGTest.cmake)
     set(absl_gtest_src_dir ${CMAKE_BINARY_DIR}/googletest-src)
     set(absl_gtest_build_dir ${CMAKE_BINARY_DIR}/googletest-build)
+    include(CMake/Googletest/DownloadGTest.cmake)
   endif()
 
   check_target(gtest)


### PR DESCRIPTION
Debian likes doing dependency management manually, so add support for testing against a local googletest checkout rather than one downloaded from GitHub. Add an `ABSL_LOCAL_GOOGLETEST_DIR` variable that can be used in conjunction with `-DABSL_RUN_TESTS=ON -DABSL_USE_GOOGLETEST_HEAD=OFF` to specify the googletest location manually, and do a bit of related cleanup.