### PR TITLE
Add ABSL_NO_SYMBOLIZE definition to avoid doing symbolization when ne…

### DIFF
--- a/absl/debugging/symbolize.cc
+++ b/absl/debugging/symbolize.cc
@@ -28,7 +28,10 @@
 #define ABSL_INTERNAL_HAVE_SYMBOLIZE_WASM
 #endif
 
-#if defined(ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE)
+
+#if defined(ABSL_NO_SYMBOLIZE)
+#include "absl/debugging/symbolize_unimplemented.inc"
+#elif defined(ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE)
 #include "absl/debugging/symbolize_elf.inc"
 #elif defined(ABSL_INTERNAL_HAVE_SYMBOLIZE_WIN32)
 // The Windows Symbolizer only works if PDB files containing the debug info


### PR DESCRIPTION
XBox platform currently doesn't support dbghelp.lib/.ddl. Add this definition to turn off symbolization when needed.