### PR TITLE
Use base_internal::AtomicHook instead of std::atomic

### DIFF
--- a/absl/status/BUILD.bazel
+++ b/absl/status/BUILD.bazel
@@ -40,6 +40,7 @@ cc_library(
     ],
     copts = ABSL_DEFAULT_COPTS,
     deps = [
+        "//absl/base:atomic_hook",
         "//absl/base:config",
         "//absl/base:core_headers",
         "//absl/base:raw_logging_internal",

--- a/absl/status/CMakeLists.txt
+++ b/absl/status/CMakeLists.txt
@@ -25,6 +25,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
+    absl::atomic_hook
     absl::config
     absl::core_headers
     absl::raw_logging_internal

--- a/absl/status/status_payload_printer.cc
+++ b/absl/status/status_payload_printer.cc
@@ -16,26 +16,21 @@
 #include <atomic>
 
 #include "absl/base/attributes.h"
+#include "absl/base/internal/atomic_hook.h"
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace status_internal {
 
-namespace {
-// Tried constant initialized global variable but it doesn't work with Lexan
-// (MSVC's `std::atomic` has trouble constant initializing).
-std::atomic<StatusPayloadPrinter>& GetStatusPayloadPrinterStorage() {
-  ABSL_CONST_INIT static std::atomic<StatusPayloadPrinter> instance{nullptr};
-  return instance;
-}
-}  // namespace
+ABSL_INTERNAL_ATOMIC_HOOK_ATTRIBUTES
+static absl::base_internal::AtomicHook<StatusPayloadPrinter> storage;
 
 void SetStatusPayloadPrinter(StatusPayloadPrinter printer) {
-  GetStatusPayloadPrinterStorage().store(printer, std::memory_order_relaxed);
+  storage.Store(printer);
 }
 
 StatusPayloadPrinter GetStatusPayloadPrinter() {
-  return GetStatusPayloadPrinterStorage().load(std::memory_order_relaxed);
+  return storage.Load();
 }
 
 }  // namespace status_internal


### PR DESCRIPTION
std::atomic has a broken implementation on the Windows platform and it
is not conform to the ABSL_CONST_INIT macro when clang-cl is used as a
compiler: the macro is expanded to the [[clang::require_constant_initialization]]
attribute and the attribute cannot be applied to the broken std::atomic.

Therefore, std::atomic has been replaced with absl::base_internal::AtomicHook
to fix the compilation error (thank Derek Mauro for the suggestion).

Issue: #659 

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>