### PR TITLE
Allow overriding Abseil IDE folder

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -23,7 +23,9 @@ include(AbseilInstallDirs)
 # project that sets
 #    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # For example, Visual Studio supports folders.
-set(ABSL_IDE_FOLDER Abseil)
+if(NOT DEFINED ABSL_IDE_FOLDER)
+  set(ABSL_IDE_FOLDER Abseil)
+endif()
 
 # absl_cc_library()
 #


### PR DESCRIPTION
by not setting when ABSL_IDE_FOLDER is provided from outside.

This allows to move Abseil into e.g. a 3rd party lib folder when used
in a larger project.