### PR TITLE
Use freebsd macro definition for ElfW macro for compatibility.

### DIFF
--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -40,6 +40,10 @@
 
 #include <link.h>  // for ElfW
 
+#if defined(__FreeBSD__) && !defined(ElfW)
+#define ElfW(x) __ElfN(x)
+#endif
+
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace debugging_internal {

--- a/absl/debugging/internal/vdso_support.cc
+++ b/absl/debugging/internal/vdso_support.cc
@@ -50,6 +50,11 @@
 #define AT_SYSINFO_EHDR 33  // for crosstoolv10
 #endif
 
+#if defined(__FreeBSD__)
+using Elf64_aux_t = Elf64_Auxinfo;
+using Elf32_aux_t = Elf32_Auxinfo;
+#endif
+
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace debugging_internal {

--- a/absl/debugging/internal/vdso_support.cc
+++ b/absl/debugging/internal/vdso_support.cc
@@ -51,8 +51,8 @@
 #endif
 
 #if defined(__FreeBSD__)
-using Elf64_aux_t = Elf64_Auxinfo;
-using Elf32_aux_t = Elf32_Auxinfo;
+using Elf64_auxv_t = Elf64_Auxinfo;
+using Elf32_auxv_t = Elf32_Auxinfo;
 #endif
 
 namespace absl {

--- a/absl/debugging/symbolize_elf.inc
+++ b/absl/debugging/symbolize_elf.inc
@@ -77,6 +77,10 @@
 #include "absl/debugging/internal/vdso_support.h"
 #include "absl/strings/string_view.h"
 
+#if defined(__FreeBSD__) && !defined(ElfW)
+#define ElfW(x) __ElfN(x)
+#endif
+
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Addresses: https://github.com/abseil/abseil-cpp/issues/1024

The `ElfW()` macro was added to `elf_generic.h` recently and as such may be absent most current releases of FreeBSD.

See: https://github.com/freebsd/freebsd-src/blob/34e7e4b6a059eee5e4e3e34de5b9d5f0d6e589f9/sys/sys/elf_generic.h#L60

There are other build issues on FreeBSD. I'll address them soonish in other PRs.

@derekmauro @EmployedRussian 