### PR TITLE
Disable abseil tests if abseil is a subprojects.

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -364,7 +364,7 @@ endfunction()
 #     GTest::gtest_main
 # )
 function(absl_cc_test)
-  if(NOT BUILD_TESTING)
+  if(NOT ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR ABSL_BUILD_TESTING) AND BUILD_TESTING))
     return()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,10 @@ set(ABSL_LOCAL_GOOGLETEST_DIR "/usr/src/googletest" CACHE PATH
   "If ABSL_USE_GOOGLETEST_HEAD is OFF and ABSL_GOOGLETEST_URL is not set, specifies the directory of a local GoogleTest checkout."
   )
 
-if(BUILD_TESTING)
+option(ABSL_BUILD_TESTING
+  "If ON, abweil will build its tests even if abseil is a subproject." OFF)
+
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR ABSL_BUILD_TESTING) AND BUILD_TESTING)
   ## check targets
   if (ABSL_USE_EXTERNAL_GOOGLETEST)
     if (ABSL_FIND_GOOGLETEST)

--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -243,7 +243,7 @@ absl_cc_library(
     ${ABSL_DEFAULT_COPTS}
 )
 
-absl_cc_library(
+absl_cc_test(
   NAME
     exception_safety_testing
   HDRS
@@ -375,7 +375,7 @@ absl_cc_test(
     GTest::gtest_main
 )
 
-absl_cc_library(
+absl_cc_test(
   NAME
     spinlock_test_common
   SRCS

--- a/absl/synchronization/CMakeLists.txt
+++ b/absl/synchronization/CMakeLists.txt
@@ -170,7 +170,7 @@ absl_cc_test(
     GTest::gmock_main
 )
 
-absl_cc_library(
+absl_cc_test(
   NAME
     per_thread_sem_test_common
   SRCS

--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -102,7 +102,6 @@ absl_cc_library(
     absl::config
     absl::raw_logging_internal
     absl::time_zone
-    GTest::gmock
   TESTONLY
 )
 


### PR DESCRIPTION
If abseil is a CMAKE subproject the abseil tests are not longer build when BUILD_TESTING is on for the parent project.

If someone uses abseil as a subproject, they probably do not want abseil tests to build.
In the rare case that someone really does want to enable testing on both packages, the new option ABSL_BUILD_TESTING can be used to override.