### PR TITLE
Obey ABSL_DEFAULT_LINKOPTS for all cc_library targets

### DIFF
--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -196,6 +196,7 @@ cc_library(
     srcs = ["internal/demangle.cc"],
     hdrs = ["internal/demangle.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = ["//visibility:private"],
     deps = [
         "//absl/base",

--- a/absl/random/BUILD.bazel
+++ b/absl/random/BUILD.bazel
@@ -128,6 +128,7 @@ cc_library(
     name = "mock_distributions",
     testonly = 1,
     hdrs = ["mock_distributions.h"],
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":distributions",
         ":mocking_bit_gen",

--- a/absl/random/internal/BUILD.bazel
+++ b/absl/random/internal/BUILD.bazel
@@ -502,6 +502,7 @@ cc_test(
 cc_library(
     name = "mock_helpers",
     hdrs = ["mock_helpers.h"],
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         "//absl/base:fast_type_id",
         "//absl/types:optional",
@@ -512,6 +513,7 @@ cc_library(
     name = "mock_overload_set",
     testonly = 1,
     hdrs = ["mock_overload_set.h"],
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":mock_helpers",
         "//absl/random:mocking_bit_gen",

--- a/absl/status/BUILD.bazel
+++ b/absl/status/BUILD.bazel
@@ -20,6 +20,7 @@
 load(
     "//absl:copts/configure_copts.bzl",
     "ABSL_DEFAULT_COPTS",
+    "ABSL_DEFAULT_LINKOPTS",
     "ABSL_TEST_COPTS",
 )
 
@@ -39,6 +40,7 @@ cc_library(
         "status_payload_printer.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         "//absl/base:atomic_hook",
         "//absl/base:core_headers",
@@ -76,6 +78,7 @@ cc_library(
         "statusor.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":status",
         "//absl/base",

--- a/absl/strings/BUILD.bazel
+++ b/absl/strings/BUILD.bazel
@@ -16,6 +16,7 @@
 load(
     "//absl:copts/configure_copts.bzl",
     "ABSL_DEFAULT_COPTS",
+    "ABSL_DEFAULT_LINKOPTS",
     "ABSL_TEST_COPTS",
 )
 
@@ -65,6 +66,7 @@ cc_library(
         "substitute.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":internal",
         "//absl/base",
@@ -95,6 +97,7 @@ cc_library(
         "internal/utf8.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         "//absl/base:config",
         "//absl/base:core_headers",
@@ -288,6 +291,7 @@ cc_library(
         "internal/cord_rep_ring_reader.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//visibility:private",
     ],
@@ -391,6 +395,7 @@ cc_library(
     name = "cordz_update_tracker",
     hdrs = ["internal/cordz_update_tracker.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -422,6 +427,7 @@ cc_library(
         "cord_buffer.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":cord_internal",
         ":cordz_functions",
@@ -452,6 +458,7 @@ cc_library(
     srcs = ["internal/cordz_handle.cc"],
     hdrs = ["internal/cordz_handle.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -468,6 +475,7 @@ cc_library(
     srcs = ["internal/cordz_info.cc"],
     hdrs = ["internal/cordz_info.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -492,6 +500,7 @@ cc_library(
     name = "cordz_update_scope",
     hdrs = ["internal/cordz_update_scope.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -524,6 +533,7 @@ cc_library(
     srcs = ["internal/cordz_sample_token.cc"],
     hdrs = ["internal/cordz_sample_token.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -539,6 +549,7 @@ cc_library(
     srcs = ["internal/cordz_functions.cc"],
     hdrs = ["internal/cordz_functions.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -554,6 +565,7 @@ cc_library(
     name = "cordz_statistics",
     hdrs = ["internal/cordz_statistics.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = [
         "//absl:__subpackages__",
     ],
@@ -663,6 +675,7 @@ cc_library(
         "cord_test_helpers.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":cord",
         ":cord_internal",
@@ -676,6 +689,7 @@ cc_library(
     testonly = 1,
     hdrs = ["internal/cord_rep_test_util.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":cord_internal",
         ":strings",
@@ -689,6 +703,7 @@ cc_library(
     testonly = 1,
     hdrs = ["cordz_test_helpers.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":cord",
         ":cord_internal",
@@ -1097,6 +1112,7 @@ cc_library(
         "str_format.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         ":str_format_internal",
     ],
@@ -1122,6 +1138,7 @@ cc_library(
         "internal/str_format/parser.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = ["//visibility:private"],
     deps = [
         ":strings",
@@ -1246,6 +1263,7 @@ cc_library(
     testonly = True,
     srcs = ["internal/pow10_helper.cc"],
     hdrs = ["internal/pow10_helper.h"],
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     visibility = ["//visibility:private"],
     deps = ["//absl/base:config"],
 )

--- a/absl/types/BUILD.bazel
+++ b/absl/types/BUILD.bazel
@@ -314,6 +314,7 @@ cc_library(
     name = "compare",
     hdrs = ["compare.h"],
     copts = ABSL_DEFAULT_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
     deps = [
         "//absl/base:core_headers",
         "//absl/meta:type_traits",


### PR DESCRIPTION
A few targets were missing `linkopts = ...` and so were not obeying the project-wide default settings.

In my downstream project that uses Abseil, I customize the default `linkopts` by patching `configure_copts.bzl`, and having the options missing in a few places causes linker errors.

---

I've confirmed that this patch is comprehensive by running `bazel query 'kind(cc_library, //...) except attr(linkopts, needle, //...)'` after adding this patch:

```patch
--- a/absl/copts/configure_copts.bzl
+++ b/absl/copts/configure_copts.bzl
@@ -35,10 +35,7 @@ ABSL_TEST_COPTS = ABSL_DEFAULT_COPTS + select({
     "//conditions:default": ABSL_GCC_TEST_FLAGS,
 })
 
-ABSL_DEFAULT_LINKOPTS = select({
-    "//absl:msvc_compiler": ABSL_MSVC_LINKOPTS,
-    "//conditions:default": [],
-})
+ABSL_DEFAULT_LINKOPTS = ["needle"]
 
 # ABSL_RANDOM_RANDEN_COPTS blaze copts flags which are required by each
 # environment to build an accelerated RandenHwAes library.
```