### PR TITLE
absl/debugging/CMakeLists.txt: link with libexecinfo if needed

### DIFF
--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+find_library(EXECINFO_LIBRARY execinfo)
+
 absl_cc_library(
   NAME
     stacktrace
@@ -33,6 +35,8 @@ absl_cc_library(
     "stacktrace.cc"
   COPTS
     ${ABSL_DEFAULT_COPTS}
+  LINKOPTS
+    $<$<BOOL:${EXECINFO_LIBRARY}>:${EXECINFO_LIBRARY}>
   DEPS
     absl::debugging_internal
     absl::config


### PR DESCRIPTION
`backtrace` and `execinfo.h` can be provided by libexecinfo on uclibc and musl resulting in the following build failure with any user of abseil-cpp (such as collectd):

```
/home/buildroot/autobuild/instance-0/output-1/host/lib/gcc/sparc-buildroot-linux-uclibc/10.3.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/buildroot/autobuild/instance-0/output-1/host/bin/../sparc-buildroot-linux-uclibc/sysroot/usr/lib/libabsl_stacktrace.so: undefined reference to `backtrace'
```

[...]

```
    libgrpc++ . . . . . . no (libgrpc++ not found)
```

[...]

```
configure: error: "Some plugins are missing dependencies - see the summary above for details"
```

Fixes:
 - http://autobuild.buildroot.org/results/6a0484412f020e763ce3ad5bda48f09c78645bff

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>