### PR TITLE
Do not check for inf or nan if  __FAST_MATH__==1

### DIFF
--- a/absl/flags/marshalling.cc
+++ b/absl/flags/marshalling.cc
@@ -177,7 +177,9 @@ std::string UnparseFloatingPointVal(T v) {
   // conversions, but may not be enough to represent all the values correctly.
   std::string digit10_str =
       absl::StrFormat("%.*g", std::numeric_limits<T>::digits10, v);
+#if !defined(__FAST_MATH__) || !__FAST_MATH__
   if (std::isnan(v) || std::isinf(v)) return digit10_str;
+#endif
 
   T roundtrip_val = 0;
   std::string err;

--- a/absl/random/beta_distribution.h
+++ b/absl/random/beta_distribution.h
@@ -89,10 +89,12 @@ class beta_distribution {
         method_ = JOEHNK;
         a_ = result_type(1) / alpha_;
         b_ = result_type(1) / beta_;
+#if !defined(__FAST_MATH__) || !__FAST_MATH__
         if (std::isinf(a_) || std::isinf(b_)) {
           method_ = DEGENERATE_SMALL;
           x_ = inverted_ ? result_type(1) : result_type(0);
         }
+#endif
         return;
       }
       if (a_ >= ThresholdForLargeA()) {

--- a/absl/strings/internal/str_format/float_conversion.cc
+++ b/absl/strings/internal/str_format/float_conversion.cc
@@ -1040,7 +1040,7 @@ bool ConvertNonNumericFloats(char sign_char, Float v,
   char text[4], *ptr = text;
   if (sign_char != '\0') *ptr++ = sign_char;
 #if defined(__FAST_MATH__) && __FAST_MATH__
-  (void) v;
+  (void)v;
   (void)conv;
   (void)sink;
   return false;

--- a/absl/strings/internal/str_format/float_conversion.cc
+++ b/absl/strings/internal/str_format/float_conversion.cc
@@ -1039,6 +1039,12 @@ bool ConvertNonNumericFloats(char sign_char, Float v,
                              FormatSinkImpl *sink) {
   char text[4], *ptr = text;
   if (sign_char != '\0') *ptr++ = sign_char;
+#if defined(__FAST_MATH__) && __FAST_MATH__
+  (void) v;
+  (void)conv;
+  (void)sink;
+  return false;
+#else
   if (std::isnan(v)) {
     ptr = std::copy_n(
         FormatConversionCharIsUpper(conv.conversion_char()) ? "NAN" : "nan", 3,
@@ -1054,6 +1060,7 @@ bool ConvertNonNumericFloats(char sign_char, Float v,
   return sink->PutPaddedString(
       string_view(text, static_cast<size_t>(ptr - text)), conv.width(), -1,
       conv.has_left_flag());
+#endif
 }
 
 // Round up the last digit of the value.

--- a/absl/strings/numbers.cc
+++ b/absl/strings/numbers.cc
@@ -533,10 +533,12 @@ size_t numbers_internal::SixDigitsToBuffer(double d, char* const buffer) {
                        // FloatToBuffer always returns the address of the buffer
                        // passed in.
 
+#if !defined(__FAST_MATH__) || !__FAST_MATH__
   if (std::isnan(d)) {
     strcpy(out, "nan");  // NOLINT(runtime/printf)
     return 3;
   }
+#endif
   if (d == 0) {  // +0 and -0 are handled here
     if (std::signbit(d)) *out++ = '-';
     *out++ = '0';

--- a/absl/time/duration.cc
+++ b/absl/time/duration.cc
@@ -86,13 +86,20 @@ constexpr int64_t kint64min = std::numeric_limits<int64_t>::min();
 
 // Can't use std::isinfinite() because it doesn't exist on windows.
 inline bool IsFinite(double d) {
+#if defined(__FAST_MATH__) && __FAST_MATH__
+  (void)d;
+  return true;
+#else
   if (std::isnan(d)) return false;
   return d != std::numeric_limits<double>::infinity() &&
          d != -std::numeric_limits<double>::infinity();
+#endif
 }
 
 inline bool IsValidDivisor(double d) {
+#if !defined(__FAST_MATH__) || !__FAST_MATH__
   if (std::isnan(d)) return false;
+#endif
   return d != 0.0;
 }
 

--- a/absl/time/time.h
+++ b/absl/time/time.h
@@ -567,8 +567,10 @@ ABSL_ATTRIBUTE_CONST_FUNCTION Duration Seconds(T n) {
     }
     return time_internal::MakePosDoubleDuration(n);
   } else {
+#if !defined(__FAST_MATH__) || !__FAST_MATH__
     if (std::isnan(n))
       return std::signbit(n) ? -InfiniteDuration() : InfiniteDuration();
+#endif
     if (n <= (std::numeric_limits<int64_t>::min)()) return -InfiniteDuration();
     return -time_internal::MakePosDoubleDuration(-n);
   }


### PR DESCRIPTION
IntelLLVM uses `-ffp-model=fast` by default,

which indirectly defines __FAST_MATH__=1

See https://clang.llvm.org/docs/UsersManual.html#cmdoption-ffast-math

We make the changes only in the non-test code, so that no warnings are generated
for calling projects.

Strange things will happen if the callers use fast-math incorrectly,
and actually create inf/nan values
e.g. some of the absl tests fail with fast-math.

