### PR TITLE
Add `!define(__clang__)` for GNU compiler matching

### DIFF
--- a/absl/strings/charconv.cc
+++ b/absl/strings/charconv.cc
@@ -347,7 +347,8 @@ bool HandleEdgeCase(const strings_internal::ParsedFloat& input, bool negative,
     // https://bugs.llvm.org/show_bug.cgi?id=37778
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86113
     constexpr ptrdiff_t kNanBufferSize = 128;
-#if defined(__GNUC__) || (defined(__clang__) && __clang_major__ < 7)
+#if (defined(__GNUC__) && !defined(__clang__)) || \
+    (defined(__clang__) && __clang_major__ < 7)
     volatile char n_char_sequence[kNanBufferSize];
 #else
     char n_char_sequence[kNanBufferSize];


### PR DESCRIPTION
The original PR (https://github.com/abseil/abseil-cpp/pull/1285) left out a condition that did not enforce matching the GNU compiler. The problem comes from clang also defining the `__GNUC__` macro, so clang would escape through the first condition.