### PR TITLE
Synchronize the --stderrthreshold flag value.

### DIFF
--- a/absl/log/flags.cc
+++ b/absl/log/flags.cc
@@ -39,6 +39,8 @@ namespace {
 void SyncLoggingFlags() {
   absl::SetFlag(&FLAGS_minloglevel, static_cast<int>(absl::MinLogLevel()));
   absl::SetFlag(&FLAGS_log_prefix, absl::ShouldPrependLogPrefix());
+  absl::SetFlag(&FLAGS_stderrthreshold,
+                static_cast<int>(absl::StderrThreshold()));
 }
 
 bool RegisterSyncLoggingFlags() {


### PR DESCRIPTION
The --minloglevel and --log_prefix were already synchronized, so this
corrects an omission.  I also rewrote the tests for these three flags to
cover more of the API surface as well as more edge cases.

Fixes #1266