### PR TITLE
add new CMake option `ABSL_USE_SYSTEM_INCLUDES`

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -26,6 +26,12 @@ if(NOT DEFINED ABSL_IDE_FOLDER)
   set(ABSL_IDE_FOLDER Abseil)
 endif()
 
+if(ABSL_USE_SYSTEM_INCLUDES)
+  set(ABSL_INTERNAL_INCLUDE_WARNING_GUARD SYSTEM)
+else()
+  set(ABSL_INTERNAL_INCLUDE_WARNING_GUARD "")
+endif()
+
 # absl_cc_library()
 #
 # CMake function to imitate Bazel's cc_library rule.
@@ -242,7 +248,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
     # unconditionally.
     set_property(TARGET ${_NAME} PROPERTY LINKER_LANGUAGE "CXX")
 
-    target_include_directories(${_NAME}
+    target_include_directories(${_NAME} ${ABSL_INTERNAL_INCLUDE_WARNING_GUARD}
       PUBLIC
         "$<BUILD_INTERFACE:${ABSL_COMMON_INCLUDE_DIRS}>"
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -290,7 +296,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
   else()
     # Generating header-only library
     add_library(${_NAME} INTERFACE)
-    target_include_directories(${_NAME}
+    target_include_directories(${_NAME} ${ABSL_INTERNAL_INCLUDE_WARNING_GUARD}
       INTERFACE
         "$<BUILD_INTERFACE:${ABSL_COMMON_INCLUDE_DIRS}>"
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if((${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.8) AND (NOT ABSL_PROPAGATE_CXX_STD)
 endif()
 
 option(ABSL_USE_SYSTEM_INCLUDES
-  "Mark C++ include directories with `SYSTEM` to prevent warnings from headers when using Abseil with incompatible warning flags"
+  "Silence warnings in Abseil headers by marking them as `SYSTEM` includes"
   OFF)
 
 list(APPEND CMAKE_MODULE_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,10 @@ if((${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.8) AND (NOT ABSL_PROPAGATE_CXX_STD)
   message(WARNING "A future Abseil release will default ABSL_PROPAGATE_CXX_STD to ON for CMake 3.8 and up. We recommend enabling this option to ensure your project still builds correctly.")
 endif()
 
+option(ABSL_USE_SYSTEM_INCLUDES
+  "Mark C++ include directories with `SYSTEM` to prevent warnings from headers when using Abseil with incompatible warning flags"
+  OFF)
+
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/CMake
   ${CMAKE_CURRENT_LIST_DIR}/absl/copts


### PR DESCRIPTION
When using Abseil as a dependency with CMake, files that include Abseil headers and have stricter warning settings can emit compiler warnings. 

CMake does provide a way to express that warnings from headers in a specific include path should be ignored, but it is expected that the library providing a target decides this rather than the user of a target (unless Abseil wants downstream users manually tinkering with the properties of Abseil targets in order to mark includes as `SYSTEM` themselves).

This adds the new option `ABSL_USE_SYSTEM_INCLUDES`, which causes Abseil's include directories be marked with `SYSTEM`. It is disabled by default, but users who wish to have this behavior can enable it. 

Fixes #964. 