### PR TITLE
container: fix introduction for node_hash_set.h

### DIFF
--- a/absl/container/node_hash_set.h
+++ b/absl/container/node_hash_set.h
@@ -76,13 +76,13 @@ struct NodeHashSetPolicy;
 // Example:
 //
 //   // Create a node hash set of three strings
-//   absl::node_hash_map<std::string, std::string> ducks =
+//   absl::node_hash_set<std::string> ducks =
 //     {"huey", "dewey", "louie"};
 //
-//  // Insert a new element into the node hash map
-//  ducks.insert("donald"};
+//  // Insert a new element into the node hash set
+//  ducks.insert("donald");
 //
-//  // Force a rehash of the node hash map
+//  // Force a rehash of the node hash set
 //  ducks.rehash(0);
 //
 //  // See if "dewey" is present


### PR DESCRIPTION
container: fix introduction for node_hash_set.h

Fixed the wrong comment description "node_hash_map" to "node_hash_set"