### PR TITLE
Fix typedef of sig_t on AIX

### DIFF
--- a/absl/time/clock_test.cc
+++ b/absl/time/clock_test.cc
@@ -18,8 +18,10 @@
 #if defined(ABSL_HAVE_ALARM)
 #include <signal.h>
 #include <unistd.h>
-#elif defined(_AIX)
+#ifdef _AIX
+// sig_t is not defined in AIX.
 typedef void (*sig_t)(int);
+#endif
 #elif defined(__linux__) || defined(__APPLE__)
 #error all known Linux and Apple targets have alarm
 #endif


### PR DESCRIPTION
`ABSL_HAVE_ALARM` is true on AIX, more info on its functionality can be found here:
https://www.ibm.com/docs/en/aix/7.2?topic=s-sigaction-sigvec-signal-subroutine

`sig_t` needs to be typedef in a separate `#if` block within the `ABSL_HAVE_ALARM` block.