### PR TITLE
Fix undefined symbol in MacOS dylib

### DIFF
--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -538,6 +538,7 @@ absl_cc_library(
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS
+    absl::strings
     absl::strings_internal
     absl::base
     absl::base_internal


### PR DESCRIPTION
I've added absl::string dependency to absl::cord as proposed by moubctez on issue #624

The problem is located on LTS 20200225 release of abseil-cpp. 
When you want to compile the library as shared object (dylib on MacOS), you get this error:
```
[ 97%] Linking CXX shared library libabsl_cord.dylib
Undefined symbols for architecture x86_64:
  "absl::lts_2020_02_25::numbers_internal::FastIntToBuffer(unsigned long long, char*)", referenced from:
      absl::lts_2020_02_25::Cord::RemovePrefix(unsigned long) in cord.cc.o
      absl::lts_2020_02_25::Cord::RemoveSuffix(unsigned long) in cord.cc.o
      absl::lts_2020_02_25::strings_internal::CordTestAccess::LengthToTag(unsigned long) in cord.cc.o
  "absl::lts_2020_02_25::StrCat(absl::lts_2020_02_25::AlphaNum const&, absl::lts_2020_02_25::AlphaNum const&)", referenced from:
      absl::lts_2020_02_25::strings_internal::CordTestAccess::LengthToTag(unsigned long) in cord.cc.o
  "absl::lts_2020_02_25::StrCat(absl::lts_2020_02_25::AlphaNum const&, absl::lts_2020_02_25::AlphaNum const&, absl::lts_2020_02_25::AlphaNum const&, absl::lts_2020_02_25::AlphaNum const&)", referenced from:
      absl::lts_2020_02_25::Cord::RemovePrefix(unsigned long) in cord.cc.o
      absl::lts_2020_02_25::Cord::RemoveSuffix(unsigned long) in cord.cc.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [absl/strings/libabsl_cord.dylib] Error 1
make[1]: *** [absl/strings/CMakeFiles/cord.dir/all] Error 2
make: *** [all] Error 2
```

It is located in **libabsl_cord.dylib** dependencies. 
I've patched the **absl/strings/CMakeLists.txt** file as described by @moubctez and my compilation of abseil-cpp works as expected:
```
[ 97%] Linking CXX shared library libabsl_cord.dylib
[ 97%] Built target cord
Scanning dependencies of target status
[ 98%] Building CXX object absl/status/CMakeFiles/status.dir/status.cc.o
[ 98%] Building CXX object absl/status/CMakeFiles/status.dir/status_payload_printer.cc.o
[ 99%] Linking CXX shared library libabsl_status.dylib
[ 99%] Built target status
Scanning dependencies of target bad_any_cast_impl
[ 99%] Building CXX object absl/types/CMakeFiles/bad_any_cast_impl.dir/bad_any_cast.cc.o
[100%] Linking CXX shared library libabsl_bad_any_cast_impl.dylib
[100%] Built target bad_any_cast_impl
```

I don't know if this correction can be also 'cherry-picked' to the master branch but on the "lts_2020_02_25" branch, it is needed in order to build the library as dylib on MacOS.

I've tested this correction on both MacOS Mojave and MacOS Catalina.

