### PR TITLE
absl/debugging: use <execinfo.h> only when available

### DIFF
--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -14,6 +14,13 @@
 # limitations under the License.
 #
 
+include(CheckIncludeFileCXX)
+
+check_include_file_cxx(execinfo.h HAVE_EXECINFO_H)
+if(HAVE_EXECINFO_H)
+    add_definitions(-DHAVE_EXECINFO_H)
+endif()
+
 absl_cc_library(
   NAME
     stacktrace

--- a/absl/debugging/internal/stacktrace_config.h
+++ b/absl/debugging/internal/stacktrace_config.h
@@ -61,7 +61,7 @@
 # elif defined(__aarch64__)
 #define ABSL_STACKTRACE_INL_HEADER \
     "absl/debugging/internal/stacktrace_aarch64-inl.inc"
-#elif defined(__arm__) && defined(__GLIBC__)
+#elif defined(__arm__) && defined(HAVE_EXECINFO_H)
 // Note: When using glibc this may require -funwind-tables to function properly.
 #define ABSL_STACKTRACE_INL_HEADER \
   "absl/debugging/internal/stacktrace_generic-inl.inc"
@@ -70,10 +70,10 @@
    "absl/debugging/internal/stacktrace_unimplemented-inl.inc"
 # endif
 #else  // defined(NO_FRAME_POINTER)
-# if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)
+# if (defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)) && defined(HAVE_EXECINFO_H)
 #define ABSL_STACKTRACE_INL_HEADER \
     "absl/debugging/internal/stacktrace_generic-inl.inc"
-# elif defined(__ppc__) || defined(__PPC__)
+# elif (defined(__ppc__) || defined(__PPC__)) && defined(HAVE_EXECINFO_H)
 #define ABSL_STACKTRACE_INL_HEADER \
     "absl/debugging/internal/stacktrace_generic-inl.inc"
 # else


### PR DESCRIPTION
Instead of relying on __GLIBC__ or other unreliable detection
mechanism, simply detect if <execinfo.h> is available before using the
stacktrace_generic-inl.inc implementation.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>