### PR TITLE
Rename True alias.

### DIFF
--- a/absl/functional/internal/any_invocable.h
+++ b/absl/functional/internal/any_invocable.h
@@ -683,23 +683,23 @@ using UnwrapStdReferenceWrapper =
 // An alias that always yields std::true_type (used with constraints) where
 // substitution failures happen when forming the template arguments.
 template <class... T>
-using True =
+using TrueAlias =
     std::integral_constant<bool, sizeof(absl::void_t<T...>*) != 0>;
 
 /*SFINAE constraints for the conversion-constructor.*/
 template <class Sig, class F,
           class = absl::enable_if_t<
               !std::is_same<RemoveCVRef<F>, AnyInvocable<Sig>>::value>>
-using CanConvert =
-    True<absl::enable_if_t<!IsInPlaceType<RemoveCVRef<F>>::value>,
-         absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
-         absl::enable_if_t<
-             Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
-         absl::enable_if_t<std::is_constructible<absl::decay_t<F>, F>::value>>;
+using CanConvert = TrueAlias<
+    absl::enable_if_t<!IsInPlaceType<RemoveCVRef<F>>::value>,
+    absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    absl::enable_if_t<
+        Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
+    absl::enable_if_t<std::is_constructible<absl::decay_t<F>, F>::value>>;
 
 /*SFINAE constraints for the std::in_place constructors.*/
 template <class Sig, class F, class... Args>
-using CanEmplace = True<
+using CanEmplace = TrueAlias<
     absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
     absl::enable_if_t<
         Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
@@ -709,19 +709,19 @@ using CanEmplace = True<
 template <class Sig, class F,
           class = absl::enable_if_t<
               !std::is_same<RemoveCVRef<F>, AnyInvocable<Sig>>::value>>
-using CanAssign =
-    True<absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
-         absl::enable_if_t<
-             Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
-         absl::enable_if_t<std::is_constructible<absl::decay_t<F>, F>::value>>;
+using CanAssign = TrueAlias<
+    absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    absl::enable_if_t<
+        Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
+    absl::enable_if_t<std::is_constructible<absl::decay_t<F>, F>::value>>;
 
 /*SFINAE constraints for the reference-wrapper conversion-assign operator.*/
 template <class Sig, class F>
-using CanAssignReferenceWrapper =
-    True<absl::enable_if_t<
-             Impl<Sig>::template CallIsValid<std::reference_wrapper<F>>::value>,
-         absl::enable_if_t<Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<
-             std::reference_wrapper<F>>::value>>;
+using CanAssignReferenceWrapper = TrueAlias<
+    absl::enable_if_t<
+        Impl<Sig>::template CallIsValid<std::reference_wrapper<F>>::value>,
+    absl::enable_if_t<Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<
+        std::reference_wrapper<F>>::value>>;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -778,7 +778,7 @@ using CanAssignReferenceWrapper =
                                                                                \
     /*SFINAE constraint to check if F is invocable with the proper signature*/ \
     template <class F>                                                         \
-    using CallIsValid = True<absl::enable_if_t<absl::disjunction<              \
+    using CallIsValid = TrueAlias<absl::enable_if_t<absl::disjunction<         \
         absl::base_internal::is_invocable_r<ReturnType,                        \
                                             absl::decay_t<F> inv_quals, P...>, \
         std::is_same<ReturnType,                                               \
@@ -788,8 +788,8 @@ using CanAssignReferenceWrapper =
     /*SFINAE constraint to check if F is nothrow-invocable when necessary*/    \
     template <class F>                                                         \
     using CallIsNoexceptIfSigIsNoexcept =                                      \
-        True<ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT(inv_quals,        \
-                                                             noex)>;           \
+        TrueAlias<ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT(inv_quals,   \
+                                                                  noex)>;      \
                                                                                \
     /*Put the AnyInvocable into an empty state.*/                              \
     Impl() = default;                                                          \


### PR DESCRIPTION
Rename the `using True =`  alias. This is because many other libraries (albeit through bad design choices) define global macros like `#define True 1` and this causes them to be un-buildable with absl. 