### PR TITLE
cmake: add ABSL_BUILD_TESTING option

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -40,7 +40,8 @@ endif()
 # LINKOPTS: List of link options
 # PUBLIC: Add this so that this library will be exported under absl::
 # Also in IDE, target will appear in Abseil folder while non PUBLIC will be in Abseil/internal.
-# TESTONLY: When added, this target will only be built if BUILD_TESTING=ON.
+# TESTONLY: When added, this target will only be built if both
+#           BUILD_TESTING=ON and ABSL_BUILD_TESTING=ON.
 #
 # Note:
 # By default, absl_cc_library will always create a library named absl_${NAME},
@@ -82,7 +83,7 @@ function(absl_cc_library)
     ${ARGN}
   )
 
-  if(ABSL_CC_LIB_TESTONLY AND NOT BUILD_TESTING)
+  if(ABSL_CC_LIB_TESTONLY AND NOT (BUILD_TESTING AND ABSL_BUILD_TESTING))
     return()
   endif()
 
@@ -364,7 +365,7 @@ endfunction()
 #     GTest::gtest_main
 # )
 function(absl_cc_test)
-  if(NOT BUILD_TESTING)
+  if(NOT (BUILD_TESTING AND ABSL_BUILD_TESTING))
     return()
   endif()
 

--- a/CMake/README.md
+++ b/CMake/README.md
@@ -20,8 +20,10 @@ googletest framework
 ### Step-by-Step Instructions
 
 1. If you want to build the Abseil tests, integrate the Abseil dependency
