### PR TITLE
Call FailureSignalHandlerOptions.writenfn with nullptr at the end

### DIFF
--- a/absl/debugging/failure_signal_handler.cc
+++ b/absl/debugging/failure_signal_handler.cc
@@ -366,6 +366,7 @@ static void AbslFailureSignalHandler(int signo, siginfo_t*, void* ucontext) {
   // goes after this point.
   if (fsh_options.writerfn != nullptr) {
     WriteFailureInfo(signo, ucontext, my_cpu, fsh_options.writerfn);
+    fsh_options.writerfn(nullptr);
   }
 
   if (fsh_options.call_previous_handler) {

--- a/absl/debugging/failure_signal_handler.h
+++ b/absl/debugging/failure_signal_handler.h
@@ -90,7 +90,7 @@ struct FailureSignalHandlerOptions {
   // If non-null, indicates a pointer to a callback function that will be called
   // upon failure, with a string argument containing failure data. This function
   // may be used as a hook to write failure data to a secondary location, such
-  // as a log file. This function will be called null data, as a hint
+  // as a log file. This function will also be called with null data, as a hint
   // to flush any buffered data before the program may be terminated. Consider
   // flushing any buffered data in all calls to this function.
   //

--- a/absl/debugging/failure_signal_handler.h
+++ b/absl/debugging/failure_signal_handler.h
@@ -90,7 +90,7 @@ struct FailureSignalHandlerOptions {
   // If non-null, indicates a pointer to a callback function that will be called
   // upon failure, with a string argument containing failure data. This function
   // may be used as a hook to write failure data to a secondary location, such
-  // as a log file. This function may also be called with null data, as a hint
+  // as a log file. This function will be called null data, as a hint
   // to flush any buffered data before the program may be terminated. Consider
   // flushing any buffered data in all calls to this function.
   //


### PR DESCRIPTION
This behavior has already been alluded to in the document, but it hasn't been
implemented.

This PR calls changes the failure signal handler to call writerfn(nullptr) at
the end of the message block. It also clarifies the documentation.

https://github.com/abseil/abseil-cpp/issues/933