### PR TITLE
Remove CMake find_library call for librt

### DIFF
--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -191,7 +191,7 @@ absl_cc_library(
     ${ABSL_DEFAULT_COPTS}
   LINKOPTS
     ${ABSL_DEFAULT_LINKOPTS}
-    $<$<BOOL:${LIBRT}>:${LIBRT}>
+    $<$<BOOL:${LIBRT}>:-lrt>
     $<$<BOOL:${MINGW}>:"advapi32">
   DEPS
     absl::atomic_hook


### PR DESCRIPTION
CMake `find_library` calls always resolves the library as shared object
over the static library. This hurts static linking and cross compilations.
(The installed `abslTargets.cmake` file had the host's librt.so file with
absolute path.)

This fix just adds the librt as a link option to the base library, without
resolving the location of the library.