### PR TITLE
[string_view] Use member-types instead of hardcoding char type

### DIFF
--- a/absl/strings/string_view.cc
+++ b/absl/strings/string_view.cc
@@ -84,7 +84,7 @@ string_view::size_type string_view::find(string_view s, size_type pos) const
     if (empty() && pos == 0 && s.empty()) return 0;
     return npos;
   }
-  const char* result =
+  string_view::const_pointer result =
       strings_internal::memmatch(ptr_ + pos, length_ - pos, s.ptr_, s.length_);
   return result ? result - ptr_ : npos;
 }
@@ -93,8 +93,9 @@ string_view::size_type string_view::find(char c, size_type pos) const noexcept {
   if (empty() || pos >= length_) {
     return npos;
   }
-  const char* result =
-      static_cast<const char*>(memchr(ptr_ + pos, c, length_ - pos));
+  string_view::const_pointer result =
+      static_cast<string_view::const_pointer>(
+          memchr(ptr_ + pos, c, length_ - pos));
   return result != nullptr ? result - ptr_ : npos;
 }
 
@@ -102,13 +103,15 @@ string_view::size_type string_view::rfind(string_view s, size_type pos) const
     noexcept {
   if (length_ < s.length_) return npos;
   if (s.empty()) return std::min(length_, pos);
-  const char* last = ptr_ + std::min(length_ - s.length_, pos) + s.length_;
-  const char* result = std::find_end(ptr_, last, s.ptr_, s.ptr_ + s.length_);
+  string_view::const_pointer last =
+      ptr_ + std::min(length_ - s.length_, pos) + s.length_;
+  string_view::const_pointer result =
+      std::find_end(ptr_, last, s.ptr_, s.ptr_ + s.length_);
   return result != last ? result - ptr_ : npos;
 }
 
 // Search range is [0..pos] inclusive.  If pos == npos, search everything.
-string_view::size_type string_view::rfind(char c, size_type pos) const
+string_view::size_type string_view::rfind(value_type c, size_type pos) const
     noexcept {
   // Note: memrchr() is not available on Windows.
   if (empty()) return npos;
@@ -153,7 +156,7 @@ string_view::size_type string_view::find_first_not_of(string_view s,
   return npos;
 }
 
-string_view::size_type string_view::find_first_not_of(char c,
+string_view::size_type string_view::find_first_not_of(value_type c,
                                                       size_type pos) const
     noexcept {
   if (empty()) return npos;
@@ -198,7 +201,7 @@ string_view::size_type string_view::find_last_not_of(string_view s,
   return npos;
 }
 
-string_view::size_type string_view::find_last_not_of(char c,
+string_view::size_type string_view::find_last_not_of(value_type c,
                                                      size_type pos) const
     noexcept {
   if (empty()) return npos;


### PR DESCRIPTION
This change replaces uses of `char` with `string_view::value_type`.
This *may* allow making `string_view` a template and support different
value types.

Updates #124, #734