### PR TITLE
Disable sigaltstack() on macOS to make backtrace() work.

### DIFF
--- a/absl/debugging/failure_signal_handler.cc
+++ b/absl/debugging/failure_signal_handler.cc
@@ -50,7 +50,9 @@
 #ifndef _WIN32
 #define ABSL_HAVE_SIGACTION
 // Apple WatchOS and TVOS don't allow sigaltstack
-#if !(defined(TARGET_OS_WATCH) && TARGET_OS_WATCH) && \
+// Apple macOS has sigaltstack, but using it makes backtrace() unusable.
+#if !(defined(TARGET_OS_OSX) && TARGET_OS_OSX) && \
+    !(defined(TARGET_OS_WATCH) && TARGET_OS_WATCH) && \
     !(defined(TARGET_OS_TV) && TARGET_OS_TV) && !defined(__QNX__)
 #define ABSL_HAVE_SIGALTSTACK
 #endif


### PR DESCRIPTION
There are many reports that sigaltstack() on Apple platforms stops backtrace() from tracing an original stack, e.g.

* https://github.com/llvm/llvm-project/commit/d39ead41056b00d10b6223543562cd304307ac9b
* https://reviews.llvm.org/D28265

If we disable an alternate stack for signal handler, we won't be able to catch stack overflow errors, but backrace() will work again.