### PR TITLE
Switch time_state to explicit default initialization instead of value initialization.

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -112,7 +112,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20220623
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/time/clock.cc
+++ b/absl/time/clock.cc
@@ -196,7 +196,7 @@ struct ABSL_CACHELINE_ALIGNED TimeState {
   absl::base_internal::SpinLock lock{absl::kConstInit,
                                      base_internal::SCHEDULE_KERNEL_ONLY};
 };
-ABSL_CONST_INIT static TimeState time_state{};
+ABSL_CONST_INIT static TimeState time_state;
 
 // Return the time in ns as told by the kernel interface.  Place in *cycleclock
 // the value of the cycleclock at about the time of the syscall.


### PR DESCRIPTION
It looks to me like the language rules treat these the same for this type, but evidently GCC feels differently.

This only matters under TSAN where SpinLock has a non-trivial destructor, and under C++20 where ABSL_CONST_INIT is implemented (as constinit) by gcc.

Fixes #1253

PiperOrigin-RevId: 469806751
Change-Id: Ic01b0142101f361bc19c95f9f9474e635669c58d