### PR TITLE
Remove Workarounds for Old Clang Bug

### DIFF
--- a/absl/numeric/int128.cc
+++ b/absl/numeric/int128.cc
@@ -111,7 +111,7 @@ uint128 MakeUint128FromFloat(T v) {
   return MakeUint128(0, static_cast<uint64_t>(v));
 }
 
-#if defined(__clang__) && !defined(__SSE3__)
+#if defined(__clang__) && (__clang_major__ < 9) && !defined(__SSE3__)
 // Workaround for clang bug: https://bugs.llvm.org/show_bug.cgi?id=38289
 // Casting from long double to uint64_t is miscompiled and drops bits.
 // It is more work, so only use when we need the workaround.

--- a/absl/strings/internal/str_format/float_conversion.cc
+++ b/absl/strings/internal/str_format/float_conversion.cc
@@ -1102,7 +1102,7 @@ void PrintExponent(int exp, char e, Buffer *out) {
 template <typename Float, typename Int>
 constexpr bool CanFitMantissa() {
   return
-#if defined(__clang__) && !defined(__SSE3__)
+#if defined(__clang__) && (__clang_major__ < 9) && !defined(__SSE3__)
       // Workaround for clang bug: https://bugs.llvm.org/show_bug.cgi?id=38289
       // Casting from long double to uint64_t is miscompiled and drops bits.
       (!std::is_same<Float, long double>::value ||


### PR DESCRIPTION
https://bugs.llvm.org/show_bug.cgi?id=38289 has been addressed since 2019.

We just have to check to see if the clang being used to compile with is any version before major version 9.