### PR TITLE
absl/debugging: Fix build on Solaris

### DIFF
--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -33,7 +33,7 @@
 
 #if defined(__ELF__) && !defined(__OpenBSD__) && !defined(__QNX__) && \
     !defined(__native_client__) && !defined(__asmjs__) &&             \
-    !defined(__wasm__) && !defined(__HAIKU__)
+    !defined(__wasm__) && !defined(__HAIKU__) && !defined(__sun)
 #define ABSL_HAVE_ELF_MEM_IMAGE 1
 #endif
 


### PR DESCRIPTION
This disables `ABSL_HAVE_ELF_MEM_IMAGE` on Solaris to fix the following build error:

```
absl/debugging/internal/vdso_support.cc:112:5: error: 'Elf64_auxv_t' was not declared in this scope
  112 |     ElfW(auxv_t) aux;
      |     ^~~~
absl/debugging/internal/vdso_support.cc:113:22: error: 'aux' was not declared in this scope
  113 |     while (read(fd, &aux, sizeof(aux)) == sizeof(aux)) {
      |                      ^~~
```