### PR TITLE
Exclude empty directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,5 +172,7 @@ if(ABSL_ENABLE_INSTALL)
     FILES_MATCHING
       PATTERN "*.inc"
       PATTERN "*.h"
+      PATTERN "copts" EXCLUDE
+      PATTERN "testdata" EXCLUDE
   )
 endif()  # ABSL_ENABLE_INSTALL


### PR DESCRIPTION
install(DIRECTORY...) creates all directories. If there is no matching
files, it becomes an empty directory. The three empty directories are
absl/copts, absl/strings/testdata and absl/time/internal/cctz/testdata.
It is a workaround as cmake does not have an option to exclude empty
directories.

Reference:	https://gitlab.kitware.com/cmake/cmake/-/issues/19189