### PR TITLE
Fix the implementation of OnlyLiteralZero

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -112,7 +112,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20230125
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 2
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x


### PR DESCRIPTION
This patch changes the implementation of OnlyLiteralZero to only fail if the second overload is chosen, instead of failing during overload resolution.

This patch cherry-picks 2de126cc5826a8d464270ead65a7a9a7b012b741.

Fixes #1419