### PR TITLE
Allow forced enabling of debug assertions

### DIFF
--- a/absl/base/macros.h
+++ b/absl/base/macros.h
@@ -90,7 +90,7 @@ ABSL_NAMESPACE_END
 //
 // This macro is inspired by
 // https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions/
-#if defined(NDEBUG)
+#if defined(NDEBUG) && !defined(ABSL_ENABLE_DEBUG_ASSERTS)
 #define ABSL_ASSERT(expr) \
   (false ? static_cast<void>(expr) : static_cast<void>(0))
 #else


### PR DESCRIPTION
ABSL_ASSERT() is always a no-op when NDEBUG is defined. This introduces
an indepdendent secondary mechanism for force-enabling these assertions
by defining ABSL_ENABLE_DEBUG_ASSERTS.

See https://crbug.com/1245687 for motivation.