### PR TITLE
cmake: add ABSL_BUILD_TESTONLY_LIBS option (fixes #997)

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -82,7 +82,7 @@ function(absl_cc_library)
     ${ARGN}
   )
 
-  if(ABSL_CC_LIB_TESTONLY AND NOT BUILD_TESTING)
+  if(ABSL_CC_LIB_TESTONLY AND NOT (BUILD_TESTING OR ABSL_BUILD_TESTONLY_LIBS))
     return()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,10 @@ set(ABSL_LOCAL_GOOGLETEST_DIR "/usr/src/googletest" CACHE PATH
   "If ABSL_USE_GOOGLETEST_HEAD is OFF and ABSL_GOOGLETEST_URL is not set, specifies the directory of a local GoogleTest checkout."
   )
 
-if(BUILD_TESTING)
+option(ABSL_BUILD_TESTONLY_LIBS
+  "If ON, Abseil will build TESTONLY libraries even if Abseil tests are not built." OFF)
+
+if(BUILD_TESTING OR ABSL_BUILD_TESTONLY_LIBS)
   ## check targets
   if (ABSL_USE_EXTERNAL_GOOGLETEST)
     if (ABSL_FIND_GOOGLETEST)


### PR DESCRIPTION
This option is meant to enable building TESTONLY libraries without
building test executables.

An external project may depend on an Abseil TESTONLY library like
`absl::random_mocking_bit_gen`.  A TESTONLY library may provide valuable
test support classes for writing tests within that external project.

Building a TESTONLY library requires a dependency on GoogleTest.
However, there may be no need to build full-fledged Abseil tests.

The behavior of a BUILD_TESTING option is not changed, it still enables
building both TESTONLY libraries and test executables.