### PR TITLE
Add support for s390x cpu frequency

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -101,6 +101,18 @@ double UnscaledCycleClock::Frequency() {
 #endif
 }
 
+#elif defined(__s390x__)
+
+int64_t UnscaledCycleClock::Now() {
+  int64_t tsc;
+  asm("stck %0" : "=Q" (tsc) : : "cc");
+  return tsc;
+}
+
+double UnscaledCycleClock::Frequency() {
+  return base_internal::NominalCPUFrequency();
+}
+
 #elif defined(__aarch64__)
 
 // System timer of ARMv8 runs at a different frequency than the CPU's.

--- a/absl/base/internal/unscaledcycleclock.h
+++ b/absl/base/internal/unscaledcycleclock.h
@@ -47,7 +47,7 @@
 // The following platforms have an implementation of a hardware counter.
 #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) || \
   defined(__powerpc__) || defined(__ppc__) || \
-  defined(_M_IX86) || defined(_M_X64)
+  defined(_M_IX86) || defined(_M_X64) || defined(__s390x__)
 #define ABSL_HAVE_UNSCALED_CYCLECLOCK_IMPLEMENTATION 1
 #else
 #define ABSL_HAVE_UNSCALED_CYCLECLOCK_IMPLEMENTATION 0
@@ -81,7 +81,7 @@
 // This macro can be used to test if UnscaledCycleClock::Frequency()
 // is NominalCPUFrequency() on a particular platform.
 #if  (defined(__i386__) || defined(__x86_64__) || \
-      defined(_M_IX86) || defined(_M_X64))
+      defined(_M_IX86) || defined(_M_X64)) || defined(__s390x__)
 #define ABSL_INTERNAL_UNSCALED_CYCLECLOCK_FREQUENCY_IS_CPU_FREQUENCY
 #endif
 


### PR DESCRIPTION
As could be seen from [this](https://github.com/abseil/abseil-cpp/issues/135#issuecomment-405463796) issue, the unit test `SysinfoTest.NominalCPUFrequency` has always been failing on s390x machines. The reason for the failure is because there is no mechanism in abseil code to retrieve CPU time and frequency for s390x machines. I am adding the methods for s390x by referencing a similar method committed to another project, see [here](https://github.com/google/benchmark/pull/540/commits/94e51b0280b48823e9f4ae31b6e4df413b179d44). 