### PR TITLE
Add C++20 alternative for result_of_t

### DIFF
--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -619,7 +619,7 @@ using underlying_type_t = typename std::underlying_type<T>::type;
 template <typename T>
 #ifdef __cpp_lib_is_invocable
 using result_of_t = typename std::invoke_result<T>::type;
-#elif
+#else
 using result_of_t = typename std::result_of<T>::type;
 #endif
 

--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -617,7 +617,11 @@ template <typename T>
 using underlying_type_t = typename std::underlying_type<T>::type;
 
 template <typename T>
+#ifdef __cpp_lib_is_invocable
+using result_of_t = typename std::invoke_result<T>::type;
+#elif
 using result_of_t = typename std::result_of<T>::type;
+#endif
 
 namespace type_traits_internal {
 // In MSVC we can't probe std::hash or stdext::hash because it triggers a


### PR DESCRIPTION
Abseil doesn't compile in the newest MSVC version as std::result_of has been removed from the C++20 standard. Instead std::invoke_result should be used. By using a the standard [__cpp_lib_is_invocable](https://en.cppreference.com/w/cpp/feature_test) define we can easily test if std::invoke_result exists.