### PR TITLE
Exclude #pragma intrinsic(_umul128) from ARM64EC

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -131,7 +131,9 @@ double UnscaledCycleClock::Frequency() {
 
 #elif defined(_M_IX86) || defined(_M_X64)
 
+#if !defined(_M_ARM64EC)
 #pragma intrinsic(__rdtsc)
+#endif
 
 int64_t UnscaledCycleClock::Now() { return __rdtsc(); }
 

--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -132,6 +132,8 @@ double UnscaledCycleClock::Frequency() {
 #elif defined(_M_IX86) || defined(_M_X64)
 
 #if !defined(_M_ARM64EC)
+// ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.
+// The ARM64EC does not support __rdtsc as an intrinsic, but an inline function.
 #pragma intrinsic(__rdtsc)
 #endif
 

--- a/absl/numeric/int128.h
+++ b/absl/numeric/int128.h
@@ -46,7 +46,11 @@
 #define ABSL_INTERNAL_WCHAR_T __wchar_t
 #if defined(_M_X64)
 #include <intrin.h>
+// ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.
+// The ARM64EC does not support _umul128 as an intrinsic, but an inline function.
+#if !defined(_M_ARM64EC)
 #pragma intrinsic(_umul128)
+#endif  // defined(_M_ARM64EC)
 #endif  // defined(_M_X64)
 #else   // defined(_MSC_VER)
 #define ABSL_INTERNAL_WCHAR_T wchar_t


### PR DESCRIPTION
ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.  The ARM64EC does not support _umul128 as an intrinsic, but an inline function. Therefore, exclude #pragma intrinsic(_umul128) from ARM64EC compilation.