### PR TITLE
fix(mutex): safely call snprintf

### DIFF
--- a/absl/synchronization/mutex.cc
+++ b/absl/synchronization/mutex.cc
@@ -430,7 +430,7 @@ static void PostSynchEvent(void *obj, int ev) {
     char buffer[ABSL_ARRAYSIZE(pcs) * 24];
     int pos = snprintf(buffer, sizeof (buffer), " @");
     for (int i = 0; i != n; i++) {
-      int b += snprintf(&buffer[pos], sizeof (buffer) - pos, " %p", pcs[i]);
+      int b = snprintf(&buffer[pos], sizeof (buffer) - pos, " %p", pcs[i]);
       if (b < 0 || b >= sizeof (buffer) - pos) {
         break;
       }

--- a/absl/synchronization/mutex.cc
+++ b/absl/synchronization/mutex.cc
@@ -430,7 +430,11 @@ static void PostSynchEvent(void *obj, int ev) {
     char buffer[ABSL_ARRAYSIZE(pcs) * 24];
     int pos = snprintf(buffer, sizeof (buffer), " @");
     for (int i = 0; i != n; i++) {
-      pos += snprintf(&buffer[pos], sizeof (buffer) - pos, " %p", pcs[i]);
+      int b += snprintf(&buffer[pos], sizeof (buffer) - pos, " %p", pcs[i]);
+      if (b < 0 || b >= sizeof (buffer) - pos) {
+        break;
+      }
+      pos += b;
     }
     ABSL_RAW_LOG(INFO, "%s%p %s %s", event_properties[ev].msg, obj,
                  (e == nullptr ? "" : e->name), buffer);


### PR DESCRIPTION
In the PostSynchEvent() function, the pos integer uses an implementation of snprintf that is fundamentally unsafe: since the return value of snprintf is the number of characters that would have been written to the buffer, if an operation reaches the end of the buffer with more than one character discarded, the return value will be greater than the buffer size, requiring a check of the buffer's current size.