### PR TITLE
Use lpthread instead of pthread when linking

### DIFF
--- a/absl/base/BUILD.bazel
+++ b/absl/base/BUILD.bazel
@@ -162,7 +162,7 @@ cc_library(
     linkopts = select({
         "//absl:windows": [],
         "//absl:wasm": [],
-        "//conditions:default": ["-pthread"],
+        "//conditions:default": ["-lpthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//visibility:public",
@@ -224,7 +224,7 @@ cc_library(
             "-DEFAULTLIB:advapi32.lib",
         ],
         "//absl:wasm": [],
-        "//conditions:default": ["-pthread"],
+        "//conditions:default": ["-lpthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":atomic_hook",

--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -149,7 +149,7 @@ cc_test(
     linkopts = select({
         "//absl:windows": [],
         "//absl:wasm": [],
-        "//conditions:default": ["-pthread"],
+        "//conditions:default": ["-lpthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":failure_signal_handler",

--- a/absl/random/internal/BUILD.bazel
+++ b/absl/random/internal/BUILD.bazel
@@ -100,7 +100,7 @@ cc_library(
     linkopts = select({
         "//absl:windows": [],
         "//absl:wasm": [],
-        "//conditions:default": ["-pthread"],
+        "//conditions:default": ["-lpthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":randen",

--- a/absl/synchronization/BUILD.bazel
+++ b/absl/synchronization/BUILD.bazel
@@ -91,7 +91,7 @@ cc_library(
     linkopts = select({
         "//absl:windows": [],
         "//absl:wasm": [],
-        "//conditions:default": ["-pthread"],
+        "//conditions:default": ["-lpthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":graphcycles_internal",


### PR DESCRIPTION
In clang-12 linking with -pthread produces a warning:
```
clang-12: warning: argument unused during compilation: '-pthread' [-Wunused-command-line-argument]
```