### PR TITLE
Use CMAKE_INSTALL_FULL_{LIBDIR,INCLUDEDIR}.

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -171,8 +171,8 @@ function(absl_cc_library)
       FILE(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/lib/pkgconfig/absl_${_NAME}.pc" CONTENT "\
 prefix=${CMAKE_INSTALL_PREFIX}\n\
 exec_prefix=\${prefix}\n\
-libdir=\${prefix}/${CMAKE_INSTALL_LIBDIR}\n\
-includedir=\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}\n\
+libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n\
+includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}\n\
 \n\
 Name: absl_${_NAME}\n\
 Description: Abseil ${_NAME} library\n\


### PR DESCRIPTION
The `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` variable do not need to be relative paths.  If they are absolute, then the concatenation `${prefix}/${CMAKE_INSTALL_LIBDIR}` is incorrect.  (This is the case on NixOS.)

This PR replaces this concatenation with `${CMAKE_INSTALL_FULL_LIBDIR}`, which always refers to an absolute path.  https://github.com/jtojnar/cmake-snips#assuming-cmake_install_dir-is-relative-path