### PR TITLE
absl/strings/internal/str_format/extension.h: add missing <stdint.h> …

### DIFF
--- a/absl/strings/internal/str_format/extension.h
+++ b/absl/strings/internal/str_format/extension.h
@@ -17,6 +17,7 @@
 #define ABSL_STRINGS_INTERNAL_STR_FORMAT_EXTENSION_H_
 
 #include <limits.h>
+#include <stdint.h>
 
 #include <cstddef>
 #include <cstring>


### PR DESCRIPTION
…include

Without the change absl-cpp build fails on this week's gcc-13 snapshot as:

    /build/abseil-cpp/absl/strings/internal/str_format/extension.h:34:33: error: found ':' in nested-name-specifier, expected '::'
       34 | enum class FormatConversionChar : uint8_t;
          |                                 ^
          |                                 ::