### PR TITLE
enable CMP0141 to allow user CMAKE_MSVC_DEBUG_INFORMATION_FORMAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ if (POLICY CMP0067)
   cmake_policy(SET CMP0067 NEW)
 endif (POLICY CMP0067)
 
+# Allow the user to specify the CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
+if (POLICY CMP0141)
+  cmake_policy(SET CMP0141 NEW)
+endif (POLICY CMP0141)
+
 project(absl LANGUAGES CXX)
 include(CTest)
 


### PR DESCRIPTION
CMake 3.25 introduced [CMAKE_MSVC_DEBUG_INFORMATION_FORMAT](https://cmake.org/cmake/help/v3.27/prop_tgt/MSVC_DEBUG_INFORMATION_FORMAT.html) which requires [CMP0141](https://cmake.org/cmake/help/v3.27/policy/CMP0141.html) to be set to NEW. It enables the user to control how debug information is stored on MSVC ABI targets.