### PR TITLE
Initial support for Haiku

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -413,7 +413,8 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
     defined(_AIX) || defined(__ros__) || defined(__native_client__) ||    \
     defined(__asmjs__) || defined(__wasm__) || defined(__Fuchsia__) ||    \
-    defined(__sun) || defined(__ASYLO__) || defined(__myriad2__)
+    defined(__sun) || defined(__ASYLO__) || defined(__myriad2__) ||       \
+    defined(__HAIKU__)
 #define ABSL_HAVE_MMAP 1
 #endif
 


### PR DESCRIPTION
This provides the baseline needed to build Abseil on Haiku systems.

A few projects have started using on Abseil as a dependency. This PR aims at providing initial support, more functionalities can come later as fixes and features are needed.