### PR TITLE
Buildfix OpenBSD.

### DIFF
--- a/absl/time/internal/cctz/src/time_zone_format.cc
+++ b/absl/time/internal/cctz/src/time_zone_format.cc
@@ -19,7 +19,7 @@
 #endif
 
 #if defined(HAS_STRPTIME) && HAS_STRPTIME
-#if !defined(_XOPEN_SOURCE)
+#if !defined(_XOPEN_SOURCE) && !defined(__OpenBSD__)
 #define _XOPEN_SOURCE  // Definedness suffices for strptime.
 #endif
 #endif


### PR DESCRIPTION
OpenBSD does not expose `vasprintf` when `_XOPEN_SOURCE` is defined, but
`__bsd_locale_fallbacks.h` in the platform libc++ requires this to be
visible, thereby causing a compilation failure. In fact, `strptime` and
`vasprintf` are normally visible without defining any standard-visibility
`#defines`, so don't do anything special here.