### PR TITLE
Avoid defining ABSL_INTERNAL_ENABLE_FORMAT_CHECKER when compiling with vscode/intellisense

### DIFF
--- a/absl/strings/internal/str_format/checker.h
+++ b/absl/strings/internal/str_format/checker.h
@@ -22,9 +22,15 @@
 // Compile time check support for entry points.
 
 #ifndef ABSL_INTERNAL_ENABLE_FORMAT_CHECKER
-#if ABSL_HAVE_ATTRIBUTE(enable_if) && !defined(__native_client__)
+
+// We disable format checker under vscode intellisense compilation.
+// See https://github.com/microsoft/vscode-cpptools/issues/3683 for
+// more details.
+#if ABSL_HAVE_ATTRIBUTE(enable_if) && !defined(__native_client__) && \
+    !defined(__INTELLISENSE__)
 #define ABSL_INTERNAL_ENABLE_FORMAT_CHECKER 1
-#endif  // ABSL_HAVE_ATTRIBUTE(enable_if) && !defined(__native_client__)
+#endif  // ABSL_HAVE_ATTRIBUTE(enable_if) && !defined(__native_client__) &&
+        // !defined(__INTELLISENSE__)
 #endif  // ABSL_INTERNAL_ENABLE_FORMAT_CHECKER
 
 namespace absl {


### PR DESCRIPTION
This macro is defined in such way that it can be overriden with the compiler -D option.
However, `#ifdef` guards only check for the existence of this macro, thus it's defacto impossible to override.
This PR fixes this issue. Needed to workaround vscode/clang spurious error https://github.com/microsoft/vscode-cpptools/issues/3683