### PR TITLE
Fixed typo `constuct` to `construct` in 3 places.

### DIFF
--- a/absl/status/status.h
+++ b/absl/status/status.h
@@ -346,7 +346,7 @@ inline StatusToStringMode& operator^=(StatusToStringMode& lhs,
 // API developers should construct their functions to return `absl::OkStatus()`
 // upon success, or an `absl::StatusCode` upon another type of error (e.g
 // an `absl::StatusCode::kInvalidArgument` error). The API provides convenience
-// functions to constuct each status code.
+// functions to construct each status code.
 //
 // Example:
 //

--- a/absl/status/statusor.h
+++ b/absl/status/statusor.h
@@ -429,7 +429,7 @@ class StatusOr : private internal_statusor::StatusOrData<T>,
   // if `T` can be constructed from a `U`. Can accept move or copy constructors.
   //
   // This constructor is explicit if `U` is not convertible to `T`. To avoid
-  // ambiguity, this constuctor is disabled if `U` is a `StatusOr<J>`, where `J`
+  // ambiguity, this constructor is disabled if `U` is a `StatusOr<J>`, where `J`
   // is convertible to `T`.
   template <
       typename U = T,

--- a/absl/status/statusor.h
+++ b/absl/status/statusor.h
@@ -429,8 +429,8 @@ class StatusOr : private internal_statusor::StatusOrData<T>,
   // if `T` can be constructed from a `U`. Can accept move or copy constructors.
   //
   // This constructor is explicit if `U` is not convertible to `T`. To avoid
-  // ambiguity, this constructor is disabled if `U` is a `StatusOr<J>`, where `J`
-  // is convertible to `T`.
+  // ambiguity, this constructor is disabled if `U` is a `StatusOr<J>`, where
+  // `J` is convertible to `T`.
   template <
       typename U = T,
       absl::enable_if_t<

--- a/absl/strings/string_view.h
+++ b/absl/strings/string_view.h
@@ -596,7 +596,7 @@ class string_view {
   }
 
  private:
-  // The constructor from std::string delegates to this constuctor.
+  // The constructor from std::string delegates to this constructor.
   // See the comment on that constructor for the rationale.
   struct SkipCheckLengthTag {};
   string_view(const char* data, size_type len, SkipCheckLengthTag) noexcept


### PR DESCRIPTION
I keep noticing this. Fixing upstream.
(I left last Friday, so I can't fix internally.)