### PR TITLE
Solving issue with implied SSE when running ARM64EC

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -889,7 +889,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #error ABSL_INTERNAL_HAVE_SSE cannot be directly set
 #elif defined(__SSE__)
 #define ABSL_INTERNAL_HAVE_SSE 1
-#elif defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
+#elif (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)) && !defined(_M_ARM64EC)
 // MSVC only defines _M_IX86_FP for x86 32-bit code, and _M_IX86_FP >= 1
 // indicates that at least SSE was targeted with the /arch:SSE option.
 // All x86-64 processors support SSE, so support can be assumed.
@@ -904,7 +904,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #error ABSL_INTERNAL_HAVE_SSE2 cannot be directly set
 #elif defined(__SSE2__)
 #define ABSL_INTERNAL_HAVE_SSE2 1
-#elif defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#elif (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)) && !defined(_M_ARM64EC)
 // MSVC only defines _M_IX86_FP for x86 32-bit code, and _M_IX86_FP >= 2
 // indicates that at least SSE2 was targeted with the /arch:SSE2 option.
 // All x86-64 processors support SSE2, so support can be assumed.


### PR DESCRIPTION
There is an issue in ARM64EC: implying that all x86-64 processors support SSE, so support can be assumed when setting the SSE flags. On Windows 11, ARM64EC is a ARM64 ABI that is interoperable with x64. With that, the macro for x64 (_M_X64) is defined when compiling with ARM64EC and in turn, both the ABSL_INTERNAL_HAVE_SSE and ABSL_INTERNAL_HAVE_SSE 2 flags are set to 1 in the config.h file. Since these flags are set to 1, intrinsic functions such as _mm_prefetch and builtin_ia32_pandn128 are being called during ARM64EC compilation**. However, when compiling, these intrinsic functions are not supported.

This change only sets SSE* settings to 1 if it is not ARM64EC so that intrinsic functions would not be called during ARM compilation and we would take ARM-specific code paths rather than x64.

**The intrinsic function _mm_prefetch in prefetch.h is called since ABSL_INTERNAL_HAVE_SSE is set to 1. The intrinsic function (builtin_ia32_pandn128) is called by another function (_mm_andnot_si128) which is called by another function _mm_or_si128 in raw_hash_set.h. This was done because ABSL_INTERNAL_HAVE_SSE2 was set to 1.

Similar to this [PR](https://github.com/abseil/abseil-cpp/pull/1135)