### PR TITLE
Fix buffer overflow in a placement `new[]` storage test.

### DIFF
--- a/absl/base/exception_safety_testing_test.cc
+++ b/absl/base/exception_safety_testing_test.cc
@@ -332,13 +332,16 @@ TEST(ThrowingValueTest, NonThrowingPlacementDelete) {
   constexpr int kArrayLen = 2;
   // We intentionally create extra space to store the tag allocated by placement
   // new[].
-  constexpr int kStorageLen = 4;
+  constexpr size_t kExtraSpaceLen = sizeof(size_t) * 2;
 
   alignas(ThrowingValue<>) unsigned char buf[sizeof(ThrowingValue<>)];
   alignas(ThrowingValue<>) unsigned char
-      array_buf[sizeof(ThrowingValue<>[kStorageLen])];
+      array_buf[kExtraSpaceLen + sizeof(ThrowingValue<>[kArrayLen])];
   auto* placed = new (&buf) ThrowingValue<>(1);
   auto placed_array = new (&array_buf) ThrowingValue<>[kArrayLen];
+  auto* placed_array_end = reinterpret_cast<unsigned char*>(placed_array) +
+                           sizeof(ThrowingValue<>[kArrayLen]);
+  EXPECT_LE(placed_array_end, array_buf + sizeof(array_buf));
 
   SetCountdown();
   ExpectNoThrow([placed, &buf]() {


### PR DESCRIPTION
AppleClang seem to allocate two extra 64-bit words per each `new[]`.

A test should pass larger buffer to a placement `new[]`.

Fixes #1090