### PR TITLE
CMake: don't attempt to use googletest unless ABSL_RUN_TESTS==true.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,8 @@ if(${ABSL_RUN_TESTS})
   # on the command line
   include(CTest)
   enable_testing()
-endif()
 
-## check targets
-if(BUILD_TESTING)
+  ## check targets
   if (NOT ABSL_USE_EXTERNAL_GOOGLETEST)
     set(absl_gtest_build_dir ${CMAKE_BINARY_DIR}/googletest-build)
     if(${ABSL_USE_GOOGLETEST_HEAD})


### PR DESCRIPTION
Fixes #690.