### PR TITLE
Fix CompressedTuple move constructor on MSVC

### DIFF
--- a/absl/container/internal/compressed_tuple.h
+++ b/absl/container/internal/compressed_tuple.h
@@ -169,9 +169,28 @@ constexpr bool ShouldAnyUseBase() {
 }
 
 template <typename T, typename V>
-using TupleMoveConstructible = typename std::conditional<
+using TupleElementMoveConstructible = typename std::conditional<
       std::is_reference<T>::value, std::is_convertible<V, T>,
       std::is_constructible<T, V&&>>::type;
+
+template <bool SizeMatches, class T, class... Vs>
+struct TupleMoveConstructible : std::false_type {};
+
+template <class... Ts, class... Vs>
+struct TupleMoveConstructible<true, CompressedTuple<Ts...>, Vs...>
+    : std::integral_constant<bool, absl::conjunction<TupleElementMoveConstructible<Ts, Vs&&>...>::value> {
+};
+
+template<typename... Es>
+struct compressed_tuple_size;
+
+template<typename... Es>
+struct compressed_tuple_size<CompressedTuple<Es...>>
+    : public std::integral_constant<std::size_t, sizeof...(Es)> {};
+
+template <class T, class... Vs>
+struct TupleItemsMoveConstructible
+    : std::integral_constant<bool, TupleMoveConstructible<compressed_tuple_size<T>::value == sizeof...(Vs), T, Vs...>::value> {};
 
 }  // namespace internal_compressed_tuple
 
@@ -217,17 +236,18 @@ class ABSL_INTERNAL_COMPRESSED_TUPLE_DECLSPEC CompressedTuple
   explicit constexpr CompressedTuple(const Ts&... base)
       : CompressedTuple::CompressedTupleImpl(absl::in_place, base...) {}
 
-  template <typename... Vs,
+  template <typename First, typename... Vs,
             absl::enable_if_t<
                 absl::conjunction<
                     // Ensure we are not hiding default copy/move constructors.
                     absl::negation<std::is_same<void(CompressedTuple),
-                                                void(absl::decay_t<Vs>...)>>,
-                    internal_compressed_tuple::TupleMoveConstructible<
-                        Ts, Vs&&>...>::value,
+                                                void(absl::decay_t<First>)>>,
+                    internal_compressed_tuple::TupleItemsMoveConstructible<
+                        CompressedTuple<Ts...>, First, Vs...>>::value,
                 bool> = true>
-  explicit constexpr CompressedTuple(Vs&&... base)
+  explicit constexpr CompressedTuple(First&& first, Vs&&... base)
       : CompressedTuple::CompressedTupleImpl(absl::in_place,
+                                             absl::forward<First>(first),
                                              absl::forward<Vs>(base)...) {}
 
   template <int I>

--- a/absl/container/internal/compressed_tuple.h
+++ b/absl/container/internal/compressed_tuple.h
@@ -169,28 +169,33 @@ constexpr bool ShouldAnyUseBase() {
 }
 
 template <typename T, typename V>
-using TupleElementMoveConstructible = typename std::conditional<
-      std::is_reference<T>::value, std::is_convertible<V, T>,
-      std::is_constructible<T, V&&>>::type;
+using TupleElementMoveConstructible =
+    typename std::conditional<std::is_reference<T>::value,
+                              std::is_convertible<V, T>,
+                              std::is_constructible<T, V&&>>::type;
 
 template <bool SizeMatches, class T, class... Vs>
 struct TupleMoveConstructible : std::false_type {};
 
 template <class... Ts, class... Vs>
 struct TupleMoveConstructible<true, CompressedTuple<Ts...>, Vs...>
-    : std::integral_constant<bool, absl::conjunction<TupleElementMoveConstructible<Ts, Vs&&>...>::value> {
-};
+    : std::integral_constant<
+          bool, absl::conjunction<
+                    TupleElementMoveConstructible<Ts, Vs&&>...>::value> {};
 
-template<typename... Es>
+template <typename T>
 struct compressed_tuple_size;
 
-template<typename... Es>
+template <typename... Es>
 struct compressed_tuple_size<CompressedTuple<Es...>>
     : public std::integral_constant<std::size_t, sizeof...(Es)> {};
 
 template <class T, class... Vs>
 struct TupleItemsMoveConstructible
-    : std::integral_constant<bool, TupleMoveConstructible<compressed_tuple_size<T>::value == sizeof...(Vs), T, Vs...>::value> {};
+    : std::integral_constant<
+          bool, TupleMoveConstructible<compressed_tuple_size<T>::value ==
+                                           sizeof...(Vs),
+                                       T, Vs...>::value> {};
 
 }  // namespace internal_compressed_tuple
 


### PR DESCRIPTION
Fixes https://github.com/abseil/abseil-cpp/issues/357

Please review, I'm unsure if the enable_if guard has the same effect as the old one.