### PR TITLE
GenerateRealFromBits: sign is already set

### DIFF
--- a/absl/random/internal/generate_real.h
+++ b/absl/random/internal/generate_real.h
@@ -127,10 +127,8 @@ inline RealType GenerateRealFromBits(uint64_t bits, int exp_bias = 0) {
 
   // Construct the 32-bit or 64-bit IEEE 754 floating-point value from
   // the individual fields: sign, exp, mantissa(bits).
-  uint_type val =
-      (std::is_same<SignedTag, GeneratePositiveTag>::value ? 0u : sign) |
-      (static_cast<uint_type>(exp) << kExp) |
-      (static_cast<uint_type>(bits) & kMask);
+  uint_type val = (sign) | (static_cast<uint_type>(exp) << kExp) |
+                  (static_cast<uint_type>(bits) & kMask);
 
   // bit_cast to the output-type
   real_type result;

--- a/absl/random/internal/generate_real.h
+++ b/absl/random/internal/generate_real.h
@@ -127,7 +127,7 @@ inline RealType GenerateRealFromBits(uint64_t bits, int exp_bias = 0) {
 
   // Construct the 32-bit or 64-bit IEEE 754 floating-point value from
   // the individual fields: sign, exp, mantissa(bits).
-  uint_type val = (sign) | (static_cast<uint_type>(exp) << kExp) |
+  uint_type val = sign | (static_cast<uint_type>(exp) << kExp) |
                   (static_cast<uint_type>(bits) & kMask);
 
   // bit_cast to the output-type


### PR DESCRIPTION
If `std::is_same<SignedTag, GeneratePositiveTag>::value` then `sign` is _already_ set to zero thanks to:

    uint_type sign = std::is_same<SignedTag, GenerateNegativeTag>::value
                         ? (static_cast<uint_type>(1) << (kUintBits - 1))
                         : 0; // <- here

So the check is unnecessary at the point where `val` is assigned to.