### PR TITLE
Skip the .exe suffix in the helpshort filter on Windows

### DIFF
--- a/absl/flags/usage_config.cc
+++ b/absl/flags/usage_config.cc
@@ -50,10 +50,15 @@ namespace {
 bool ContainsHelpshortFlags(absl::string_view filename) {
   // By default we only want flags in binary's main. We expect the main
   // routine to reside in <program>.cc or <program>-main.cc or
-  // <program>_main.cc, where the <program> is the name of the binary.
+  // <program>_main.cc, where the <program> is the name of the binary
+  // (without .exe on Windows).
   auto suffix = flags_internal::Basename(filename);
-  if (!absl::ConsumePrefix(&suffix,
-                           flags_internal::ShortProgramInvocationName()))
+  auto program_name = flags_internal::ShortProgramInvocationName();
+  absl::string_view program_name_ref = program_name;
+#if defined(_WIN32)
+  absl::ConsumeSuffix(&program_name_ref, ".exe");
+#endif
+  if (!absl::ConsumePrefix(&suffix, program_name_ref))
     return false;
   return absl::StartsWith(suffix, ".") || absl::StartsWith(suffix, "-main.") ||
          absl::StartsWith(suffix, "_main.");

--- a/absl/flags/usage_config_test.cc
+++ b/absl/flags/usage_config_test.cc
@@ -84,7 +84,11 @@ TEST_F(FlagsUsageConfigTest, TestGetSetFlagsUsageConfig) {
 // --------------------------------------------------------------------
 
 TEST_F(FlagsUsageConfigTest, TestContainsHelpshortFlags) {
+#if defined(_WIN32)
+  flags::SetProgramInvocationName("usage_config_test.exe");
+#else
   flags::SetProgramInvocationName("usage_config_test");
+#endif
 
   auto config = flags::GetUsageConfig();
   EXPECT_TRUE(config.contains_helpshort_flags("adir/cd/usage_config_test.cc"));


### PR DESCRIPTION
On Windows, the `flags_internal::ShortProgramInvocationName()`
function usually returns the program name with '.exe' (if the
extension is present in the command line during the program startup).
This fact breaks the checks in the `ContainsHelpshortFlags` filter:
obviously, module names have no .exe in them. Therefore, no defined flags
are shown when the program runs with the --help flag. The program name
should be used in filter without this extension even though it is present.

The unit test has also been updated.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>