### PR TITLE
internal/spinlock.h: Remove unused `<sys/types.h>`

### DIFF
--- a/absl/base/internal/spinlock.h
+++ b/absl/base/internal/spinlock.h
@@ -30,7 +30,6 @@
 #define ABSL_BASE_INTERNAL_SPINLOCK_H_
 
 #include <stdint.h>
-#include <sys/types.h>
 
 #include <atomic>
 


### PR DESCRIPTION
This include is unused and `sys/types.h` is not available on some platforms.