### PR TITLE
cmake: Check if CMP0077 is available (Fix #742)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,9 @@ cmake_policy(SET CMP0057 NEW)
 cmake_policy(SET CMP0048 NEW)
 
 # option() honor variables
-cmake_policy(SET CMP0077 NEW)
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
 
 project(absl CXX)
 


### PR DESCRIPTION
Since CMP0077 was introduced in CMake 3.13, I should have first detect if CMP0077 is available before set it to NEW.

FYI only policies >= 66 need this since they have been introduced after CMake 3.5 and may not be available, see https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html