### PR TITLE
Allow later versions of Xcode to not have the apple_build_version workaround

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -1136,7 +1136,7 @@ class ABSL_DLL MixingHashState : public HashStateBase<MixingHashState> {
   // probably per-build and not per-process.
   ABSL_ATTRIBUTE_ALWAYS_INLINE static uint64_t Seed() {
 #if (!defined(__clang__) || __clang_major__ > 11) && \
-    !defined(__apple_build_version__)
+    (!defined(__apple_build_version__) || __apple_build_version__ >= 19558921) // Xcode 12
     return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&kSeed));
 #else
     // Workaround the absence of


### PR DESCRIPTION
Apple's clang fork has the missing commit now, and we can safely use the above codepath.