### PR TITLE
Update from_string documentation re: whitespaces

### DIFF
--- a/absl/strings/charconv.h
+++ b/absl/strings/charconv.h
@@ -64,8 +64,9 @@ struct from_chars_result {
 // the result in `value`.
 //
 // The matching pattern format is almost the same as that of strtod(), except
-// that C locale is not respected, and an initial '+' character in the input
-// range will never be matched.
+// that (1) C locale is not respected, (2) an initial '+' character in the
+// input range will never be matched, and (3) leading whitespaces are not
+// ignored.
 //
 // If `fmt` is set, it must be one of the enumerator values of the chars_format.
 // (This is despite the fact that chars_format is a bitmask type.)  If set to


### PR DESCRIPTION
While looking into different string->float parsing libraries, I found that absl deviates from strtod in how it treats leading whitespaces. This is currently undocumented.

A [standard-conforming strtod](https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtod.html) implementation will look for

> the longest initial subsequence of the input string, starting with the first non-white-space character, that is of the expected form

absl uses the definition from `std::from_chars`, which states that

> The pattern is the expected form of the subject sequence [...], as described for strtod [...]. [1] 

The "subject sequence" is the **middle** part of strtol/strtod, excluding the leading whitespace.

As such, the implementation is correct, but the documentation could be improved. (I found a similar issue on cppreference and [added a comment](https://en.cppreference.com/w/Talk:cpp/utility/from_chars))