### PR TITLE
Use `thread_local` when C++11 is supported

### DIFF
--- a/absl/base/internal/per_thread_tls.h
+++ b/absl/base/internal/per_thread_tls.h
@@ -38,6 +38,9 @@
 #error ABSL_PER_THREAD_TLS cannot be directly set
 #elif defined(ABSL_PER_THREAD_TLS_KEYWORD)
 #error ABSL_PER_THREAD_TLS_KEYWORD cannot be directly set
+#elif defined(__cplusplus) && __cplusplus >= 201103L
+#define ABSL_PER_THREAD_TLS_KEYWORD thread_local
+#define ABSL_PER_THREAD_TLS 1
 #elif defined(ABSL_HAVE_TLS)
 #define ABSL_PER_THREAD_TLS_KEYWORD __thread
 #define ABSL_PER_THREAD_TLS 1


### PR DESCRIPTION
This enables native TLS on platforms where it is available.

Before this change, native TLS is used via the `__thread` keyword only
on (Linux && (clang || libcstd++)). After this change, native TLS is
used on all systems where C++11 is available, regardless of compiler of
C++ standard library flavor (e.g. libc++).

/cc @drfloob