### PR TITLE
Use affirmative phrasing in the kOK explanation

### DIFF
--- a/absl/status/status.h
+++ b/absl/status/status.h
@@ -92,7 +92,7 @@ ABSL_NAMESPACE_BEGIN
 enum class StatusCode : int {
   // StatusCode::kOk
   //
-  // kOK (gRPC code "OK") does not indicate an error; this value is returned on
+  // kOK (gRPC code "OK") indicates no error; this value is returned on
   // success. It is typical to check for this value before proceeding on any
   // given call across an API or RPC boundary. To check this value, use the
   // `absl::Status::ok()` member function rather than inspecting the raw code.


### PR DESCRIPTION
Hello! Over in the Pigweed docs we are copying your status code descriptions verbatim.

I noticed that the description of OK uses a negative phrasing which might lead to confusion. An affirmative phrasing seems to clarify the description a bit.

https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/136732/comment/a5762c41_f19ec865/