### PR TITLE
Added flag in absl/container/internal/have_see.h to see if AVX512 is …

### DIFF
--- a/absl/container/internal/have_sse.h
+++ b/absl/container/internal/have_sse.h
@@ -34,6 +34,19 @@
 #endif
 #endif
 
+#ifndef ABSL_INTERNAL_RAW_HASH_SET_HAVE_AVX512
+#if defined(__AVX512BW__) && defined(__AVX512VL__)
+#define ABSL_INTERNAL_RAW_HASH_SET_HAVE_AVX512 1
+#else
+#define ABSL_INTERNAL_RAW_HASH_SET_HAVE_AVX512 0
+#endif
+#endif
+
+#if ABSL_INTERNAL_RAW_HASH_SET_HAVE_AVX512 && \
+    !ABSL_INTERNAL_RAW_HASH_SET_HAVE_SSE3
+#error "Bad configuration!"
+#endif
+
 #if ABSL_INTERNAL_RAW_HASH_SET_HAVE_SSSE3 && \
     !ABSL_INTERNAL_RAW_HASH_SET_HAVE_SSE2
 #error "Bad configuration!"
@@ -45,6 +58,10 @@
 
 #if ABSL_INTERNAL_RAW_HASH_SET_HAVE_SSSE3
 #include <tmmintrin.h>
+#endif
+
+#if ABSL_INTERNAL_RAW_HASH_SET_HAVE_AVX512
+#include <immintrin.h>
 #endif
 
 #endif  // ABSL_CONTAINER_INTERNAL_HAVE_SSE_H_


### PR DESCRIPTION
Modified absl/container/internal/have_sse.h so that it would set a flag if AVX512 was supported. Modified absl/container/internal/raw_hash_set.h so that if AVX512 is supported it will use AVX512 instructions in a few places increasing the efficiency of the group instructions.