### PR TITLE
fix compile fails with asan and -Wredundant-decls

### DIFF
--- a/absl/base/internal/unaligned_access.h
+++ b/absl/base/internal/unaligned_access.h
@@ -45,17 +45,7 @@
 // For all three tools, replacing an unaligned access with a tool-specific
 // callback solves the problem.
 
-// Make sure uint16_t/uint32_t/uint64_t are defined.
-#include <stdint.h>
-
-extern "C" {
-uint16_t __sanitizer_unaligned_load16(const void *p);
-uint32_t __sanitizer_unaligned_load32(const void *p);
-uint64_t __sanitizer_unaligned_load64(const void *p);
-void __sanitizer_unaligned_store16(void *p, uint16_t v);
-void __sanitizer_unaligned_store32(void *p, uint32_t v);
-void __sanitizer_unaligned_store64(void *p, uint64_t v);
-}  // extern "C"
+#include <sanitizer/common_interface_defs.h>
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN


### PR DESCRIPTION
If compile with asan, unaligned_access.h redeclares the same sanitizer
function with sanitizer/common_interface_defs.h.

This patch removes these declarations, and includes sanitizer header
file to avoid this warning.