### PR TITLE
Avoid variable shadowing 

### DIFF
--- a/absl/container/internal/btree.h
+++ b/absl/container/internal/btree.h
@@ -504,8 +504,8 @@ struct SearchResult {
 template <typename V>
 struct SearchResult<V, false> {
   SearchResult() {}
-  explicit SearchResult(V value) : value(value) {}
-  SearchResult(V value, MatchKind /*match*/) : value(value) {}
+  explicit SearchResult(V va) : value(va) {}
+  SearchResult(V va, MatchKind /*match*/) : value(va) {}
 
   V value;
 


### PR DESCRIPTION
The code before the patch has variable name shadowing. When abseil is used with compile warnings turned to errors to detect variable shadowing, this is a source of compile error, but btree has the problem.