### PR TITLE
Few crc32c small improvements

### DIFF
--- a/absl/crc/crc32c.h
+++ b/absl/crc/crc32c.h
@@ -26,7 +26,6 @@
 #define ABSL_CRC_CRC32C_H_
 
 #include <cstdint>
-#include <iostream>
 #include <ostream>
 
 #include "absl/crc/internal/crc32c_inline.h"

--- a/absl/crc/crc32c.h
+++ b/absl/crc/crc32c.h
@@ -51,7 +51,7 @@ constexpr crc32c_t ToCrc32c(uint32_t n) {
 // operator^
 //
 // Performs a bitwise XOR on two CRC32C values
-inline crc32c_t operator^(crc32c_t lhs, crc32c_t rhs) {
+constexpr crc32c_t operator^(crc32c_t lhs, crc32c_t rhs) {
   const auto lhs_int = static_cast<uint32_t>(lhs);
   const auto rhs_int = static_cast<uint32_t>(rhs);
   return ToCrc32c(lhs_int ^ rhs_int);

--- a/absl/crc/crc32c.h
+++ b/absl/crc/crc32c.h
@@ -46,7 +46,7 @@ enum class crc32c_t : uint32_t {};
 //
 // Converts a uint32_t value to crc32c_t. This API is necessary in C++14
 // and earlier. Code targeting C++17-or-later can instead use `crc32c_t{n}`.
-inline crc32c_t ToCrc32c(uint32_t n) {
+constexpr crc32c_t ToCrc32c(uint32_t n) {
   return static_cast<crc32c_t>(n);
 }
 // operator^

--- a/absl/crc/internal/crc_memcpy_x86_64.cc
+++ b/absl/crc/internal/crc_memcpy_x86_64.cc
@@ -164,7 +164,7 @@ crc32c_t AcceleratedCrcMemcpyEngine<vec_regions, int_regions>::Compute(
     void* __restrict dst, const void* __restrict src, std::size_t length,
     crc32c_t initial_crc) const {
   constexpr std::size_t kRegions = vec_regions + int_regions;
-  constexpr crc32c_t kCrcDataXor = crc32c_t{0xffffffff};
+  constexpr crc32c_t kCrcDataXor = ToCrc32c(0xffffffffU);
   constexpr std::size_t kBlockSize = sizeof(__m128i);
   constexpr std::size_t kCopyRoundSize = kRegions * kBlockSize;
 


### PR DESCRIPTION
* Allow ToCrc32c in constexpr context (constexpr function also is inline)
* Remove unnecessary big include
* Fix my local compilation with invalid crc32c_t construction