### PR TITLE
fix MSVC warning 4245: conversion signed => unsigned during initialization

### DIFF
--- a/absl/container/internal/container_memory.h
+++ b/absl/container/internal/container_memory.h
@@ -250,8 +250,8 @@ namespace memory_internal {
 // type, which is non-portable.
 template <class Pair, class = std::true_type>
 struct OffsetOf {
-  static constexpr size_t kFirst = -1;
-  static constexpr size_t kSecond = -1;
+  static constexpr size_t kFirst = static_cast<size_t>(-1);
+  static constexpr size_t kSecond = static_cast<size_t>(-1);
 };
 
 template <class Pair>


### PR DESCRIPTION
MSVC bails out for me with -Werror (like we enforce for our own code at AbsInt), if I use the flat hash tables because of this sign/unsigned issue in the code (warning 4245).

With this trivial fix, all is fine and it should have zero impact on the generated (binary) code.