### PR TITLE
Make flat_hash_map and flat_hash_set default constructors constexpr

### DIFF
--- a/absl/container/flat_hash_map.h
+++ b/absl/container/flat_hash_map.h
@@ -156,7 +156,7 @@ class flat_hash_map : public absl::container_internal::raw_hash_map<
   //
   //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
   //   absl::flat_hash_map<int, std::string> map7(v.begin(), v.end());
-  flat_hash_map() {}
+  constexpr flat_hash_map() {}
   using Base::Base;
 
   // flat_hash_map::begin()

--- a/absl/container/flat_hash_map_test.cc
+++ b/absl/container/flat_hash_map_test.cc
@@ -48,6 +48,11 @@ struct BeforeMain {
 };
 const BeforeMain before_main;
 
+#if defined(__cpp_constinit) && __cpp_constinit >= 201907L
+// Check that absl::flat_hash_map is constinit-friendly.
+constinit absl::flat_hash_map<int,int> constinitHashMap;
+#endif
+
 template <class K, class V>
 using Map = flat_hash_map<K, V, StatefulTestingHash, StatefulTestingEqual,
                           Alloc<std::pair<const K, V>>>;

--- a/absl/container/flat_hash_set.h
+++ b/absl/container/flat_hash_set.h
@@ -148,7 +148,7 @@ class flat_hash_set
   //
   //   std::vector<std::string> v = {"a", "b"};
   //   absl::flat_hash_set<std::string> set7(v.begin(), v.end());
-  flat_hash_set() {}
+  constexpr flat_hash_set() {}
   using Base::Base;
 
   // flat_hash_set::begin()

--- a/absl/container/flat_hash_set_test.cc
+++ b/absl/container/flat_hash_set_test.cc
@@ -48,6 +48,11 @@ struct BeforeMain {
 };
 const BeforeMain before_main;
 
+#if defined(__cpp_constinit) && __cpp_constinit >= 201907L
+// Check that absl::flat_hash_set is constinit-friendly.
+constinit absl::flat_hash_set<int> constinitHashSet;
+#endif
+
 template <class T>
 using Set =
     absl::flat_hash_set<T, StatefulTestingHash, StatefulTestingEqual, Alloc<T>>;

--- a/absl/container/internal/raw_hash_map.h
+++ b/absl/container/internal/raw_hash_map.h
@@ -59,7 +59,7 @@ class raw_hash_map : public raw_hash_set<Policy, Hash, Eq, Alloc> {
   using iterator = typename raw_hash_map::raw_hash_set::iterator;
   using const_iterator = typename raw_hash_map::raw_hash_set::const_iterator;
 
-  raw_hash_map() {}
+  constexpr raw_hash_map() {}
   using raw_hash_map::raw_hash_set::raw_hash_set;
 
   // The last two template parameters ensure that both arguments are rvalues

--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -487,7 +487,7 @@ static_assert(ctrl_t::kDeleted == static_cast<ctrl_t>(-2),
 ABSL_DLL extern const ctrl_t kEmptyGroup[16];
 
 // Returns a pointer to a control byte group that can be used by empty tables.
-inline ctrl_t* EmptyGroup() {
+constexpr inline ctrl_t* EmptyGroup() {
   // Const must be cast away here; no uses of this function will actually write
   // to it, because it is only used for empty tables.
   return const_cast<ctrl_t*>(kEmptyGroup);
@@ -1643,7 +1643,7 @@ class raw_hash_set {
 
   // Note: can't use `= default` due to non-default noexcept (causes
   // problems for some compilers). NOLINTNEXTLINE
-  raw_hash_set() noexcept(
+  constexpr raw_hash_set() noexcept(
       std::is_nothrow_default_constructible<hasher>::value&&
           std::is_nothrow_default_constructible<key_equal>::value&&
               std::is_nothrow_default_constructible<allocator_type>::value) {}


### PR DESCRIPTION
This allows one to declare constinit global flat_hash_map and flat_hash_set variables without fear of the static initialization order fiasco.