### PR TITLE
CMake: improve super build usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ cmake_policy(SET CMP0057 NEW)
 # Project version variables are the empty string if version is unspecified
 cmake_policy(SET CMP0048 NEW)
 
+# option() honor variables
+cmake_policy(SET CMP0077 NEW)
+
 project(absl CXX)
 
 # Output directory is correct by default for most build setups. However, when
@@ -41,9 +44,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # when absl is included as subproject (i.e. using add_subdirectory(abseil-cpp))
 # in the source tree of a project that uses it, install rules are disabled.
 if(NOT "^${CMAKE_SOURCE_DIR}$" STREQUAL "^${PROJECT_SOURCE_DIR}$")
-  set(ABSL_ENABLE_INSTALL FALSE)
+  option(ABSL_ENABLE_INSTALL "Enable install rule" OFF)
 else()
-  set(ABSL_ENABLE_INSTALL TRUE)
+  option(ABSL_ENABLE_INSTALL "Enable install rule" ON)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH


### PR DESCRIPTION
Up to now when integrating abseil-cpp as subproject it is impossible:
- to change option value due to lack of CMP0077
- reuse the absl install rules since there are disabled and we can't change this (use of set() in stead of option())

note: These are blocking google/or-tools so currently we have to maintain a patch.
note: May fix #703