### PR TITLE
Add -Wno-pedantic to ABSL_GCC_FLAGS

### DIFF
--- a/absl/copts/GENERATED_AbseilCopts.cmake
+++ b/absl/copts/GENERATED_AbseilCopts.cmake
@@ -35,6 +35,7 @@ list(APPEND ABSL_CLANG_CL_TEST_FLAGS
 list(APPEND ABSL_GCC_FLAGS
     "-Wall"
     "-Wextra"
+    "-Wno-pedantic"
     "-Wcast-qual"
     "-Wconversion-null"
     "-Wformat-security"

--- a/absl/copts/GENERATED_copts.bzl
+++ b/absl/copts/GENERATED_copts.bzl
@@ -36,6 +36,7 @@ ABSL_CLANG_CL_TEST_FLAGS = [
 ABSL_GCC_FLAGS = [
     "-Wall",
     "-Wextra",
+    "-Wno-pedantic",
     "-Wcast-qual",
     "-Wconversion-null",
     "-Wformat-security",

--- a/absl/copts/copts.py
+++ b/absl/copts/copts.py
@@ -52,6 +52,7 @@ COPT_VARS = {
     "ABSL_GCC_FLAGS": [
         "-Wall",
         "-Wextra",
+        "-Wno-pedantic",
         "-Wcast-qual",
         "-Wconversion-null",
         "-Wformat-security",


### PR DESCRIPTION
Abseil doesn't compile with -pedantic -Werror due to warnings such as

```
external/abseil/absl/numeric/int128_have_intrinsic.inc: In function 'constexpr absl::lts_20211102::int128 absl::lts_20211102::operator>>(absl::lts_20211102::int128, int)':
external/abseil/absl/numeric/int128_have_intrinsic.inc:295:22: error: ISO C++ does not support '__int128' for 'type name' [-Werror=pedantic]
  295 |   return static_cast<__int128>(lhs) >> amount;
      |                      ^~~~~~~~
```

This makes it unpleasant to depend on it in projects that set -pedantic -Werror by default and use build systems such as bazel that make it hard to pass compiler flags to dependencies. I currently fix the problem by patching copts.py:

```bazel
http_archive(
    name = "abseil",
    urls = ["https://github.com/abseil/abseil-cpp/archive/20211102.0.zip"],
    strip_prefix = "abseil-cpp-20211102.0",
    patches = ['...'],
    patch_cmds = ['python3 absl/copts/generate_copts.py'],
)
```

where the dots point to a patch file with

```
--- absl/copts/copts.py
+++ absl/copts/copts.py
@@ -52,6 +52,7 @@
     "ABSL_GCC_FLAGS": [
         "-Wall",
         "-Wextra",
+        "-Wno-pedantic",
         "-Wcast-qual",
         "-Wconversion-null",
         "-Wformat-security",

```

This works fine, but I thought the PR might save others some extra setup time.