### PR TITLE
CMake: remove unneeded enable_testing() cmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,6 @@ if(${ABSL_RUN_TESTS})
   # enable CTest.  This will set BUILD_TESTING to ON unless otherwise specified
   # on the command line
   include(CTest)
-  enable_testing()
 
   ## check targets
   if (NOT ABSL_USE_EXTERNAL_GOOGLETEST)


### PR DESCRIPTION
Remove redundant call "enable_testing()" which is already performed by CTest module

ref: https://github.com/Kitware/CMake/blob/43372d5ba34d2a95a886f39a254870c122e98fa2/Modules/CTest.cmake#L83-L84