### PR TITLE
Silence std::aligned_storage warnings in C++23 mode.

### DIFF
--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -40,6 +40,7 @@
 #include <type_traits>
 
 #include "absl/base/config.h"
+#include "absl/base/attributes.h"
 
 // Defines the default alignment. `__STDCPP_DEFAULT_NEW_ALIGNMENT__` is a C++17
 // feature.
@@ -278,6 +279,7 @@ using remove_extent_t = typename std::remove_extent<T>::type;
 template <typename T>
 using remove_all_extents_t = typename std::remove_all_extents<T>::type;
 
+ABSL_INTERNAL_DISABLE_DEPRECATED_DECLARATION_WARNING
 namespace type_traits_internal {
 // This trick to retrieve a default alignment is necessary for our
 // implementation of aligned_storage_t to be consistent with any
@@ -296,6 +298,7 @@ struct default_alignment_of_aligned_storage<
 template <size_t Len, size_t Align = type_traits_internal::
                           default_alignment_of_aligned_storage<Len>::value>
 using aligned_storage_t = typename std::aligned_storage<Len, Align>::type;
+ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING
 
 template <typename T>
 using decay_t = typename std::decay<T>::type;


### PR DESCRIPTION
This is only a workaround, working only with gcc/clang, while waiting for a better long term fix not using std::aligned_storage, which is tracked by b/260219225.

Note: I don't know how to silence warnings with MSCV, so I let Windows users submitting the same fix for their platform.

This warning was already reported in #1251.
