### PR TITLE
Small optimization to cctz year_index.

### DIFF
--- a/absl/time/internal/cctz/include/cctz/civil_time_detail.h
+++ b/absl/time/internal/cctz/include/cctz/civil_time_detail.h
@@ -84,7 +84,11 @@ CONSTEXPR_F bool is_leap_year(year_t y) noexcept {
   return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
 }
 CONSTEXPR_F int year_index(year_t y, month_t m) noexcept {
-  return (static_cast<int>((y + (m > 2)) % 400) + 400) % 400;
+  int year_index = static_cast<int>((y + (m > 2)) % 400);
+  if (year_index < 0) {
+    year_index += 400;
+  }
+  return year_index;
 }
 CONSTEXPR_F int days_per_century(year_t y, month_t m) noexcept {
   const int yi = year_index(y, m);


### PR DESCRIPTION
The year_index function had been forcing the modulus result to be
non-negative by adding 400 and taking the modulus again. Even with the
multiply&shift technique that compilers use for integer division with
known divisor, this isn't very cheap. Most of the time it should be
faster to do a conditional-move or branch on the modulus results, though
it is possible there are processors where this isn't faster. It is
also possible to further improve this by doing the division logic
ourselves using __int128 but not all compilers/platforms have this
(abseil int128 isn't constexpr for needed operations).

Some microbenchmark results:
```
name                                                         old cpu/op  new cpu/op  delta
BM_Difference_Days                                           15.4ns ±14%  14.5ns ± 4%     ~     (p=0.247 n=10+10)
BM_Step_Days                                                 10.9ns ±16%  10.4ns ± 3%     ~      (p=0.604 n=10+9)
BM_GetWeekday                                                1.59ns ±13%  1.50ns ± 2%     ~      (p=0.315 n=10+9)
BM_NextWeekday                                               14.3ns ±14%  13.4ns ± 6%     ~      (p=0.113 n=10+9)
BM_PrevWeekday                                               13.5ns ±14%  12.7ns ± 3%     ~     (p=0.325 n=10+10)
BM_Zone_LoadUTCTimeZoneFirst                                 13.9ns ±13%  13.1ns ± 6%     ~     (p=0.315 n=10+10)
BM_Zone_LoadUTCTimeZoneLast                                  13.8ns ±14%  13.0ns ± 5%     ~     (p=0.089 n=10+10)
BM_Zone_LoadTimeZoneFirst                                     372µs ±15%   326µs ± 3%  -12.27%  (p=0.000 n=10+10)
BM_Zone_LoadTimeZoneCached                                   42.8ns ±15%  40.4ns ± 5%     ~     (p=0.123 n=10+10)
BM_Zone_LoadLocalTimeZoneCached                               140ns ±16%   135ns ± 4%     ~      (p=0.968 n=10+9)
BM_Zone_LoadAllTimeZonesFirst                                 147µs ±11%   129µs ± 9%  -12.19%   (p=0.000 n=10+9)
BM_Zone_LoadAllTimeZonesCached                               70.9ns ±14%  65.9ns ± 2%     ~      (p=0.053 n=10+9)
BM_Zone_TimeZoneEqualityImplicit                             6.14ns ±15%  5.81ns ± 4%     ~      (p=0.720 n=10+9)
BM_Zone_TimeZoneEqualityExplicit                             2.61ns ±14%  2.47ns ± 2%     ~      (p=0.742 n=10+8)
BM_Zone_UTCTimeZone                                          2.63ns ±13%  2.45ns ± 3%     ~      (p=0.138 n=10+9)
BM_Time_ToCivil_CCTZ                                         45.8ns ±15%  43.7ns ± 3%     ~      (p=0.897 n=10+8)
BM_Time_ToCivil_Libc                                         70.8ns ±13%  66.4ns ± 2%     ~     (p=0.105 n=10+10)
BM_Time_ToCivilUTC_CCTZ                                       126ns ±12%   102ns ± 2%  -18.69%  (p=0.000 n=10+10)
BM_Time_ToCivilUTC_Libc                                      42.9ns ±13%  42.6ns ±14%     ~     (p=0.739 n=10+10)
BM_Time_FromCivil_CCTZ                                       38.5ns ±12%  35.8ns ± 5%     ~     (p=0.105 n=10+10)
BM_Time_FromCivil_Libc                                       1.07µs ±14%  1.00µs ± 3%   -6.72%  (p=0.029 n=10+10)
BM_Time_FromCivilUTC_CCTZ                                    28.5ns ±14%  26.5ns ± 3%     ~     (p=0.089 n=10+10)
BM_Time_FromCivilDay0_CCTZ                                   63.3ns ±15%  60.1ns ± 2%     ~      (p=0.968 n=10+9)
BM_Time_FromCivilDay0_Libc                                   1.16µs ±14%  1.07µs ± 3%     ~      (p=0.146 n=10+8)
BM_Format_FormatTime/0           [%a, %d %b %Y %H:%M:%S %z]   398ns ±13%   362ns ± 3%     ~     (p=0.075 n=10+10)
BM_Format_FormatTime/1           [%d %b %Y %H:%M:%S %z    ]   332ns ±14%   315ns ± 3%     ~      (p=1.000 n=10+8)
BM_Format_FormatTime/2           [%Y-%m-%d%ET%H:%M:%E*S%Ez]   326ns ±14%   299ns ± 3%   -8.08%  (p=0.004 n=10+10)
BM_Format_FormatTime/3           [%Y-%m-%d%ET%H:%M:%S%Ez  ]   292ns ±14%   276ns ± 5%     ~      (p=0.356 n=10+9)
BM_Format_FormatTime/4           [%Y-%m-%d%ET%H:%M:%S     ]   251ns ±14%   235ns ± 5%     ~     (p=0.105 n=10+10)
BM_Format_FormatTime/5           [%Y-%m-%d                ]   134ns ±14%   126ns ± 3%     ~     (p=0.393 n=10+10)
BM_Format_ParseTime/0            [%a, %d %b %Y %H:%M:%S %z]  1.48µs ±15%  1.41µs ± 6%     ~     (p=0.631 n=10+10)
BM_Format_ParseTime/1            [%d %b %Y %H:%M:%S %z    ]  1.23µs ±22%  1.12µs ± 2%   -9.29%   (p=0.003 n=10+8)
BM_Format_ParseTime/2            [%Y-%m-%d%ET%H:%M:%E*S%Ez]   322ns ±14%   299ns ± 2%     ~      (p=0.133 n=10+9)
BM_Format_ParseTime/3            [%Y-%m-%d%ET%H:%M:%S%Ez  ]   285ns ±14%   270ns ± 2%     ~      (p=0.965 n=10+8)
BM_Format_ParseTime/4            [%Y-%m-%d%ET%H:%M:%S     ]   175ns ±14%   167ns ± 3%     ~      (p=0.720 n=10+9)
BM_Format_ParseTime/5            [%Y-%m-%d                ]   119ns ±15%   115ns ± 3%     ~      (p=0.549 n=10+9)
```