### PR TITLE
Fix MSVC compiler error when address sanitizers are enabled

### DIFF
--- a/absl/base/dynamic_annotations.h
+++ b/absl/base/dynamic_annotations.h
@@ -471,7 +471,7 @@ using absl::base_internal::ValgrindSlowdown;
   __sanitizer_annotate_contiguous_container(beg, end, old_mid, new_mid)
 #define ABSL_ADDRESS_SANITIZER_REDZONE(name) \
   struct {                                   \
-    char x[8] __attribute__((aligned(8)));   \
+    alignas(8) char x[8];                    \
   } name
 
 #else


### PR DESCRIPTION
The `ABSL_ADDRESS_SANITIZER_REDZONE` macro specifies the alignment of the `name` struct with a non-portable alignment attribute. When address sanitizers on MSVC are enabled, compiles will fail on this line as a result. Since `alignas` has been supported since C++11, I believe this should be a straightforward substitution.