### PR TITLE
Fix compiling int128.cc against certain STLs

### DIFF
--- a/absl/numeric/int128.cc
+++ b/absl/numeric/int128.cc
@@ -216,9 +216,9 @@ std::ostream& operator<<(std::ostream& os, uint128 v) {
     } else if (adjustfield == std::ios::internal &&
                (flags & std::ios::showbase) &&
                (flags & std::ios::basefield) == std::ios::hex && v != 0) {
-      rep.insert(2, count, os.fill());
+      rep.insert((size_t)2, count, os.fill());
     } else {
-      rep.insert(0, count, os.fill());
+      rep.insert((size_t)0, count, os.fill());
     }
   }
 
@@ -314,16 +314,16 @@ std::ostream& operator<<(std::ostream& os, int128 v) {
         break;
       case std::ios::internal:
         if (print_as_decimal && (rep[0] == '+' || rep[0] == '-')) {
-          rep.insert(1, count, os.fill());
+          rep.insert(1u, count, os.fill());
         } else if ((flags & std::ios::basefield) == std::ios::hex &&
                    (flags & std::ios::showbase) && v != 0) {
-          rep.insert(2, count, os.fill());
+          rep.insert((size_t)2, count, os.fill());
         } else {
-          rep.insert(0, count, os.fill());
+          rep.insert((size_t)0, count, os.fill());
         }
         break;
       default:  // std::ios::right
-        rep.insert(0, count, os.fill());
+        rep.insert((size_t)0, count, os.fill());
         break;
     }
   }


### PR DESCRIPTION
We use patched libc++ which uses raw pointers as std::string iterators.
Compiling abseil-cpp against our libc++ results in the following ambious call:

```
absl/numeric/int128.cc:221:11: error: call to member function 'insert' is ambiguous
      rep.insert(0u, count, os.fill());
      ~~~~^~~~~~
libcxx/include/string:1153:19: note: candidate function
    basic_string& insert(size_type __pos, size_type __n, value_type __c);
                  ^
libcxx/include/string:1156:19: note: candidate function
    iterator      insert(const_iterator __pos, size_type __n, value_type __c);
```

This PR adds explicit casts to help the compiler.
Unfortutalety it is not enough to add `u` suffix, and `us` literal was only added in C++23.