### PR TITLE
Added missing asserts for seq.index() < capacity_ and unified their u…

### DIFF
--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -1327,6 +1327,7 @@ class raw_hash_set {
       }
       if (ABSL_PREDICT_TRUE(g.MatchEmpty())) return end();
       seq.next();
+      assert(seq.index() < capacity_ && "full table!");
     }
   }
   template <class K = key_type>
@@ -1678,8 +1679,8 @@ class raw_hash_set {
 #endif
         return {seq.offset(mask.LowestBitSet()), seq.index()};
       }
-      assert(seq.index() < capacity_ && "full table!");
       seq.next();
+      assert(seq.index() < capacity_ && "full table!");
     }
   }
 
@@ -1710,6 +1711,7 @@ class raw_hash_set {
       }
       if (ABSL_PREDICT_TRUE(g.MatchEmpty())) break;
       seq.next();
+      assert(seq.index() < capacity_ && "full table!");
     }
     return {prepare_insert(hash), true};
   }
@@ -1857,6 +1859,7 @@ struct HashtableDebugAccess<Set, absl::void_t<typename Set::raw_hash_set>> {
       }
       if (g.MatchEmpty()) return num_probes;
       seq.next();
+      assert(seq.index() < capacity_ && "full table!");
       ++num_probes;
     }
   }

--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -1859,7 +1859,6 @@ struct HashtableDebugAccess<Set, absl::void_t<typename Set::raw_hash_set>> {
       }
       if (g.MatchEmpty()) return num_probes;
       seq.next();
-      assert(seq.index() < capacity_ && "full table!");
       ++num_probes;
     }
   }


### PR DESCRIPTION
In a highly specific situation the call to find() was found to be stuck in an infinite cycle as it never checked whether `probe_seq::index_` as accessed by `seq.index()` exceeded `capacity_`.

This situation arose after a call to a faulty implementation of `std::memset` (using uClibc's v0.9.32.1 memset, ARM platform) in `reset_ctrl()` which ended up setting the control block to `0xffffff80 0xffffff80 ...` as opposed to `0x80808080 0x80808080 ...`.

The reordering of calls in `find_first_non_full()` is simply to prevent one extra, unnecessary traversal.