### PR TITLE
Remove absl::result_of_t in C++20

### DIFF
--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -180,7 +180,7 @@
 // absl::variant is a typedef of std::variant, use the feature macro
 // ABSL_USES_STD_VARIANT.
 
-#define ABSL_OPTION_USE_STD_VARIANT 2
+#define ABSL_OPTION_USE_STD_VARIANT 0
 
 
 // ABSL_OPTION_USE_INLINE_NAMESPACE

--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -180,7 +180,7 @@
 // absl::variant is a typedef of std::variant, use the feature macro
 // ABSL_USES_STD_VARIANT.
 
-#define ABSL_OPTION_USE_STD_VARIANT 0
+#define ABSL_OPTION_USE_STD_VARIANT 2
 
 
 // ABSL_OPTION_USE_INLINE_NAMESPACE

--- a/absl/container/btree_test.cc
+++ b/absl/container/btree_test.cc
@@ -22,8 +22,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/base/internal/raw_logging.h"
 #include "absl/base/macros.h"
 #include "absl/container/btree_map.h"
@@ -38,6 +36,8 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/compare.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 ABSL_FLAG(int, test_values, 10000, "The number of values to use for tests");
 
@@ -1249,10 +1249,17 @@ void AssertKeyCompareToAdapted() {
   using Adapted = typename key_compare_to_adapter<Compare>::type;
   static_assert(!std::is_same<Adapted, Compare>::value,
                 "key_compare_to_adapter should have adapted this comparator.");
+#if !defined(__cpp_lib_is_invocable)
   static_assert(
       std::is_same<absl::weak_ordering,
                    absl::result_of_t<Adapted(const K &, const K &)>>::value,
       "Adapted comparator should be a key-compare-to comparator.");
+#else
+  static_assert(
+      std::is_same<absl::weak_ordering,
+                   absl::invoke_result_t<Adapted, const K &, const K &>>::value,
+      "Adapted comparator should be a key-compare-to comparator.");
+#endif
 }
 template <typename Compare, typename K>
 void AssertKeyCompareToNotAdapted() {
@@ -1260,10 +1267,17 @@ void AssertKeyCompareToNotAdapted() {
   static_assert(
       std::is_same<Unadapted, Compare>::value,
       "key_compare_to_adapter shouldn't have adapted this comparator.");
+#if !defined(__cpp_lib_is_invocable)
   static_assert(
       std::is_same<bool,
                    absl::result_of_t<Unadapted(const K &, const K &)>>::value,
       "Un-adapted comparator should return bool.");
+#else
+  static_assert(
+      std::is_same<
+          bool, absl::invoke_result_t<Unadapted, const K &, const K &>>::value,
+      "Un-adapted comparator should return bool.");
+#endif
 }
 
 TEST(Btree, KeyCompareToAdapter) {

--- a/absl/container/internal/btree.h
+++ b/absl/container/internal/btree.h
@@ -432,10 +432,9 @@ class btree_node {
   //   - Otherwise, choose binary.
   // TODO(ezb): Might make sense to add condition(s) based on node-size.
   using use_linear_search = std::integral_constant<
-      bool,
-                std::is_arithmetic<key_type>::value &&
-                    (std::is_same<std::less<key_type>, key_compare>::value ||
-                     std::is_same<std::greater<key_type>, key_compare>::value)>;
+      bool, std::is_arithmetic<key_type>::value &&
+                (std::is_same<std::less<key_type>, key_compare>::value ||
+                 std::is_same<std::greater<key_type>, key_compare>::value)>;
 
   // This class is organized by gtl::Layout as if it had the following
   // structure:
@@ -1836,8 +1835,13 @@ constexpr bool btree<P>::static_assert_validation() {
       "target node size too large");
 
   // Verify that key_compare returns an absl::{weak,strong}_ordering or bool.
+#if !defined(__cpp_lib_is_invocable)
   using compare_result_type =
       absl::result_of_t<key_compare(key_type, key_type)>;
+#else
+  using compare_result_type =
+      absl::invoke_result_t<key_compare, key_type, key_type>;
+#endif
   static_assert(
       std::is_same<compare_result_type, bool>::value ||
           std::is_convertible<compare_result_type, absl::weak_ordering>::value,

--- a/absl/container/internal/btree.h
+++ b/absl/container/internal/btree.h
@@ -76,10 +76,17 @@ namespace container_internal {
 
 // A helper class that indicates if the Compare parameter is a key-compare-to
 // comparator.
+#if !defined(__cpp_lib_is_invocable)
 template <typename Compare, typename T>
 using btree_is_key_compare_to =
     std::is_convertible<absl::result_of_t<Compare(const T &, const T &)>,
                         absl::weak_ordering>;
+#else
+template <typename Compare, typename T>
+using btree_is_key_compare_to =
+    std::is_convertible<absl::invoke_result_t<Compare, const T &, const T &>,
+                        absl::weak_ordering>;
+#endif
 
 struct StringBtreeDefaultLess {
   using is_transparent = void;

--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -36,6 +36,7 @@
 #define ABSL_META_TYPE_TRAITS_H_
 
 #include <stddef.h>
+
 #include <functional>
 #include <type_traits>
 
@@ -244,8 +245,8 @@ template <typename... Ts>
 struct disjunction;
 
 template <typename T, typename... Ts>
-struct disjunction<T, Ts...> :
-      std::conditional<T::value, T, disjunction<Ts...>>::type {};
+struct disjunction<T, Ts...>
+    : std::conditional<T::value, T, disjunction<Ts...>>::type {};
 
 template <typename T>
 struct disjunction<T> : T {};
@@ -297,7 +298,7 @@ struct is_function
 template <typename T>
 struct is_trivially_destructible
     : std::integral_constant<bool, __has_trivial_destructor(T) &&
-                                   std::is_destructible<T>::value> {
+                                       std::is_destructible<T>::value> {
 #ifdef ABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
  private:
   static constexpr bool compliant = std::is_trivially_destructible<T>::value ==
@@ -345,9 +346,10 @@ struct is_trivially_destructible
 // Nontrivially destructible types will cause the expression to be nontrivial.
 template <typename T>
 struct is_trivially_default_constructible
-    : std::integral_constant<bool, __has_trivial_constructor(T) &&
-                                   std::is_default_constructible<T>::value &&
-                                   is_trivially_destructible<T>::value> {
+    : std::integral_constant<bool,
+                             __has_trivial_constructor(T) &&
+                                 std::is_default_constructible<T>::value &&
+                                 is_trivially_destructible<T>::value> {
 #if defined(ABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE) && \
     !defined(                                            \
         ABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION)
@@ -616,8 +618,25 @@ using common_type_t = typename std::common_type<T...>::type;
 template <typename T>
 using underlying_type_t = typename std::underlying_type<T>::type;
 
+#if !defined(__cpp_lib_is_invocable)
 template <typename T>
 using result_of_t = typename std::result_of<T>::type;
+#else
+template <typename T, typename... Ts>
+using invoke_result_t = typename std::invoke_result<T, Ts...>::type;
+
+// template <typename T>
+// struct result_of;
+//
+// template <typename T, typename... Ts>
+// struct result_of<T(Ts...)> {
+//  using invoke_result_t<T, Ts...>;
+//};
+//
+// template <typename T>
+// using result_of_t = typename result_of<T>::type;
+
+#endif
 
 namespace type_traits_internal {
 // In MSVC we can't probe std::hash or stdext::hash because it triggers a
@@ -749,8 +768,8 @@ namespace type_traits_internal {
 // Make the swap-related traits/function accessible from this namespace.
 using swap_internal::IsNothrowSwappable;
 using swap_internal::IsSwappable;
-using swap_internal::Swap;
 using swap_internal::StdSwapIsUnconstrained;
+using swap_internal::Swap;
 
 }  // namespace type_traits_internal
 ABSL_NAMESPACE_END

--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -624,18 +624,6 @@ using result_of_t = typename std::result_of<T>::type;
 #else
 template <typename T, typename... Ts>
 using invoke_result_t = typename std::invoke_result<T, Ts...>::type;
-
-// template <typename T>
-// struct result_of;
-//
-// template <typename T, typename... Ts>
-// struct result_of<T(Ts...)> {
-//  using invoke_result_t<T, Ts...>;
-//};
-//
-// template <typename T>
-// using result_of_t = typename result_of<T>::type;
-
 #endif
 
 namespace type_traits_internal {

--- a/absl/types/compare.h
+++ b/absl/types/compare.h
@@ -569,21 +569,36 @@ constexpr absl::weak_ordering compare_result_as_ordering(
     const absl::weak_ordering c) {
   return c;
 }
-
+#if !defined(__cpp_lib_is_invocable)
 template <
     typename Compare, typename K, typename LK,
     absl::enable_if_t<!std::is_same<bool, absl::result_of_t<Compare(
                                               const K &, const LK &)>>::value,
                       int> = 0>
+#else
+template <
+    typename Compare, typename K, typename LK,
+    absl::enable_if_t<!std::is_same<bool, absl::invoke_result_t<Compare, 
+                                              const K &, const LK &>>::value,
+                      int> = 0>
+#endif
 constexpr absl::weak_ordering do_three_way_comparison(const Compare &compare,
                                                       const K &x, const LK &y) {
   return compare_result_as_ordering(compare(x, y));
 }
+#if !defined(__cpp_lib_is_invocable)
 template <
     typename Compare, typename K, typename LK,
     absl::enable_if_t<std::is_same<bool, absl::result_of_t<Compare(
                                              const K &, const LK &)>>::value,
                       int> = 0>
+#else
+template <
+    typename Compare, typename K, typename LK,
+    absl::enable_if_t<std::is_same<bool, absl::invoke_result_t<Compare, 
+                                             const K &, const LK &>>::value,
+                      int> = 0>
+#endif
 constexpr absl::weak_ordering do_three_way_comparison(const Compare &compare,
                                                       const K &x, const LK &y) {
   return compare(x, y) ? absl::weak_ordering::less

--- a/absl/types/internal/variant.h
+++ b/absl/types/internal/variant.h
@@ -939,11 +939,20 @@ struct PerformVisitation {
   template <std::size_t... TupIs, std::size_t... Is>
   constexpr ReturnType Run(std::false_type /*has_valueless*/,
                            index_sequence<TupIs...>, SizeT<Is>...) const {
+#if !defined(__cpp_lib_is_invocable)
     static_assert(
         std::is_same<ReturnType,
                      absl::result_of_t<Op(VariantAccessResult<
                                           Is, QualifiedVariants>...)>>::value,
         "All visitation overloads must have the same return type.");
+#else
+    static_assert(
+        std::is_same<
+            ReturnType,
+            absl::invoke_result_t<
+                Op, VariantAccessResult<Is, QualifiedVariants>...>>::value,
+        "All visitation overloads must have the same return type.");
+#endif
     return absl::base_internal::Invoke(
         absl::forward<Op>(op),
         VariantCoreAccess::Access<Is>(


### PR DESCRIPTION
This PR removes absl::result_of_t when compiling for C++20. I did the dead-simplest thing: I just added `#if` guards everywhere it is used. 

Alternatives that spring to mind:
* Provide a drop in replacement for result_of_t in C++20. I have some commented out code to this effect.
* Provide an implementation of invoke_result_t in C++14 and earlier, port everything in the library to use this.

Something appears to be wrong with your .clang-format file. It doesn't appear to produce the same results as the formatting that is actually in these files.