### PR TITLE
Use noexcept for move constructors

### DIFF
--- a/absl/cleanup/cleanup.h
+++ b/absl/cleanup/cleanup.h
@@ -88,7 +88,7 @@ class ABSL_MUST_USE_RESULT Cleanup final {
  public:
   Cleanup(Callback callback) : storage_(std::move(callback)) {}  // NOLINT
 
-  Cleanup(Cleanup&& other) = default;
+  Cleanup(Cleanup&& other) noexcept = default;
 
   void Cancel() && {
     ABSL_HARDENING_ASSERT(storage_.IsCallbackEngaged());

--- a/absl/cleanup/internal/cleanup.h
+++ b/absl/cleanup/internal/cleanup.h
@@ -55,7 +55,7 @@ class Storage {
     is_callback_engaged_ = true;
   }
 
-  Storage(Storage&& other) {
+  Storage(Storage&& other) noexcept {
     ABSL_HARDENING_ASSERT(other.IsCallbackEngaged());
 
     ::new (GetCallbackBuffer()) Callback(std::move(other.GetCallback()));

--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -781,7 +781,8 @@ class CommonFieldsGenerationInfoEnabled {
 
  public:
   CommonFieldsGenerationInfoEnabled() = default;
-  CommonFieldsGenerationInfoEnabled(CommonFieldsGenerationInfoEnabled&& that)
+  CommonFieldsGenerationInfoEnabled(
+      CommonFieldsGenerationInfoEnabled&& that) noexcept
       : reserved_growth_(that.reserved_growth_), generation_(that.generation_) {
     that.reserved_growth_ = 0;
     that.generation_ = EmptyGeneration();
@@ -901,7 +902,7 @@ class CommonFields : public CommonFieldsGenerationInfo {
   CommonFields& operator=(const CommonFields&) = delete;
 
   // Movable
-  CommonFields(CommonFields&& that)
+  CommonFields(CommonFields&& that) noexcept
       : CommonFieldsGenerationInfo(
             std::move(static_cast<CommonFieldsGenerationInfo&&>(that))),
         // Explicitly copying fields into "this" and then resetting "that"
@@ -2457,7 +2458,7 @@ class raw_hash_set {
     const size_t cap = capacity();
     if (cap > Group::kWidth &&
         // Do these calcuations in 64-bit to avoid overflow.
-        size() * uint64_t{32} <= cap* uint64_t{25}) {
+        size() * uint64_t{32} <= cap * uint64_t{25}) {
       // Squash DELETED without growing if there is enough capacity.
       //
       // Rehash in place if the current size is <= 25/32 of capacity.

--- a/absl/crc/internal/crc_cord_state.cc
+++ b/absl/crc/internal/crc_cord_state.cc
@@ -42,7 +42,7 @@ CrcCordState::CrcCordState(const CrcCordState& other)
 }
 
 CrcCordState::CrcCordState(CrcCordState&& other)
-    : refcounted_rep_(other.refcounted_rep_) {
+    : refcounted_rep_(other.refcounted_rep_) noexcept {
   // Make `other` valid for use after move.
   other.refcounted_rep_ = RefSharedEmptyRep();
 }
@@ -56,7 +56,7 @@ CrcCordState& CrcCordState::operator=(const CrcCordState& other) {
   return *this;
 }
 
-CrcCordState& CrcCordState::operator=(CrcCordState&& other) {
+CrcCordState& CrcCordState::operator=(CrcCordState&& other) noexcept {
   if (this != &other) {
     Unref(refcounted_rep_);
     refcounted_rep_ = other.refcounted_rep_;
@@ -66,9 +66,7 @@ CrcCordState& CrcCordState::operator=(CrcCordState&& other) {
   return *this;
 }
 
-CrcCordState::~CrcCordState() {
-  Unref(refcounted_rep_);
-}
+CrcCordState::~CrcCordState() { Unref(refcounted_rep_); }
 
 crc32c_t CrcCordState::Checksum() const {
   if (rep().prefix_crc.empty()) {

--- a/absl/crc/internal/crc_cord_state.h
+++ b/absl/crc/internal/crc_cord_state.h
@@ -43,14 +43,14 @@ class CrcCordState {
   // Constructors.
   CrcCordState();
   CrcCordState(const CrcCordState&);
-  CrcCordState(CrcCordState&&);
+  CrcCordState(CrcCordState&&) noexcept;
 
   // Destructor. Atomically unreferences the data.
   ~CrcCordState();
 
   // Copy and move operators.
   CrcCordState& operator=(const CrcCordState&);
-  CrcCordState& operator=(CrcCordState&&);
+  CrcCordState& operator=(CrcCordState&&) noexcept;
 
   // A (length, crc) pair.
   struct PrefixCrc {

--- a/absl/random/internal/pool_urbg.h
+++ b/absl/random/internal/pool_urbg.h
@@ -106,8 +106,8 @@ class PoolURBG {
   }
 
   // move-constructor does move cache.
-  PoolURBG(PoolURBG&&) = default;
-  PoolURBG& operator=(PoolURBG&&) = default;
+  PoolURBG(PoolURBG&&) noexcept = default;
+  PoolURBG& operator=(PoolURBG&&) noexcept = default;
 
   inline result_type operator()() {
     if (next_ >= kBufferSize) {

--- a/absl/random/internal/salted_seed_seq.h
+++ b/absl/random/internal/salted_seed_seq.h
@@ -61,8 +61,8 @@ class SaltedSeedSeq {
   SaltedSeedSeq(const SaltedSeedSeq&) = delete;
   SaltedSeedSeq& operator=(const SaltedSeedSeq&) = delete;
 
-  SaltedSeedSeq(SaltedSeedSeq&&) = default;
-  SaltedSeedSeq& operator=(SaltedSeedSeq&&) = default;
+  SaltedSeedSeq(SaltedSeedSeq&&) noexcept = default;
+  SaltedSeedSeq& operator=(SaltedSeedSeq&&) noexcept = default;
 
   template <typename RandomAccessIterator>
   void generate(RandomAccessIterator begin, RandomAccessIterator end) {

--- a/absl/status/internal/statusor_internal.h
+++ b/absl/status/internal/statusor_internal.h
@@ -225,7 +225,7 @@ class StatusOrData {
     return *this;
   }
 
-  StatusOrData& operator=(StatusOrData&& other) {
+  StatusOrData& operator=(StatusOrData&& other) noexcept {
     if (this == &other) return *this;
     if (other.ok())
       Assign(std::move(other.data_));

--- a/absl/status/status.h
+++ b/absl/status/status.h
@@ -445,7 +445,7 @@ class Status final {
 
   // The moved-from state is valid but unspecified.
   Status(Status&&) noexcept;
-  Status& operator=(Status&&);
+  Status& operator=(Status&&) noexcept;
 
   ~Status();
 
@@ -775,7 +775,7 @@ inline Status::Status(Status&& x) noexcept : rep_(x.rep_) {
   x.rep_ = MovedFromRep();
 }
 
-inline Status& Status::operator=(Status&& x) {
+inline Status& Status::operator=(Status&& x) noexcept {
   uintptr_t old_rep = rep_;
   if (x.rep_ != old_rep) {
     rep_ = x.rep_;

--- a/absl/status/statusor.cc
+++ b/absl/status/statusor.cc
@@ -40,7 +40,8 @@ BadStatusOrAccess& BadStatusOrAccess::operator=(
   return *this;
 }
 
-BadStatusOrAccess& BadStatusOrAccess::operator=(BadStatusOrAccess&& other) {
+BadStatusOrAccess& BadStatusOrAccess::operator=(
+    BadStatusOrAccess&& other) noexcept {
   // Ensure assignment is correct regardless of whether this->InitWhat() has
   // already been called.
   other.InitWhat();
@@ -49,7 +50,7 @@ BadStatusOrAccess& BadStatusOrAccess::operator=(BadStatusOrAccess&& other) {
   return *this;
 }
 
-BadStatusOrAccess::BadStatusOrAccess(BadStatusOrAccess&& other)
+BadStatusOrAccess::BadStatusOrAccess(BadStatusOrAccess&& other) noexcept
     : status_(std::move(other.status_)) {}
 
 const char* BadStatusOrAccess::what() const noexcept {

--- a/absl/status/statusor.h
+++ b/absl/status/statusor.h
@@ -77,8 +77,8 @@ class BadStatusOrAccess : public std::exception {
 
   BadStatusOrAccess(const BadStatusOrAccess& other);
   BadStatusOrAccess& operator=(const BadStatusOrAccess& other);
-  BadStatusOrAccess(BadStatusOrAccess&& other);
-  BadStatusOrAccess& operator=(BadStatusOrAccess&& other);
+  BadStatusOrAccess(BadStatusOrAccess&& other) noexcept;
+  BadStatusOrAccess& operator=(BadStatusOrAccess&& other) noexcept;
 
   // BadStatusOrAccess::what()
   //
@@ -218,10 +218,10 @@ class StatusOr : private internal_statusor::StatusOrData<T>,
   StatusOr& operator=(const StatusOr&) = default;
 
   // `StatusOr<T>` is move constructible if `T` is move constructible.
-  StatusOr(StatusOr&&) = default;
+  StatusOr(StatusOr&&) noexcept = default;
   // `StatusOr<T>` is moveAssignable if `T` is move constructible and move
   // assignable.
-  StatusOr& operator=(StatusOr&&) = default;
+  StatusOr& operator=(StatusOr&&) noexcept = default;
 
   // Converting Constructors
 

--- a/absl/strings/internal/cord_rep_consume.cc
+++ b/absl/strings/internal/cord_rep_consume.cc
@@ -54,7 +54,7 @@ void Consume(CordRep* rep, ConsumeFn consume_fn) {
 }
 
 void ReverseConsume(CordRep* rep, ConsumeFn consume_fn) {
-  return Consume(rep, std::move(consume_fn));
+  return Consume(rep, consume_fn);
 }
 
 }  // namespace cord_internal

--- a/absl/strings/internal/ostringstream.h
+++ b/absl/strings/internal/ostringstream.h
@@ -69,14 +69,13 @@ class OStringStream final : public std::ostream {
   //
   // The destructor of OStringStream doesn't use the std::string. It's OK to
   // destroy the std::string before the stream.
-  explicit OStringStream(std::string* str)
-      : std::ostream(&buf_), buf_(str) {}
-  OStringStream(OStringStream&& that)
+  explicit OStringStream(std::string* str) : std::ostream(&buf_), buf_(str) {}
+  OStringStream(OStringStream&& that) noexcept
       : std::ostream(std::move(static_cast<std::ostream&>(that))),
         buf_(that.buf_) {
     rdbuf(&buf_);
   }
-  OStringStream& operator=(OStringStream&& that) {
+  OStringStream& operator=(OStringStream&& that) noexcept {
     std::ostream::operator=(std::move(static_cast<std::ostream&>(that)));
     buf_ = that.buf_;
     rdbuf(&buf_);

--- a/absl/strings/internal/str_format/parser.h
+++ b/absl/strings/internal/str_format/parser.h
@@ -124,7 +124,9 @@ class ParsedFormatBase {
 
   ParsedFormatBase(const ParsedFormatBase& other) { *this = other; }
 
-  ParsedFormatBase(ParsedFormatBase&& other) { *this = std::move(other); }
+  ParsedFormatBase(ParsedFormatBase&& other) noexcept {
+    *this = std::move(other);
+  }
 
   ParsedFormatBase& operator=(const ParsedFormatBase& other) {
     if (this == &other) return *this;
@@ -136,7 +138,7 @@ class ParsedFormatBase {
     return *this;
   }
 
-  ParsedFormatBase& operator=(ParsedFormatBase&& other) {
+  ParsedFormatBase& operator=(ParsedFormatBase&& other) noexcept {
     if (this == &other) return *this;
     has_error_ = other.has_error_;
     data_ = std::move(other.data_);
@@ -185,7 +187,6 @@ class ParsedFormatBase {
   std::unique_ptr<char[]> data_;
   std::vector<ConversionItem> items_;
 };
-
 
 // A value type representing a preparsed format.  These can be created, copied
 // around, and reused to speed up formatting loops.

--- a/absl/types/internal/variant.h
+++ b/absl/types/internal/variant.h
@@ -1274,12 +1274,12 @@ class VariantStateBaseDestructorNontrivial : protected VariantStateBase<T...> {
   using Base::Base;
 
   VariantStateBaseDestructorNontrivial() = default;
-  VariantStateBaseDestructorNontrivial(VariantStateBaseDestructorNontrivial&&) =
-      default;
+  VariantStateBaseDestructorNontrivial(
+      VariantStateBaseDestructorNontrivial&&) noexcept = default;
   VariantStateBaseDestructorNontrivial(
       const VariantStateBaseDestructorNontrivial&) = default;
   VariantStateBaseDestructorNontrivial& operator=(
-      VariantStateBaseDestructorNontrivial&&) = default;
+      VariantStateBaseDestructorNontrivial&&) noexcept = default;
   VariantStateBaseDestructorNontrivial& operator=(
       const VariantStateBaseDestructorNontrivial&) = default;
 
@@ -1340,7 +1340,8 @@ class VariantMoveBaseNontrivial : protected VariantStateBaseDestructor<T...> {
 
   VariantMoveBaseNontrivial(VariantMoveBaseNontrivial const&) = default;
 
-  VariantMoveBaseNontrivial& operator=(VariantMoveBaseNontrivial&&) = default;
+  VariantMoveBaseNontrivial& operator=(VariantMoveBaseNontrivial&&) noexcept =
+      default;
   VariantMoveBaseNontrivial& operator=(VariantMoveBaseNontrivial const&) =
       default;
 
@@ -1358,7 +1359,7 @@ class VariantCopyBaseNontrivial : protected VariantMoveBase<T...> {
   using Base::Base;
 
   VariantCopyBaseNontrivial() = default;
-  VariantCopyBaseNontrivial(VariantCopyBaseNontrivial&&) = default;
+  VariantCopyBaseNontrivial(VariantCopyBaseNontrivial&&) noexcept = default;
 
   struct Construct {
     template <std::size_t I>
@@ -1381,7 +1382,8 @@ class VariantCopyBaseNontrivial : protected VariantMoveBase<T...> {
     index_ = other.index_;
   }
 
-  VariantCopyBaseNontrivial& operator=(VariantCopyBaseNontrivial&&) = default;
+  VariantCopyBaseNontrivial& operator=(VariantCopyBaseNontrivial&&) noexcept =
+      default;
   VariantCopyBaseNontrivial& operator=(VariantCopyBaseNontrivial const&) =
       default;
 
@@ -1401,7 +1403,8 @@ class VariantMoveAssignBaseNontrivial : protected VariantCopyBase<T...> {
   using Base::Base;
 
   VariantMoveAssignBaseNontrivial() = default;
-  VariantMoveAssignBaseNontrivial(VariantMoveAssignBaseNontrivial&&) = default;
+  VariantMoveAssignBaseNontrivial(VariantMoveAssignBaseNontrivial&&) noexcept =
+      default;
   VariantMoveAssignBaseNontrivial(const VariantMoveAssignBaseNontrivial&) =
       default;
   VariantMoveAssignBaseNontrivial& operator=(
@@ -1432,11 +1435,12 @@ class VariantCopyAssignBaseNontrivial : protected VariantMoveAssignBase<T...> {
   using Base::Base;
 
   VariantCopyAssignBaseNontrivial() = default;
-  VariantCopyAssignBaseNontrivial(VariantCopyAssignBaseNontrivial&&) = default;
+  VariantCopyAssignBaseNontrivial(VariantCopyAssignBaseNontrivial&&) noexcept =
+      default;
   VariantCopyAssignBaseNontrivial(const VariantCopyAssignBaseNontrivial&) =
       default;
   VariantCopyAssignBaseNontrivial& operator=(
-      VariantCopyAssignBaseNontrivial&&) = default;
+      VariantCopyAssignBaseNontrivial&&) noexcept = default;
 
   VariantCopyAssignBaseNontrivial& operator=(
       const VariantCopyAssignBaseNontrivial& other) {

--- a/absl/types/optional.h
+++ b/absl/types/optional.h
@@ -139,7 +139,7 @@ class optional : private optional_internal::optional_data<T>,
   optional(const optional&) = default;
 
   // Move constructor, standard semantics
-  optional(optional&&) = default;
+  optional(optional&&) noexcept = default;
 
   // Constructs a non-empty `optional` direct-initialized value of type `T` from
   // the arguments `std::forward<Args>(args)...`  within the `optional`.
@@ -279,7 +279,7 @@ class optional : private optional_internal::optional_data<T>,
   optional& operator=(const optional& src) = default;
 
   // Move assignment operator, standard semantics
-  optional& operator=(optional&& src) = default;
+  optional& operator=(optional&& src) noexcept = default;
 
   // Value assignment operators
   template <typename U = T,


### PR DESCRIPTION
We should not throw exceptions during move constructors.