### PR TITLE
Improve WebAssembly detection when using Bazel.

### DIFF
--- a/absl/BUILD.bazel
+++ b/absl/BUILD.bazel
@@ -66,6 +66,14 @@ config_setting(
 config_setting(
     name = "wasm",
     values = {
+        "cpu": "wasm",
+    },
+    visibility = [":__subpackages__"],
+)
+
+config_setting(
+    name = "wasm32",
+    values = {
         "cpu": "wasm32",
     },
     visibility = [":__subpackages__"],

--- a/absl/base/BUILD.bazel
+++ b/absl/base/BUILD.bazel
@@ -162,6 +162,9 @@ cc_library(
         "//absl:msvc_compiler": [],
         "//absl:clang-cl_compiler": [],
         "//absl:wasm": [],
+        "//absl:wasm32": [],
+        "@platforms//cpu:wasm32": [],
+        "@platforms//cpu:wasm64": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     visibility = [

--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -156,6 +156,9 @@ cc_test(
         "//absl:msvc_compiler": [],
         "//absl:clang-cl_compiler": [],
         "//absl:wasm": [],
+        "//absl:wasm32": [],
+        "@platforms//cpu:wasm32": [],
+        "@platforms//cpu:wasm64": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [

--- a/absl/random/internal/BUILD.bazel
+++ b/absl/random/internal/BUILD.bazel
@@ -106,6 +106,9 @@ cc_library(
         "//absl:msvc_compiler": [],
         "//absl:clang-cl_compiler": [],
         "//absl:wasm": [],
+        "//absl:wasm32": [],
+        "@platforms//cpu:wasm32": [],
+        "@platforms//cpu:wasm64": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [

--- a/absl/synchronization/BUILD.bazel
+++ b/absl/synchronization/BUILD.bazel
@@ -90,6 +90,9 @@ cc_library(
         "//absl:msvc_compiler": [],
         "//absl:clang-cl_compiler": [],
         "//absl:wasm": [],
+        "//absl:wasm32": [],
+        "@platforms//cpu:wasm32": [],
+        "@platforms//cpu:wasm64": [],
         "//conditions:default": ["-pthread"],
     }) + ABSL_DEFAULT_LINKOPTS,
     deps = [


### PR DESCRIPTION
Unfortunately, the --cpu values are not standardized, and both
--cpu=wasm and --cpu=wasm32 are used in the wild. Most notably,
Emscripten's Bazel rules use --cpu=wasm, which was missing.

While there, add support for @platforms//cpu:{wasm32,wasm64}.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>