### PR TITLE
Filter out `-Xarch_` flags from pkg-config files

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -186,8 +186,16 @@ function(absl_cc_library)
         endif()
       endif()
     endforeach()
+    set(skip_next_cflag OFF)
     foreach(cflag ${ABSL_CC_LIB_COPTS})
-      if(${cflag} MATCHES "^(-Wno|/wd)")
+      if(skip_next_cflag)
+        set(skip_next_cflag OFF)
+      elseif(${cflag} MATCHES "^-Xarch_")
+        # An -Xarch_ flag implies that its successor only applies to the
+        # specified platform. Filter both of them out before the successor
+        # reaches the "^-m" filter.
+        set(skip_next_cflag ON)
+      elseif(${cflag} MATCHES "^(-Wno|/wd)")
         # These flags are needed to suppress warnings that might fire in our headers.
         set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")
       elseif(${cflag} MATCHES "^(-W|/w[1234eo])")


### PR DESCRIPTION
In Clang, an `-Xarch_` compiler flag indicates that its successor only applies to the specified platform (e.g., `-Xarch_x86_64 -maes`). This is used in `absl/copts/AbseilConfigureCopts.cmake` to selectively enable hardware AES support on Apple platforms.

However, when generating pkg-config files, those `-m` flags are filtered out, while the `-Xarch_` flags that precede them are left untouched. This led to the error reported in #1408.

Fix that by filtering out each `-Xarch_` flag with its successor at once.

Fixes #1408.