### PR TITLE
Fix abs/strings/numbers compilation on Win/MSVS.

### DIFF
--- a/absl/strings/numbers.h
+++ b/absl/strings/numbers.h
@@ -25,7 +25,11 @@
 #define ABSL_STRINGS_NUMBERS_H_
 
 #ifdef __SSE4_2__
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
 #include <x86intrin.h>
+#endif
 #endif
 
 #include <cstddef>


### PR DESCRIPTION
There is no x86intrin.h on Win/MSVS.
Use intrin.h instead.