### PR TITLE
Simplify trivial boolean expressions

### DIFF
--- a/absl/debugging/internal/demangle.cc
+++ b/absl/debugging/internal/demangle.cc
@@ -914,7 +914,7 @@ static bool ParseSeqId(State *state) {
   if (guard.IsTooComplex()) return false;
   const char *p = RemainingInput(state);
   for (; *p != '\0'; ++p) {
-    if (!IsDigit(*p) && !(*p >= 'A' && *p <= 'Z')) {
+    if (!IsDigit(*p) && IsLower(*p)) {
       break;
     }
   }

--- a/absl/synchronization/blocking_counter.cc
+++ b/absl/synchronization/blocking_counter.cc
@@ -31,7 +31,7 @@ bool IsDone(void *arg) { return *reinterpret_cast<bool *>(arg); }
 BlockingCounter::BlockingCounter(int initial_count)
     : count_(initial_count),
       num_waiting_(0),
-      done_{initial_count == 0 ? true : false} {
+      done_{initial_count == 0} {
   ABSL_RAW_CHECK(initial_count >= 0, "BlockingCounter initial_count negative");
 }
 

--- a/absl/types/optional.h
+++ b/absl/types/optional.h
@@ -604,7 +604,7 @@ constexpr auto operator==(const optional<T>& x, const optional<U>& y)
     -> decltype(optional_internal::convertible_to_bool(*x == *y)) {
   return static_cast<bool>(x) != static_cast<bool>(y)
              ? false
-             : static_cast<bool>(x) == false ? true
+             : !static_cast<bool>(x) ? true
                                              : static_cast<bool>(*x == *y);
 }
 
@@ -615,7 +615,7 @@ constexpr auto operator!=(const optional<T>& x, const optional<U>& y)
     -> decltype(optional_internal::convertible_to_bool(*x != *y)) {
   return static_cast<bool>(x) != static_cast<bool>(y)
              ? true
-             : static_cast<bool>(x) == false ? false
+             : !static_cast<bool>(x) ? false
                                              : static_cast<bool>(*x != *y);
 }
 // Returns: If !y, false; otherwise, if !x, true; otherwise *x < *y.


### PR DESCRIPTION
There is no reason to manually compare with true or false when the boolean operators do that for us.