### PR TITLE
Disable pthread for standalone wasm build support

### DIFF
--- a/absl/BUILD.bazel
+++ b/absl/BUILD.bazel
@@ -58,3 +58,8 @@ config_setting(
     },
     visibility = [":__subpackages__"],
 )
+
+config_setting(
+    name = "wasm",
+    values = {"cpu": "wasm"},
+)

--- a/absl/BUILD.bazel
+++ b/absl/BUILD.bazel
@@ -61,5 +61,5 @@ config_setting(
 
 config_setting(
     name = "wasm",
-    values = {"cpu": "wasm"},
+    values = {"cpu": "wasm32"},
 )

--- a/absl/base/BUILD.bazel
+++ b/absl/base/BUILD.bazel
@@ -161,6 +161,7 @@ cc_library(
     copts = ABSL_DEFAULT_COPTS,
     linkopts = select({
         "//absl:windows": [],
+        "//absl:wasm": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     visibility = [
@@ -222,6 +223,7 @@ cc_library(
         "//absl:windows": [
             "-DEFAULTLIB:advapi32.lib",
         ],
+        "//absl:wasm": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [

--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -148,6 +148,7 @@ cc_test(
     copts = ABSL_TEST_COPTS,
     linkopts = select({
         "//absl:windows": [],
+        "//absl:wasm": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [

--- a/absl/random/internal/BUILD.bazel
+++ b/absl/random/internal/BUILD.bazel
@@ -96,6 +96,7 @@ cc_library(
     copts = ABSL_DEFAULT_COPTS,
     linkopts = select({
         "//absl:windows": [],
+        "//absl:wasm": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [

--- a/absl/synchronization/BUILD.bazel
+++ b/absl/synchronization/BUILD.bazel
@@ -90,6 +90,7 @@ cc_library(
     copts = ABSL_DEFAULT_COPTS,
     linkopts = select({
         "//absl:windows": [],
+        "//absl:wasm": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [


### PR DESCRIPTION
Introduced wasm support by adding knobs to disable for standalone wasm build.