-[Google Test](https://github.com/google/googletest) into your CMake project. To disable Abseil tests, you have to pass
-`-DBUILD_TESTING=OFF` when configuring your project with CMake.
+[Google Test](https://github.com/google/googletest) into your CMake
+project. To disable Abseil tests, you have to pass either
+`-DBUILD_TESTING=OFF` or `-DABSL_BUILD_TESTING=OFF` when configuring your
+project with CMake.
 
 2. Download Abseil and copy it into a subdirectory in your CMake project or add
 Abseil as a [git submodule](https://git-scm.com/docs/git-submodule) in your
@@ -91,7 +93,8 @@ setting a consistent `CMAKE_CXX_STANDARD` that is sufficiently high.
 
 ### Running Abseil Tests with CMake
 
-Use the `-DBUILD_TESTING=ON` flag to run Abseil tests.
+Use the `-DABSL_BUILD_TESTING=ON` flag to run Abseil tests.  Note that
+BUILD_TESTING must also be on (the default).
 
 You will need to provide Abseil with a Googletest dependency.  There are two
 options for how to do this:
@@ -109,7 +112,7 @@ For example, to run just the Abseil tests, you could use this script:
 cd path/to/abseil-cpp
 mkdir build
 cd build
-cmake -DBUILD_TESTING=ON -DABSL_USE_GOOGLETEST_HEAD=ON ..
+cmake -DABSL_BUILD_TESTING=ON -DABSL_USE_GOOGLETEST_HEAD=ON ..
 make -j
 ctest
 ```
@@ -175,7 +178,7 @@ cmake --build /temporary/build/abseil-cpp --target install
 
 ## Google Test Options
 
-`-DBUILD_TESTING=ON` must be set to enable testing
+`-DABSL_BUILD_TESTING=ON` must be set to enable testing
 
 - Have Abseil download and build Google Test for you: `-DABSL_USE_EXTERNAL_GOOGLETEST=OFF` (default)
   - Download and build latest Google Test: `-DABSL_USE_GOOGLETEST_HEAD=ON`

--- a/CMake/install_test_project/test.sh
+++ b/CMake/install_test_project/test.sh
@@ -55,7 +55,7 @@ cmake "${absl_dir}" \
   -DABSL_USE_EXTERNAL_GOOGLETEST=ON \
   -DABSL_FIND_GOOGLETEST=ON  \
   -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_TESTING=ON \
+  -DABSL_BUILD_TESTING=ON \
   -DBUILD_SHARED_LIBS="${build_shared_libs}"
 make -j $(nproc)
 ctest -j $(nproc) --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,6 @@ if (POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif (POLICY CMP0091)
 
-# Set BUILD_TESTING to OFF by default.
-# This must come before the project() and include(CTest) lines.
-OPTION(BUILD_TESTING "Build tests" OFF)
-
 project(absl LANGUAGES CXX)
 include(CTest)
 
@@ -111,6 +107,9 @@ find_package(Threads REQUIRED)
 
 include(CMakeDependentOption)
 
+option(ABSL_BUILD_TESTING
+  "If ON, Abseil will build all of Abseil's own tests." OFF)
+
 option(ABSL_USE_EXTERNAL_GOOGLETEST
   "If ON, Abseil will assume that the targets for GoogleTest are already provided by the including project. This makes sense when Abseil is used with add_subproject." OFF)
 
@@ -130,7 +129,7 @@ set(ABSL_LOCAL_GOOGLETEST_DIR "/usr/src/googletest" CACHE PATH
   "If ABSL_USE_GOOGLETEST_HEAD is OFF and ABSL_GOOGLETEST_URL is not set, specifies the directory of a local GoogleTest checkout."
   )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND ABSL_BUILD_TESTING)
   ## check targets
   if (ABSL_USE_EXTERNAL_GOOGLETEST)
     if (ABSL_FIND_GOOGLETEST)

--- a/ci/linux_gcc-latest_libstdcxx_cmake.sh
+++ b/ci/linux_gcc-latest_libstdcxx_cmake.sh
@@ -54,7 +54,7 @@ for std in ${ABSL_CMAKE_CXX_STANDARDS}; do
           cmake /abseil-cpp \
             -DABSL_GOOGLETEST_DOWNLOAD_URL=${ABSL_GOOGLETEST_DOWNLOAD_URL} \
             -DBUILD_SHARED_LIBS=${build_shared} \
-            -DBUILD_TESTING=ON \
+            -DABSL_BUILD_TESTING=ON \
             -DCMAKE_BUILD_TYPE=${compilation_mode} \
             -DCMAKE_CXX_STANDARD=${std} \
             -DCMAKE_MODULE_LINKER_FLAGS=\"-Wl,--no-undefined\" && \

--- a/ci/linux_gcc_alpine_cmake.sh
+++ b/ci/linux_gcc_alpine_cmake.sh
@@ -53,7 +53,7 @@ for std in ${ABSL_CMAKE_CXX_STANDARDS}; do
         /bin/sh -c "
           cmake /abseil-cpp \
             -DABSL_GOOGLETEST_DOWNLOAD_URL=${ABSL_GOOGLETEST_DOWNLOAD_URL} \
-            -DBUILD_TESTING=ON \
+            -DABSL_BUILD_TESTING=ON \
             -DCMAKE_BUILD_TYPE=${compilation_mode} \
             -DCMAKE_CXX_STANDARD=${std} \
             -DCMAKE_MODULE_LINKER_FLAGS=\"-Wl,--no-undefined\" && \

--- a/ci/macos_xcode_cmake.sh
+++ b/ci/macos_xcode_cmake.sh
@@ -45,7 +45,7 @@ for compilation_mode in ${ABSL_CMAKE_BUILD_TYPES}; do
     time cmake ${ABSEIL_ROOT} \
       -GXcode \
       -DBUILD_SHARED_LIBS=${build_shared} \
-      -DBUILD_TESTING=ON \
+      -DABSL_BUILD_TESTING=ON \
       -DCMAKE_BUILD_TYPE=${compilation_mode} \
       -DCMAKE_CXX_STANDARD=11 \
       -DCMAKE_MODULE_LINKER_FLAGS="-Wl,--no-undefined" \


### PR DESCRIPTION
Abseil's own tests now are disabled if either BUILD_TESTING
or a new option called ABSL_BUILD_TESTING is false.
Additionally, Abseil's CMakeLists.txt no longer re-declares
the BUILD_TESTING option with a value of false.

Abseil had been using just the BUILD_TESTING option, since
Previous to that, Abseil had a project specific flag for
this, as is the typical idom used in other projects.

BUILD_TESTING is a simplistic all-or-nothing policy that
suffices for simpler projects.  When Abseil is incorporated
as a subproject, the encompasing build has no convenient way
to disable just Abseil's tests by default, yet enable its
own.

Fixes #1056