### PR TITLE
absl/base/internal/direct_mmap.h: fix musl build on mips

### DIFF
--- a/absl/base/internal/direct_mmap.h
+++ b/absl/base/internal/direct_mmap.h
@@ -41,13 +41,13 @@
 
 #ifdef __mips__
 // Include definitions of the ABI currently in use.
-#ifdef __BIONIC__
+#if defined (__BIONIC__) || !defined(__GLIBC__)
 // Android doesn't have sgidefs.h, but does have asm/sgidefs.h, which has the
 // definitions we need.
 #include <asm/sgidefs.h>
 #else
 #include <sgidefs.h>
-#endif  // __BIONIC__
+#endif  // __BIONIC__ || !__GLIBC__
 #endif  // __mips__
 
 // SYS_mmap and SYS_munmap are not defined in Android.


### PR DESCRIPTION
Fix the following musl build failure on mips:

```
In file included from /nvmedata/autobuild/instance-15/output-1/build/libabseil-cpp-20211102.0/absl/base/internal/low_level_alloc.cc:26:
/nvmedata/autobuild/instance-15/output-1/build/libabseil-cpp-20211102.0/absl/base/internal/direct_mmap.h:49:10: fatal error: sgidefs.h: No such file or directory
   49 | #include <sgidefs.h>
      |          ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/3fa027e602bacb22316fb5d9b233baa0b0f0e845

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>