### PR TITLE
Add -Wno-unknown-warning-option to ABSL_LLVM_FLAGS 

### DIFF
--- a/absl/copts/GENERATED_AbseilCopts.cmake
+++ b/absl/copts/GENERATED_AbseilCopts.cmake
@@ -94,6 +94,7 @@ list(APPEND ABSL_LLVM_FLAGS
     "-Wno-implicit-int-conversion"
     "-Wno-shorten-64-to-32"
     "-Wno-sign-conversion"
+    "-Wno-unknown-warning-option"
     "-DNOMINMAX"
 )
 

--- a/absl/copts/GENERATED_copts.bzl
+++ b/absl/copts/GENERATED_copts.bzl
@@ -95,6 +95,7 @@ ABSL_LLVM_FLAGS = [
     "-Wno-implicit-int-conversion",
     "-Wno-shorten-64-to-32",
     "-Wno-sign-conversion",
+    "-Wno-unknown-warning-option",
     "-DNOMINMAX",
 ]
 

--- a/absl/copts/copts.py
+++ b/absl/copts/copts.py
@@ -112,6 +112,9 @@ COPT_VARS = {
         "-Wno-implicit-int-conversion",
         "-Wno-shorten-64-to-32",
         "-Wno-sign-conversion",
+        # Disable warnings on unknown warning flags (when warning flags are
+        # unknown on older compiler versions)
+        "-Wno-unknown-warning-option",
         # Don't define min and max macros (Build on Windows using clang)
         "-DNOMINMAX",
     ],


### PR DESCRIPTION
To disable warnings on unknown warning flags on older versions of **clang**.

See #1007 for context.