### PR TITLE
direct_mmap: Use off_t on linux

### DIFF
--- a/absl/base/internal/direct_mmap.h
+++ b/absl/base/internal/direct_mmap.h
@@ -72,7 +72,7 @@ namespace base_internal {
 // Platform specific logic extracted from
 // https://chromium.googlesource.com/linux-syscall-support/+/master/linux_syscall_support.h
 inline void* DirectMmap(void* start, size_t length, int prot, int flags, int fd,
-                        off64_t offset) noexcept {
+                        off_t offset) noexcept {
 #if defined(__i386__) || defined(__ARM_ARCH_3__) || defined(__ARM_EABI__) || \
     defined(__m68k__) || defined(__sh__) ||                                  \
     (defined(__hppa__) && !defined(__LP64__)) ||                             \
@@ -102,7 +102,7 @@ inline void* DirectMmap(void* start, size_t length, int prot, int flags, int fd,
 #else
   return reinterpret_cast<void*>(
       syscall(SYS_mmap2, start, length, prot, flags, fd,
-              static_cast<off_t>(offset / pagesize)));
+              offset / pagesize));
 #endif
 #elif defined(__s390x__)
   // On s390x, mmap() arguments are passed in memory.


### PR DESCRIPTION
off64_t is not provided without defining _LARGEFILE64_SOURCE on musl this define is not defined automatically like glibc where it gets defined when _GNU_SOURCE is defined. Using off_t makes it portable across musl/glibc and for using 64bit off_t on glibc 32bit systems -D_FILE_OFFSET_BITS=64 can be defined during build via CXXFLAGS

Signed-off-by: Khem Raj <raj.khem@gmail.com>