### PR TITLE
Avoid directly accessing allocator members

### DIFF
--- a/absl/memory/memory.h
+++ b/absl/memory/memory.h
@@ -352,7 +352,7 @@ struct RebindAlloc {
 
 template <typename T, typename U>
 struct RebindAlloc<T, U, true> {
-  using type = typename T::template rebind<U>::other;
+  using type = typename std::allocator_traits<T>::template rebind_alloc<U>;
 };
 
 }  // namespace memory_internal
@@ -575,8 +575,8 @@ struct allocator_traits {
   template <typename A, typename... Args>
   static auto construct_impl(int, A& a,  // NOLINT(runtime/references)
                              Args&&... args)
-      -> decltype(a.construct(std::forward<Args>(args)...)) {
-    a.construct(std::forward<Args>(args)...);
+      -> decltype(std::allocator_traits<A>::construct(a, std::forward<Args>(args)...)) {
+    std::allocator_traits<A>::construct(a, std::forward<Args>(args)...);
   }
 
   template <typename T, typename... Args>
@@ -586,8 +586,9 @@ struct allocator_traits {
 
   template <typename A, typename T>
   static auto destroy_impl(int, A& a,  // NOLINT(runtime/references)
-                           T* p) -> decltype(a.destroy(p)) {
-    a.destroy(p);
+                           T* p)
+       -> decltype(std::allocator_traits<A>::destroy(a, p)) {
+    std::allocator_traits<A>::destroy(a, p);
   }
   template <typename T>
   static void destroy_impl(char, Alloc&, T* p) {


### PR DESCRIPTION
C++11 introduced allocator_traits and since C++17 some allocator members have been deprecated.

These few lines produced thousands of lines of warnings and explanations on MSVC when compiled with `/std:c++17`.