### PR TITLE
CMake: flag conformance_testing as TESTONLY

### DIFF
--- a/absl/types/CMakeLists.txt
+++ b/absl/types/CMakeLists.txt
@@ -259,7 +259,7 @@ absl_cc_library(
     absl::strings
     absl::utility
     gmock_main
-  PUBLIC
+  TESTONLY
 )
 
 absl_cc_test(


### PR DESCRIPTION
All libraries depending on any gmock target should be flagged as TESTONLY