### PR TITLE
Prefer static variable std::string::npos over access via instance

### DIFF
--- a/absl/log/flags.cc
+++ b/absl/log/flags.cc
@@ -93,7 +93,7 @@ ABSL_FLAG(std::string, log_backtrace_at, "",
       if (log_backtrace_at.empty()) return;
 
       const size_t last_colon = log_backtrace_at.rfind(':');
-      if (last_colon == log_backtrace_at.npos) return;
+      if (last_colon == std::string::npos) return;
 
       const absl::string_view file =
           absl::string_view(log_backtrace_at).substr(0, last_colon);

--- a/absl/log/internal/log_message.cc
+++ b/absl/log/internal/log_message.cc
@@ -106,7 +106,7 @@ absl::string_view Basename(absl::string_view filepath) {
 #else
   size_t path = filepath.find_last_of('/');
 #endif
-  if (path != filepath.npos) filepath.remove_prefix(path + 1);
+  if (path != std::string::npos) filepath.remove_prefix(path + 1);
   return filepath;
 }
 

--- a/absl/log/stripping_test.cc
+++ b/absl/log/stripping_test.cc
@@ -116,7 +116,7 @@ class FileHasSubstrMatcher final : public ::testing::MatcherInterface<FILE*> {
       }
       const absl::string_view haystack(&buf[0], buf_data_size);
       const auto off = haystack.find(needle_);
-      if (off != haystack.npos) {
+      if (off != std::string::npos) {
         *listener << "string found at offset " << buf_start_offset + off;
         return true;
       }

--- a/absl/strings/match.h
+++ b/absl/strings/match.h
@@ -45,11 +45,11 @@ ABSL_NAMESPACE_BEGIN
 // Returns whether a given string `haystack` contains the substring `needle`.
 inline bool StrContains(absl::string_view haystack,
                         absl::string_view needle) noexcept {
-  return haystack.find(needle, 0) != haystack.npos;
+  return haystack.find(needle, 0) != std::string::npos;
 }
 
 inline bool StrContains(absl::string_view haystack, char needle) noexcept {
-  return haystack.find(needle) != haystack.npos;
+  return haystack.find(needle) != std::string::npos;
 }
 
 // StartsWith()

--- a/absl/strings/str_replace.cc
+++ b/absl/strings/str_replace.cc
@@ -43,7 +43,7 @@ int ApplySubstitutions(
       substitutions += 1;
     }
     sub.offset = s.find(sub.old, pos);
-    if (sub.offset == s.npos) {
+    if (sub.offset == std::string::npos) {
       subs.pop_back();
     } else {
       // Insertion sort to ensure the last ViableSubstitution continues to be

--- a/absl/strings/str_replace.h
+++ b/absl/strings/str_replace.h
@@ -165,7 +165,7 @@ std::vector<ViableSubstitution> FindSubstitutions(
     absl::string_view old(get<0>(rep));
 
     size_t pos = s.find(old);
-    if (pos == s.npos) continue;
+    if (pos == std::string::npos) continue;
 
     // Ignore attempts to replace "". This condition is almost never true,
     // but above condition is frequently true. That's why we test for this

--- a/absl/strings/string_view_test.cc
+++ b/absl/strings/string_view_test.cc
@@ -1110,7 +1110,7 @@ TEST(StringViewTest, ConstexprCompiles) {
   EXPECT_EQ(np, nullptr);
   EXPECT_NE(cstr_ptr, nullptr);
 
-  constexpr size_t sp_npos = sp.npos;
+  constexpr size_t sp_npos = std::string::npos;
   EXPECT_EQ(sp_npos, static_cast<size_t>(-1));
 }
 


### PR DESCRIPTION
npos is the same for all strings, so comparing to std::string::npos over the npos field of the string instances being check is clearer.