### PR TITLE
bugfix #953 CMake: add option to use Google Test already installed on system

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -336,8 +336,8 @@ endfunction()
 #     "awesome_test.cc"
 #   DEPS
 #     absl::awesome
-#     gmock
-#     gtest_main
+#     GTest::gmock
+#     GTest::gtest_main
 # )
 function(absl_cc_test)
   if(NOT BUILD_TESTING)

--- a/CMake/README.md
+++ b/CMake/README.md
@@ -99,3 +99,48 @@ absl::synchronization
 absl::time
 absl::utility
 ```
+
+## Traditional CMake Set-Up
+
+For larger projects, it may make sense to use the traditional CMake set-up where you build and install projects separately.
+
+First, you'd need to build and install Google Test:
+```
+cmake -S /source/googletest -B /build/googletest -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/installation/dir -DBUILD_GMOCK=ON
+cmake --build /build/googletest --target install
+```
+
+Then you need to configure and build Abseil. Make sure you enable `ABSL_USE_EXTERNAL_GOOGLETEST` and `ABSL_FIND_GOOGLETEST`. You also need to enable `ABSL_ENABLE_INSTALL` so that you can install Abseil itself.
+```
+cmake -S /source/abseil-cpp -B /build/abseil-cpp -DCMAKE_PREFIX_PATH=/installation/dir -DCMAKE_INSTALL_PREFIX=/installation/dir -DABSL_ENABLE_INSTALL=ON -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON
+cmake --build /temporary/build/abseil-cpp
+```
+
+(`CMAKE_PREFIX_PATH` is where you already have Google Test installed; `CMAKE_INSTALL_PREFIX` is where you want to have Abseil installed; they can be different.)
+
+Run the tests:
+```
+ctest --test-dir /temporary/build/abseil-cpp
+```
+
+And finally install:
+```
+cmake --build /temporary/build/abseil-cpp --target install
+```
+
+# CMake Option Synposis
+
+## Enable Standard CMake Installation
+
+`-DABSL_ENABLE_INSTALL=ON`
+
+## Google Test Options
+
+`-DBUILD_TESTING=ON` must be set to enable testing
+
+- Have Abseil download and build Google Test for you: `-DABSL_USE_EXTERNAL_GOOGLETEST=OFF` (default)
+  - Download and build latest Google Test: `-DABSL_USE_GOOGLETEST_HEAD=ON`
+  - Download specific Google Test version (ZIP archive): `-DABSL_GOOGLETEST_DOWNLOAD_URL=https://.../version.zip`
+  - Use Google Test from specific local directory: `-DABSL_LOCAL_GOOGLETEST_DIR=/path/to/googletest`
+- Use Google Test included elsewhere in your project: `-DABSL_USE_EXTERNAL_GOOGLETEST=ON`
+- Use standard CMake `find_package(CTest)` to find installed Google Test: `-DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,17 @@ endif()
 ## pthread
 find_package(Threads REQUIRED)
 
+include(CMakeDependentOption)
+
 option(ABSL_USE_EXTERNAL_GOOGLETEST
   "If ON, Abseil will assume that the targets for GoogleTest are already provided by the including project. This makes sense when Abseil is used with add_subproject." OFF)
+
+cmake_dependent_option(ABSL_FIND_GOOGLETEST
+  "If ON, Abseil will use find_package(GTest) rather than assuming that GoogleTest is already provided by the including project."
+  ON
+  "ABSL_USE_EXTERNAL_GOOGLETEST"
+  OFF)
+
 
 option(ABSL_USE_GOOGLETEST_HEAD
   "If ON, abseil will download HEAD from GoogleTest at config time." OFF)
@@ -116,7 +125,15 @@ set(ABSL_LOCAL_GOOGLETEST_DIR "/usr/src/googletest" CACHE PATH
 
 if(BUILD_TESTING)
   ## check targets
-  if (NOT ABSL_USE_EXTERNAL_GOOGLETEST)
+  if (ABSL_USE_EXTERNAL_GOOGLETEST)
+    if (ABSL_FIND_GOOGLETEST)
+      find_package(GTest REQUIRED)
+    else()
+      if (NOT TARGET gtest AND NOT TARGET GTest::gtest)
+        message(FATAL_ERROR "ABSL_USE_EXTERNAL_GOOGLETEST is ON and ABSL_FIND_GOOGLETEST is OFF, which means that the top-level project must build the Google Test project. However, the target gtest was not found.")
+      endif()
+    endif()
+  else()
     set(absl_gtest_build_dir ${CMAKE_BINARY_DIR}/googletest-build)
     if(ABSL_USE_GOOGLETEST_HEAD AND ABSL_GOOGLETEST_DOWNLOAD_URL)
       message(FATAL_ERROR "Do not set both ABSL_USE_GOOGLETEST_HEAD and ABSL_GOOGLETEST_DOWNLOAD_URL")
@@ -134,14 +151,22 @@ if(BUILD_TESTING)
     include(CMake/Googletest/DownloadGTest.cmake)
   endif()
 
-  check_target(gtest)
-  check_target(gtest_main)
-  check_target(gmock)
+  if (NOT ABSL_FIND_GOOGLETEST)
+    # When Google Test is included directly rather than through find_package, the aliases are missing.
+    add_library(GTest::gtest_main ALIAS gtest_main)
+    add_library(GTest::gtest ALIAS gtest)
+    add_library(GTest::gmock ALIAS gmock)
+  endif()
+
+  check_target(GTest::gtest)
+  check_target(GTest::gtest_main)
+  check_target(GTest::gmock)
+  check_target(GTest::gmock_main)
 
   list(APPEND ABSL_TEST_COMMON_LIBRARIES
-    gtest_main
-    gtest
-    gmock
+    GTest::gtest_main
+    GTest::gtest
+    GTest::gmock
     ${CMAKE_THREAD_LIBS_INIT}
   )
 endif()

--- a/absl/algorithm/CMakeLists.txt
+++ b/absl/algorithm/CMakeLists.txt
@@ -35,7 +35,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::algorithm
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -65,5 +65,5 @@ absl_cc_test(
     absl::core_headers
     absl::memory
     absl::span
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -230,7 +230,7 @@ absl_cc_library(
     ${ABSL_DEFAULT_COPTS}
   DEPS
     absl::config
-    gtest
+    GTest::gtest
   TESTONLY
 )
 
@@ -259,7 +259,7 @@ absl_cc_library(
     absl::meta
     absl::strings
     absl::utility
-    gtest
+    GTest::gtest
   TESTONLY
 )
 
@@ -273,7 +273,7 @@ absl_cc_test(
   DEPS
     absl::exception_safety_testing
     absl::memory
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -300,8 +300,8 @@ absl_cc_test(
     absl::atomic_hook_test_helper
     absl::atomic_hook
     absl::core_headers
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -314,7 +314,7 @@ absl_cc_test(
   DEPS
     absl::base
     absl::core_headers
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -327,8 +327,8 @@ absl_cc_test(
   DEPS
     absl::errno_saver
     absl::strerror
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -342,7 +342,7 @@ absl_cc_test(
     absl::base
     absl::config
     absl::throw_delegate
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -357,7 +357,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::base_internal
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -371,8 +371,8 @@ absl_cc_test(
     absl::base_internal
     absl::memory
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -388,7 +388,7 @@ absl_cc_library(
     absl::base_internal
     absl::core_headers
     absl::synchronization
-    gtest
+    GTest::gtest
   TESTONLY
 )
 
@@ -406,7 +406,7 @@ absl_cc_test(
     absl::config
     absl::core_headers
     absl::synchronization
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -435,7 +435,7 @@ absl_cc_test(
     absl::base
     absl::config
     absl::endian
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -448,7 +448,7 @@ absl_cc_test(
   DEPS
     absl::config
     absl::synchronization
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -462,7 +462,7 @@ absl_cc_test(
     absl::base
     absl::core_headers
     absl::synchronization
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -475,7 +475,7 @@ absl_cc_test(
   DEPS
     absl::raw_logging_internal
     absl::strings
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -488,7 +488,7 @@ absl_cc_test(
   DEPS
     absl::base
     absl::synchronization
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -516,7 +516,7 @@ absl_cc_test(
     absl::core_headers
     absl::synchronization
     Threads::Threads
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -543,7 +543,7 @@ absl_cc_test(
   DEPS
     absl::exponential_biased
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -570,7 +570,7 @@ absl_cc_test(
   DEPS
     absl::core_headers
     absl::periodic_sampler
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -596,7 +596,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::scoped_set_env
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -620,8 +620,8 @@ absl_cc_test(
     absl::flags_marshalling
     absl::log_severity
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -651,8 +651,8 @@ absl_cc_test(
   DEPS
     absl::strerror
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -677,7 +677,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::fast_type_id
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -690,5 +690,5 @@ absl_cc_test(
   DEPS
     absl::core_headers
     absl::optional
-    gtest_main
+    GTest::gtest_main
 )

--- a/absl/cleanup/CMakeLists.txt
+++ b/absl/cleanup/CMakeLists.txt
@@ -51,5 +51,5 @@ absl_cc_test(
     absl::cleanup
     absl::config
     absl::utility
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -80,7 +80,7 @@ absl_cc_test(
     absl::strings
     absl::test_instance_tracker
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -109,7 +109,7 @@ absl_cc_test(
     absl::optional
     absl::test_instance_tracker
     absl::utility
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -144,7 +144,7 @@ absl_cc_test(
     absl::exception_testing
     absl::hash_testing
     absl::memory
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -158,7 +158,7 @@ absl_cc_test(
     absl::fixed_array
     absl::config
     absl::exception_safety_testing
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -222,7 +222,7 @@ absl_cc_test(
     absl::memory
     absl::raw_logging_internal
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -236,7 +236,7 @@ absl_cc_test(
     absl::inlined_vector
     absl::config
     absl::exception_safety_testing
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -262,7 +262,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::test_instance_tracker
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -297,7 +297,7 @@ absl_cc_test(
     absl::unordered_map_modifiers_test
     absl::any
     absl::raw_logging_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -335,7 +335,7 @@ absl_cc_test(
     absl::memory
     absl::raw_logging_internal
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -370,7 +370,7 @@ absl_cc_test(
     absl::unordered_map_lookup_test
     absl::unordered_map_members_test
     absl::unordered_map_modifiers_test
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -404,7 +404,7 @@ absl_cc_test(
     absl::unordered_set_lookup_test
     absl::unordered_set_members_test
     absl::unordered_set_modifiers_test
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -433,7 +433,7 @@ absl_cc_test(
     absl::container_memory
     absl::strings
     absl::test_instance_tracker
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -465,7 +465,7 @@ absl_cc_test(
     absl::hash
     absl::random_random
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -507,7 +507,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::hash_policy_testing
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -531,7 +531,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::hash_policy_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -561,7 +561,7 @@ absl_cc_test(
   DEPS
     absl::hashtablez_sampler
     absl::have_sse
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -618,7 +618,7 @@ absl_cc_test(
   DEPS
     absl::hash_policy_traits
     absl::node_hash_policy
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -693,7 +693,7 @@ absl_cc_test(
     absl::core_headers
     absl::raw_logging_internal
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -707,7 +707,7 @@ absl_cc_test(
     absl::raw_hash_set
     absl::tracked
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -740,7 +740,7 @@ absl_cc_test(
     absl::core_headers
     absl::raw_logging_internal
     absl::span
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -765,7 +765,7 @@ absl_cc_library(
   DEPS
     absl::hash_generator_testing
     absl::hash_policy_testing
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -779,7 +779,7 @@ absl_cc_library(
   DEPS
     absl::hash_generator_testing
     absl::hash_policy_testing
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -792,7 +792,7 @@ absl_cc_library(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::type_traits
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -806,7 +806,7 @@ absl_cc_library(
   DEPS
     absl::hash_generator_testing
     absl::hash_policy_testing
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -820,7 +820,7 @@ absl_cc_library(
   DEPS
     absl::hash_generator_testing
     absl::hash_policy_testing
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -834,7 +834,7 @@ absl_cc_library(
   DEPS
     absl::hash_generator_testing
     absl::hash_policy_testing
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -847,7 +847,7 @@ absl_cc_library(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::type_traits
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -861,7 +861,7 @@ absl_cc_library(
   DEPS
     absl::hash_generator_testing
     absl::hash_policy_testing
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -877,7 +877,7 @@ absl_cc_test(
     absl::unordered_set_lookup_test
     absl::unordered_set_members_test
     absl::unordered_set_modifiers_test
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -892,5 +892,5 @@ absl_cc_test(
     absl::unordered_map_lookup_test
     absl::unordered_map_members_test
     absl::unordered_map_modifiers_test
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -87,7 +87,7 @@ absl_cc_test(
     absl::memory
     absl::raw_logging_internal
     absl::strings
-    gmock
+    GTest::gmock
 )
 
 absl_cc_library(
@@ -141,7 +141,7 @@ absl_cc_test(
     absl::strings
     absl::raw_logging_internal
     Threads::Threads
-    gmock
+    GTest::gmock
 )
 
 absl_cc_library(
@@ -194,7 +194,7 @@ absl_cc_test(
     absl::core_headers
     absl::memory
     absl::raw_logging_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -261,7 +261,7 @@ absl_cc_test(
   DEPS
     absl::leak_check_api_enabled_for_testing
     absl::base
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -275,7 +275,7 @@ absl_cc_test(
   DEPS
     absl::leak_check_api_disabled_for_testing
     absl::base
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -292,7 +292,7 @@ absl_cc_test(
     absl::leak_check_disable
     absl::base
     absl::raw_logging_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -322,7 +322,7 @@ absl_cc_test(
     absl::stack_consumption
     absl::core_headers
     absl::raw_logging_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 # component target

--- a/absl/flags/CMakeLists.txt
+++ b/absl/flags/CMakeLists.txt
@@ -310,7 +310,7 @@ absl_cc_test(
     absl::flags_reflection
     absl::memory
     absl::strings
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -322,7 +322,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::flags_config
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -342,7 +342,7 @@ absl_cc_test(
     absl::flags_reflection
     absl::strings
     absl::time
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -354,7 +354,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::flags_marshalling
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -373,7 +373,7 @@ absl_cc_test(
     absl::scoped_set_env
     absl::span
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -385,7 +385,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::flags_path_util
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -398,7 +398,7 @@ absl_cc_test(
   DEPS
     absl::flags_program_name
     absl::strings
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -415,7 +415,7 @@ absl_cc_test(
     absl::flags_usage
     absl::memory
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -429,7 +429,7 @@ absl_cc_test(
     absl::base
     absl::flags_internal
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -444,7 +444,7 @@ absl_cc_test(
     absl::flags_path_util
     absl::flags_program_name
     absl::strings
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -463,5 +463,5 @@ absl_cc_test(
     absl::flags_reflection
     absl::flags_usage
     absl::strings
-    gtest
+    GTest::gtest
 )

--- a/absl/functional/CMakeLists.txt
+++ b/absl/functional/CMakeLists.txt
@@ -39,7 +39,7 @@ absl_cc_test(
   DEPS
     absl::bind_front
     absl::memory
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -68,5 +68,5 @@ absl_cc_test(
     absl::function_ref
     absl::memory
     absl::test_instance_tracker
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/hash/CMakeLists.txt
+++ b/absl/hash/CMakeLists.txt
@@ -52,7 +52,7 @@ absl_cc_library(
     absl::meta
     absl::strings
     absl::variant
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -72,7 +72,7 @@ absl_cc_test(
     absl::spy_hash_state
     absl::meta
     absl::int128
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -113,7 +113,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::city
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -141,5 +141,5 @@ absl_cc_test(
   DEPS
     absl::wyhash
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/memory/CMakeLists.txt
+++ b/absl/memory/CMakeLists.txt
@@ -37,7 +37,7 @@ absl_cc_test(
   DEPS
     absl::memory
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -51,5 +51,5 @@ absl_cc_test(
     absl::memory
     absl::config
     absl::exception_safety_testing
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/meta/CMakeLists.txt
+++ b/absl/meta/CMakeLists.txt
@@ -35,7 +35,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 # component target

--- a/absl/numeric/CMakeLists.txt
+++ b/absl/numeric/CMakeLists.txt
@@ -38,7 +38,7 @@ absl_cc_test(
     absl::bits
     absl::core_headers
     absl::random_random
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -73,7 +73,7 @@ absl_cc_test(
     absl::core_headers
     absl::hash_testing
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 # component target

--- a/absl/random/CMakeLists.txt
+++ b/absl/random/CMakeLists.txt
@@ -62,8 +62,8 @@ absl_cc_test(
     absl::random_random
     absl::random_internal_sequence_urbg
     absl::fast_type_id
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -119,8 +119,8 @@ absl_cc_library(
     absl::type_traits
     absl::utility
     absl::variant
-    gmock
-    gtest
+    GTest::gmock
+    GTest::gtest
   TESTONLY
 )
 
@@ -136,8 +136,8 @@ absl_cc_test(
   DEPS
     absl::random_mocking_bit_gen
     absl::random_random
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -153,8 +153,8 @@ absl_cc_test(
     absl::random_bit_gen_ref
     absl::random_mocking_bit_gen
     absl::random_random
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_library(
@@ -245,8 +245,8 @@ absl_cc_test(
     absl::random_random
     absl::random_internal_sequence_urbg
     absl::random_internal_pcg_engine
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -268,8 +268,8 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::str_format
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -285,8 +285,8 @@ absl_cc_test(
     absl::random_distributions
     absl::random_random
     absl::random_internal_distribution_test_util
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -301,8 +301,8 @@ absl_cc_test(
     absl::random_distributions
     absl::random_random
     absl::raw_logging_internal
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -322,8 +322,8 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::str_format
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -343,8 +343,8 @@ absl_cc_test(
     absl::random_random
     absl::raw_logging_internal
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -367,8 +367,8 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::str_format
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -391,8 +391,8 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::str_format
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -414,8 +414,8 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::str_format
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -435,8 +435,8 @@ absl_cc_test(
     absl::random_random
     absl::raw_logging_internal
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -456,8 +456,8 @@ absl_cc_test(
     absl::random_internal_sequence_urbg
     absl::random_random
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -477,8 +477,8 @@ absl_cc_test(
     absl::random_random
     absl::raw_logging_internal
     absl::strings
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -492,7 +492,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_random
-    gtest_main
+    GTest::gtest_main
 )
 
 absl_cc_test(
@@ -508,8 +508,8 @@ absl_cc_test(
     absl::random_seed_sequences
     absl::random_internal_nonsecure_base
     absl::random_random
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -894,7 +894,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_traits
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -911,7 +911,7 @@ absl_cc_test(
     absl::bits
     absl::flags
     absl::random_internal_generate_real
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -926,7 +926,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_distribution_test_util
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -941,7 +941,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_fastmath
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -957,8 +957,8 @@ absl_cc_test(
   DEPS
     absl::random_internal_explicit_seed_seq
     absl::random_seed_sequences
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -973,8 +973,8 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_salted_seed_seq
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -990,7 +990,7 @@ absl_cc_test(
   DEPS
     absl::core_headers
     absl::random_internal_distribution_test_util
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1005,7 +1005,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_fast_uniform_bits
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1024,7 +1024,7 @@ absl_cc_test(
     absl::random_distributions
     absl::random_seed_sequences
     absl::strings
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1039,8 +1039,8 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_seed_material
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1057,7 +1057,7 @@ absl_cc_test(
     absl::random_internal_pool_urbg
     absl::span
     absl::type_traits
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1074,8 +1074,8 @@ absl_cc_test(
     absl::random_internal_explicit_seed_seq
     absl::random_internal_pcg_engine
     absl::time
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1094,8 +1094,8 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::time
-    gmock
-    gtest_main
+    GTest::gmock
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1111,7 +1111,7 @@ absl_cc_test(
   DEPS
     absl::random_internal_randen
     absl::type_traits
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1127,7 +1127,7 @@ absl_cc_test(
   DEPS
     absl::endian
     absl::random_internal_randen_slow
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1146,8 +1146,8 @@ absl_cc_test(
     absl::random_internal_randen_hwaes_impl
     absl::raw_logging_internal
     absl::str_format
-    gmock
-    gtest
+    GTest::gmock
+    GTest::gtest
 )
 
 # Internal-only target, do not depend on directly.
@@ -1178,7 +1178,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_uniform_helper
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1193,7 +1193,7 @@ absl_cc_test(
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
     absl::random_internal_iostream_state_saver
-    gtest_main
+    GTest::gtest_main
 )
 
 # Internal-only target, do not depend on directly.
@@ -1210,5 +1210,5 @@ absl_cc_test(
     absl::random_internal_wide_multiply
     absl::bits
     absl::int128
-    gtest_main
+    GTest::gtest_main
 )

--- a/absl/status/CMakeLists.txt
+++ b/absl/status/CMakeLists.txt
@@ -50,7 +50,7 @@ absl_cc_test(
   DEPS
     absl::status
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -84,5 +84,5 @@ absl_cc_test(
   DEPS
     absl::status
     absl::statusor
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -101,7 +101,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::base
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -115,7 +115,7 @@ absl_cc_test(
     absl::strings
     absl::core_headers
     absl::fixed_array
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -128,7 +128,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -142,7 +142,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -156,7 +156,7 @@ absl_cc_test(
     absl::strings_internal
     absl::base
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -169,7 +169,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -184,7 +184,7 @@ absl_cc_test(
     absl::config
     absl::core_headers
     absl::dynamic_annotations
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -197,7 +197,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -209,7 +209,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -226,7 +226,7 @@ absl_cc_test(
     absl::btree
     absl::flat_hash_map
     absl::node_hash_map
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -238,7 +238,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::strings_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -253,7 +253,7 @@ absl_cc_test(
     absl::base
     absl::core_headers
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -268,7 +268,7 @@ absl_cc_test(
     absl::base
     absl::core_headers
     absl::memory
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -281,7 +281,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -301,7 +301,7 @@ absl_cc_test(
     absl::random_random
     absl::random_distributions
     absl::strings_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -314,7 +314,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::base
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -326,7 +326,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::strings_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -340,7 +340,7 @@ absl_cc_test(
     absl::strings
     absl::str_format
     absl::pow10_helper
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -355,7 +355,7 @@ absl_cc_test(
     absl::strings
     absl::config
     absl::raw_logging_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -370,7 +370,7 @@ absl_cc_test(
   DEPS
     absl::strings
     absl::config
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -428,7 +428,7 @@ absl_cc_test(
     absl::cord
     absl::strings
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -442,7 +442,7 @@ absl_cc_test(
     absl::str_format
     absl::str_format_internal
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -455,7 +455,7 @@ absl_cc_test(
   DEPS
     absl::str_format
     absl::str_format_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -467,7 +467,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::str_format_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -479,7 +479,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::str_format
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -494,7 +494,7 @@ absl_cc_test(
     absl::str_format_internal
     absl::raw_logging_internal
     absl::int128
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -507,7 +507,7 @@ absl_cc_test(
   DEPS
     absl::str_format_internal
     absl::cord
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -520,7 +520,7 @@ absl_cc_test(
   DEPS
     absl::str_format_internal
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -547,7 +547,7 @@ absl_cc_test(
   DEPS
     absl::pow10_helper
     absl::str_format
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -600,7 +600,7 @@ absl_cc_test(
     absl::cordz_update_tracker
     absl::core_headers
     absl::synchronization
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -628,7 +628,7 @@ absl_cc_test(
     absl::config
     absl::cordz_functions
     absl::cordz_test_helpers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -675,7 +675,7 @@ absl_cc_test(
     absl::random_distributions
     absl::synchronization
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -722,7 +722,7 @@ absl_cc_test(
     absl::span
     absl::stacktrace
     absl::symbolize
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -742,7 +742,7 @@ absl_cc_test(
     absl::cordz_update_scope
     absl::cordz_update_tracker
     absl::thread_pool
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -780,7 +780,7 @@ absl_cc_test(
     absl::synchronization
     absl::thread_pool
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -813,7 +813,7 @@ absl_cc_test(
     absl::cordz_update_scope
     absl::cordz_update_tracker
     absl::core_headers
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -899,7 +899,7 @@ absl_cc_test(
     absl::endian
     absl::raw_logging_internal
     absl::fixed_array
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -916,7 +916,7 @@ absl_cc_test(
     absl::core_headers
     absl::raw_logging_internal
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -931,7 +931,7 @@ absl_cc_test(
     absl::cord_internal
     absl::core_headers
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -955,5 +955,5 @@ absl_cc_test(
     absl::core_headers
     absl::raw_logging_internal
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/synchronization/CMakeLists.txt
+++ b/absl/synchronization/CMakeLists.txt
@@ -95,7 +95,7 @@ absl_cc_test(
   DEPS
     absl::synchronization
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -108,7 +108,7 @@ absl_cc_test(
   DEPS
     absl::synchronization
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -122,7 +122,7 @@ absl_cc_test(
     absl::graphcycles_internal
     absl::core_headers
     absl::raw_logging_internal
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -154,7 +154,7 @@ absl_cc_test(
     absl::memory
     absl::raw_logging_internal
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -167,7 +167,7 @@ absl_cc_test(
   DEPS
     absl::synchronization
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -183,7 +183,7 @@ absl_cc_library(
     absl::config
     absl::strings
     absl::time
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -199,7 +199,7 @@ absl_cc_test(
     absl::synchronization
     absl::strings
     absl::time
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(

--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -102,7 +102,7 @@ absl_cc_library(
     absl::config
     absl::raw_logging_internal
     absl::time_zone
-    gmock
+    GTest::gmock
   TESTONLY
 )
 
@@ -124,5 +124,5 @@ absl_cc_test(
     absl::config
     absl::core_headers
     absl::time_zone
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/types/CMakeLists.txt
+++ b/absl/types/CMakeLists.txt
@@ -69,7 +69,7 @@ absl_cc_test(
     absl::exception_testing
     absl::raw_logging_internal
     absl::test_instance_tracker
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -85,7 +85,7 @@ absl_cc_test(
     absl::exception_testing
     absl::raw_logging_internal
     absl::test_instance_tracker
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -99,7 +99,7 @@ absl_cc_test(
     absl::any
     absl::config
     absl::exception_safety_testing
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -136,7 +136,7 @@ absl_cc_test(
     absl::inlined_vector
     absl::hash_testing
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -156,7 +156,7 @@ absl_cc_test(
     absl::inlined_vector
     absl::hash_testing
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -222,7 +222,7 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -236,7 +236,7 @@ absl_cc_test(
     absl::optional
     absl::config
     absl::exception_safety_testing
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -258,7 +258,7 @@ absl_cc_library(
     absl::type_traits
     absl::strings
     absl::utility
-    gmock_main
+    GTest::gmock_main
   TESTONLY
 )
 
@@ -275,7 +275,7 @@ absl_cc_test(
   DEPS
     absl::conformance_testing
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -288,7 +288,7 @@ absl_cc_test(
   DEPS
     absl::conformance_testing
     absl::type_traits
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -324,7 +324,7 @@ absl_cc_test(
     absl::memory
     absl::type_traits
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_library(
@@ -350,7 +350,7 @@ absl_cc_test(
   DEPS
     absl::base
     absl::compare
-    gmock_main
+    GTest::gmock_main
 )
 
 absl_cc_test(
@@ -365,5 +365,5 @@ absl_cc_test(
     absl::config
     absl::exception_safety_testing
     absl::memory
-    gmock_main
+    GTest::gmock_main
 )

--- a/absl/utility/CMakeLists.txt
+++ b/absl/utility/CMakeLists.txt
@@ -40,5 +40,5 @@ absl_cc_test(
     absl::core_headers
     absl::memory
     absl::strings
-    gmock_main
+    GTest::gmock_main
 )


### PR DESCRIPTION
At the moment, if you don't build Google Test as part of your project, the build fails with the following error:

```
CMake Error at CMake/AbseilHelpers.cmake:401 (message):
   ABSL: compiling absl requires a gtest CMake target in your project,
                     see CMake/README.md for more details
Call Stack (most recent call first):
  CMakeLists.txt:132 (check_target)
```

As of this change, you can use `-DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON` to have Abseil use the standard CMake find_package(GTest) mechanism.