### PR TITLE
CMake: Link CoreFoundation with -framework

### DIFF
--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -54,10 +54,6 @@ absl_cc_library(
     ${ABSL_DEFAULT_COPTS}
 )
 
-if(APPLE)
-  find_library(CoreFoundation CoreFoundation)
-endif()
-
 absl_cc_library(
   NAME
     time_zone
@@ -85,7 +81,7 @@ absl_cc_library(
     ${ABSL_DEFAULT_COPTS}
   DEPS
     Threads::Threads
-    $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>
+    $<$<PLATFORM_ID:Darwin>:-Wl,-framework,CoreFoundation>
 )
 
 # Internal-only target, do not depend on directly.


### PR DESCRIPTION
This fixes https://github.com/abseil/abseil-cpp/issues/1494

With CMake 3.24 we can also use `$<LINK_LIBRARY:FRAMEWORK,CoreFoundation>`
but abseil is still at CMake 3.10

The change has been tested here: https://github.com/daschuer/vcpkg/actions/runs/5670741925

