### PR TITLE
Add missing ABSL_DLL for a few functions

### DIFF
--- a/absl/types/bad_optional_access.h
+++ b/absl/types/bad_optional_access.h
@@ -67,7 +67,7 @@ class bad_optional_access : public std::exception {
 namespace optional_internal {
 
 // throw delegator
-[[noreturn]] void throw_bad_optional_access();
+[[noreturn]] ABSL_DLL void throw_bad_optional_access();
 
 }  // namespace optional_internal
 ABSL_NAMESPACE_END

--- a/absl/types/bad_variant_access.h
+++ b/absl/types/bad_variant_access.h
@@ -70,8 +70,8 @@ class bad_variant_access : public std::exception {
 
 namespace variant_internal {
 
-[[noreturn]] void ThrowBadVariantAccess();
-[[noreturn]] void Rethrow();
+[[noreturn]] ABSL_DLL void ThrowBadVariantAccess();
+[[noreturn]] ABSL_DLL void Rethrow();
 
 }  // namespace variant_internal
 ABSL_NAMESPACE_END


### PR DESCRIPTION
The `throw_bad_optional_access` and `ThrowBadVariantAccess` are used in a few inlined functions and should have the `ABSL_DLL` prefix, otherwise linking with `absl.dll` will fail with errors like:

```
error LNK2019: unresolved external symbol "void __cdecl absl::
optional_internal::throw_bad_optional_access(void)" (?throw_bad_optional_access@opt
ional_internal@absl@@YAXXZ) referenced in function "public: class base::TimeDelta &
 __cdecl absl::optional<class base::TimeDelta>::value(void)& " (?value@?$optional@V
TimeDelta@base@@@absl@@QEGAAAEAVTimeDelta@base@@XZ)\r\n'
```