### PR TITLE
memcpy: Only copy data_ if allocated or size > 0

### DIFF
--- a/absl/container/internal/inlined_vector.h
+++ b/absl/container/internal/inlined_vector.h
@@ -465,7 +465,9 @@ class Storage {
                           other_storage.GetIsAllocated());
 
     GetSizeAndIsAllocated() = other_storage.GetSizeAndIsAllocated();
-    data_ = other_storage.data_;
+    if (GetSizeAndIsAllocated()) {
+      data_ = other_storage.data_;
+    }
   }
 
   void DeallocateIfAllocated() {


### PR DESCRIPTION
Do not copy data_ if not allocated or if size == 0. While copying empty inlined data is harmless, the data_ being copied from may be uninitialized, resulting into a compiler warning like this:
```
external/com_google_absl/absl/container/internal/inlined_vector.h:448:5: error: '<unnamed>.absl::InlinedVector<char, 128, std::allocator<char> >::storage_.absl::inlined_vector_internal::Storage<char, 128, std::allocator<char> >::data_' is used uninitialized [-Werror=uninitialized]
  448 |     data_ = other_storage.data_;
      |     ^~~~~
```
Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>