### PR TITLE
Support compilers that are unknown to CMake

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -32,6 +32,14 @@ else()
   set(ABSL_INTERNAL_INCLUDE_WARNING_GUARD "")
 endif()
 
+function(_target_compile_features_if_available TARGET TYPE FEATURE)
+  if(FEATURE IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    target_compile_features(${TARGET} ${TYPE} ${FEATURE})
+  else()
+    message(WARNING "Feature ${FEATURE} is unknown for the CXX compiler")
+  endif()
+endfunction()
+
 # absl_cc_library()
 #
 # CMake function to imitate Bazel's cc_library rule.
@@ -270,7 +278,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
       # Abseil libraries require C++14 as the current minimum standard.
       # Top-level application CMake projects should ensure a consistent C++
       # standard for all compiled sources by setting CMAKE_CXX_STANDARD.
-      target_compile_features(${_NAME} PUBLIC cxx_std_14)
+      _target_compile_features_if_available(${_NAME} PUBLIC cxx_std_14)
     else()
       # Note: This is legacy (before CMake 3.8) behavior. Setting the
       # target-level CXX_STANDARD property to ABSL_CXX_STANDARD (which is
@@ -318,7 +326,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
       # Abseil libraries require C++14 as the current minimum standard.
       # Top-level application CMake projects should ensure a consistent C++
       # standard for all compiled sources by setting CMAKE_CXX_STANDARD.
-      target_compile_features(${_NAME} INTERFACE cxx_std_14)
+      _target_compile_features_if_available(${_NAME} INTERFACE cxx_std_14)
 
       # (INTERFACE libraries can't have the CXX_STANDARD property set, so there
       # is no legacy behavior else case).
@@ -430,7 +438,7 @@ function(absl_cc_test)
     # Abseil libraries require C++14 as the current minimum standard.
     # Top-level application CMake projects should ensure a consistent C++
     # standard for all compiled sources by setting CMAKE_CXX_STANDARD.
-    target_compile_features(${_NAME} PUBLIC cxx_std_14)
+    _target_compile_features_if_available(${_NAME} PUBLIC cxx_std_14)
   else()
     # Note: This is legacy (before CMake 3.8) behavior. Setting the
     # target-level CXX_STANDARD property to ABSL_CXX_STANDARD (which is


### PR DESCRIPTION
Abseil failed to configure with `ABSL_PROPAGATE_CXX_STD` if the compiler was not known to CMake:

    target_compile_features no known features for CXX compiler

Turns the error into a warning by checking `CMAKE_CXX_COMPILE_FEATURES`
before calling `target_compile_features`.