### PR TITLE
Make `SanitizerSafeCopy()` constexpr, and check for constant evaluation

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -112,7 +112,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20230125
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/strings/internal/cord_internal.h
+++ b/absl/strings/internal/cord_internal.h
@@ -768,18 +768,22 @@ class InlineData {
     }
 
 #ifdef ABSL_INTERNAL_CORD_HAVE_SANITIZER
-    Rep SanitizerSafeCopy() const {
-      Rep res;
-      if (is_tree()) {
-        res = *this;
+    constexpr Rep SanitizerSafeCopy() const {
+      if (!absl::is_constant_evaluated()) {
+        Rep res;
+        if (is_tree()) {
+          res = *this;
+        } else {
+          res.set_tag(tag());
+          memcpy(res.as_chars(), as_chars(), inline_size());
+        }
+        return res;
       } else {
-        res.set_tag(tag());
-        memcpy(res.as_chars(), as_chars(), inline_size());
+        return *this;
       }
-      return res;
     }
 #else
-    const Rep& SanitizerSafeCopy() const { return *this; }
+    constexpr const Rep& SanitizerSafeCopy() const { return *this; }
 #endif
 
     // If the data has length <= kMaxInline, we store it in `data`, and

--- a/ci/linux_docker_containers.sh
+++ b/ci/linux_docker_containers.sh
@@ -16,6 +16,6 @@
 # Test scripts should source this file to get the identifiers.
 
 readonly LINUX_ALPINE_CONTAINER="gcr.io/google.com/absl-177019/alpine:20201026"
-readonly LINUX_CLANG_LATEST_CONTAINER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20220217"
-readonly LINUX_GCC_LATEST_CONTAINER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20220217"
+readonly LINUX_CLANG_LATEST_CONTAINER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20230217"
+readonly LINUX_GCC_LATEST_CONTAINER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20230217"
 readonly LINUX_GCC_FLOOR_CONTAINER="gcr.io/google.com/absl-177019/linux_gcc-floor:20230120"


### PR DESCRIPTION
Also update test Docker container so that LTS patches can be tested

This patch cherry-picks 2 commits:
a0f9b465212aea24d3264b82d315b8ee59e8d7a0
35e8e3f7a2c6972d4c591448e8bbe4f9ed9f815a

Fixes https://github.com/abseil/abseil-cpp/issues/1379