### PR TITLE
Workaround bug in GCC 7.2

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -444,7 +444,7 @@ H AbslHashValue(H hash_state, T C::* ptr) {
     // On other platforms, we assume that pointers-to-members do not have
     // padding.
 #ifdef __cpp_lib_has_unique_object_representations
-    static_assert(std::has_unique_object_representations_v<T C::*>);
+    static_assert(std::has_unique_object_representations<T C::*>::value);
 #endif  // __cpp_lib_has_unique_object_representations
     return n;
 #endif


### PR DESCRIPTION
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83830.

Before GCC 7.4, `__cpp_lib_has_unique_object_representations` was defined but `has_unique_object_representations_v` was not.

I don't personally use old compiler versions, but [conan-center-index](https://github.com/conan-io/conan-center-index) does for CI builds, and they want me to attempt to merge this upstream before accepting a patch for their abseil package (https://github.com/conan-io/conan-center-index/pull/11946).