### PR TITLE
Fix Bazel build on aarch64

### DIFF
--- a/absl/copts/configure_copts.bzl
+++ b/absl/copts/configure_copts.bzl
@@ -72,7 +72,6 @@ def absl_random_randen_copts_init():
         "x64_windows_msvc",
         "x64_windows",
         "aarch64",
-        
     ]
     for cpu in cpu_configs:
         native.config_setting(

--- a/absl/copts/configure_copts.bzl
+++ b/absl/copts/configure_copts.bzl
@@ -50,6 +50,7 @@ ABSL_RANDOM_RANDEN_COPTS = select({
     ":cpu_x64_windows": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
     ":cpu_k8": ABSL_RANDOM_HWAES_X64_FLAGS,
     ":cpu_ppc": ["-mcrypto"],
+    ":cpu_aarch64": ABSL_RANDOM_HWAES_ARM64_FLAGS,
 
     # Supported by default or unsupported.
     "//conditions:default": [],
@@ -70,6 +71,8 @@ def absl_random_randen_copts_init():
         "darwin",
         "x64_windows_msvc",
         "x64_windows",
+        "aarch64",
+        
     ]
     for cpu in cpu_configs:
         native.config_setting(


### PR DESCRIPTION
The solution of #982 and #662.


 * Device: NVIDIA Jetson Xavier NX
 * OS: Ubuntu 18.04
 * CPU: 6-core NVIDIA Carmel ARM®v8.2 64-bit


## BEFORE:
```
DEBUG: Rule 'com_google_absl' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "aabf6c57e3834f8dc3873a927f37eaf69975d4b28117fc7427dfb1c661542a87"
DEBUG: Repository com_google_absl instantiated at:
  /home/ubuntu/Projects/my_workspace/WORKSPACE:3:13: in <toplevel>
Repository rule http_archive defined at:
  /home/ubuntu/.cache/bazel/_bazel_ubuntu/b8008d82eb65899d4e39675de40d6cec/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
INFO: Analyzed target //example:hello_world (7 packages loaded, 98 targets configured).
INFO: Found 1 target...
ERROR: /home/ubuntu/.cache/bazel/_bazel_ubuntu/b8008d82eb65899d4e39675de40d6cec/external/com_google_absl/absl/random/internal/BUILD.bazel:331:11: C++ compilation of rule '@com_google_absl//absl/random/internal:randen_hwaes_impl' failed (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 31 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 31 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
In file included from external/com_google_absl/absl/random/internal/randen_hwaes.cc:225:0:
/usr/lib/gcc/aarch64-linux-gnu/7/include/arm_neon.h: In function 'Vector128 {anonymous}::AesRound(const Vector128&, const Vector128&)':
/usr/lib/gcc/aarch64-linux-gnu/7/include/arm_neon.h:12440:1: error: inlining failed in call to always_inline 'uint8x16_t vaesmcq_u8(uint8x16_t)': target specific option mismatch
 vaesmcq_u8 (uint8x16_t data)
 ^~~~~~~~~~
external/com_google_absl/absl/random/internal/randen_hwaes.cc:251:20: note: called from here
   return vaesmcq_u8(vaeseq_u8(state, uint8x16_t{})) ^ round_key;
          ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from external/com_google_absl/absl/random/internal/randen_hwaes.cc:225:0:
/usr/lib/gcc/aarch64-linux-gnu/7/include/arm_neon.h:12426:1: error: inlining failed in call to always_inline 'uint8x16_t vaeseq_u8(uint8x16_t, uint8x16_t)': target specific option mismatch
 vaeseq_u8 (uint8x16_t data, uint8x16_t key)
 ^~~~~~~~~
external/com_google_absl/absl/random/internal/randen_hwaes.cc:251:20: note: called from here
   return vaesmcq_u8(vaeseq_u8(state, uint8x16_t{})) ^ round_key;
          ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: warning: unrecognized command line option '-Wno-pass-failed'
Target //example:hello_world failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 8.358s, Critical Path: 2.18s
INFO: 14 processes: 3 internal, 11 linux-sandbox.
FAILED: Build did NOT complete successfully
```

## AFTER:
```
Loading: 
Loading: 0 packages loaded
Analyzing: target //:hello_main (0 packages loaded, 0 targets configured)
INFO: Analyzed target //:hello_main (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
[0 / 1] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target //:hello_main up-to-date:
  bazel-bin/hello_main
INFO: Elapsed time: 0.250s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/hello_main a_commandline_arg
INFO: Build completed successfully, 1 total action
```