### PR TITLE
Added a BUILD file in root to expose license.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,25 @@
+#
+# Copyright 2020 The Abseil Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+# Expose license for external usage through bazel.
+exports_files([
+    "LICENSE",
+    "AUTHORS",
+])


### PR DESCRIPTION
Added a build file to expose license for external usage through bazel. This is typical in other bazel projects (esp. at Google), see:
  - Tensorflow: https://github.com/tensorflow/tensorflow/blob/master/BUILD
  - Protobuf: https://github.com/protocolbuffers/protobuf/blob/master/BUILD

Used when absl is packaged as a dependency.