### PR TITLE
Convert empty constructors to default ones

### DIFF
--- a/absl/crc/internal/crc_internal.h
+++ b/absl/crc/internal/crc_internal.h
@@ -64,7 +64,7 @@ class CRCImpl : public CRC {  // Implemention of the abstract class CRC
  public:
   using Uint32By256 = uint32_t[256];
 
-  CRCImpl() {}
+  CRCImpl() = default;
   ~CRCImpl() override = default;
 
   // The internal version of CRC::New().
@@ -96,8 +96,8 @@ class CRCImpl : public CRC {  // Implemention of the abstract class CRC
 // This is the 32-bit implementation.  It handles all sizes from 8 to 32.
 class CRC32 : public CRCImpl {
  public:
-  CRC32() {}
-  ~CRC32() override {}
+  CRC32() = default;
+  ~CRC32() override = default;
 
   void Extend(uint32_t* crc, const void* bytes, size_t length) const override;
   void ExtendByZeroes(uint32_t* crc, size_t length) const override;

--- a/absl/debugging/leak_check.cc
+++ b/absl/debugging/leak_check.cc
@@ -65,8 +65,8 @@ bool LeakCheckerIsActive() { return false; }
 void DoIgnoreLeak(const void*) { }
 void RegisterLivePointers(const void*, size_t) { }
 void UnRegisterLivePointers(const void*, size_t) { }
-LeakCheckDisabler::LeakCheckDisabler() { }
-LeakCheckDisabler::~LeakCheckDisabler() { }
+LeakCheckDisabler::LeakCheckDisabler() = default;
+LeakCheckDisabler::~LeakCheckDisabler() = default;
 ABSL_NAMESPACE_END
 }  // namespace absl
 

--- a/absl/flags/internal/commandlineflag.cc
+++ b/absl/flags/internal/commandlineflag.cc
@@ -19,7 +19,7 @@ namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace flags_internal {
 
-FlagStateInterface::~FlagStateInterface() {}
+FlagStateInterface::~FlagStateInterface() = default;
 
 }  // namespace flags_internal
 ABSL_NAMESPACE_END

--- a/absl/log/internal/nullstream.h
+++ b/absl/log/internal/nullstream.h
@@ -114,7 +114,7 @@ class NullStreamMaybeFatal final : public NullStream {
 // and expression-defined severity use `NullStreamMaybeFatal` above.
 class NullStreamFatal final : public NullStream {
  public:
-  NullStreamFatal() {}
+  NullStreamFatal() = default;
   // ABSL_ATTRIBUTE_NORETURN doesn't seem to work on destructors with msvc, so
   // disable msvc's warning about the d'tor never returning.
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/absl/types/optional.h
+++ b/absl/types/optional.h
@@ -130,7 +130,7 @@ class optional : private optional_internal::optional_data<T>,
 
   // Constructs an `optional` holding an empty value, NOT a default constructed
   // `T`.
-  constexpr optional() noexcept {}
+  constexpr optional() noexcept = default;
 
   // Constructs an `optional` initialized with `nullopt` to hold an empty value.
   constexpr optional(nullopt_t) noexcept {}  // NOLINT(runtime/explicit)


### PR DESCRIPTION
These make the changed constructors match closer to the other ones that are default.