### PR TITLE
- Fix deprecated header in visual studio version 17.3.0 C++20

### DIFF
--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -70,7 +70,7 @@
 // Include a standard library header to allow configuration based on the
 // standard library in use.
 #ifdef __cplusplus
-#include <ciso646>
+#include <iso646.h>
 #endif
 
 // -----------------------------------------------------------------------------

--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -67,12 +67,6 @@
 #ifndef ABSL_BASE_OPTIONS_H_
 #define ABSL_BASE_OPTIONS_H_
 
-// Include a standard library header to allow configuration based on the
-// standard library in use.
-#ifdef __cplusplus
-#include <iso646.h>
-#endif
-
 // -----------------------------------------------------------------------------
 // Type Compatibility Options
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
There was a header that was no longer used in c++20 of Visual studio version 17.3.0, so I fixed it.