### PR TITLE
Define MAP_ANONYMOUS if not defined

### DIFF
--- a/absl/base/internal/low_level_alloc.cc
+++ b/absl/base/internal/low_level_alloc.cc
@@ -57,14 +57,9 @@
 #include "absl/base/internal/raw_logging.h"
 #include "absl/base/internal/spinlock.h"
 
-// MAP_ANONYMOUS
-#if defined(__APPLE__) || defined(__hexagon__)
-// For mmap, Linux defines both MAP_ANONYMOUS and MAP_ANON and says MAP_ANON is
-// deprecated. In Darwin, MAP_ANON is all there is.
-#if !defined MAP_ANONYMOUS
+#if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON
-#endif  // !MAP_ANONYMOUS
-#endif  // __APPLE__
+#endif
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN

--- a/absl/debugging/failure_signal_handler.cc
+++ b/absl/debugging/failure_signal_handler.cc
@@ -31,6 +31,9 @@
 
 #ifdef ABSL_HAVE_MMAP
 #include <sys/mman.h>
+#if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
 #endif
 
 #ifdef __linux__
@@ -157,9 +160,6 @@ static bool SetupAlternateStackOnce() {
 #ifdef ABSL_HAVE_MMAP
 #ifndef MAP_STACK
 #define MAP_STACK 0
-#endif
-#if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
-#define MAP_ANONYMOUS MAP_ANON
 #endif
   sigstk.ss_sp = mmap(nullptr, sigstk.ss_size, PROT_READ | PROT_WRITE,
                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);

--- a/absl/debugging/internal/examine_stack.cc
+++ b/absl/debugging/internal/examine_stack.cc
@@ -24,6 +24,9 @@
 
 #ifdef ABSL_HAVE_MMAP
 #include <sys/mman.h>
+#if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
 #endif
 
 #if defined(__linux__) || defined(__APPLE__)

--- a/absl/debugging/internal/stack_consumption.cc
+++ b/absl/debugging/internal/stack_consumption.cc
@@ -26,6 +26,10 @@
 #include "absl/base/attributes.h"
 #include "absl/base/internal/raw_logging.h"
 
+#if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace debugging_internal {

--- a/absl/debugging/symbolize_test.cc
+++ b/absl/debugging/symbolize_test.cc
@@ -40,6 +40,10 @@
 #include "absl/memory/memory.h"
 #include "absl/strings/string_view.h"
 
+#if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 using testing::Contains;
 
 #ifdef _WIN32


### PR DESCRIPTION
Building abseil on OS X 10.10 and earlier fails:

```
absl/debugging/internal/examine_stack.cc:58:34: error: use of undeclared identifier 'MAP_ANONYMOUS'
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
                                 ^
1 error generated.
```

The fix for this issue is to define `MAP_ANONYMOUS` to be equal to the older `MAP_ANON` if it is not already defined.

There are other places in the abseil code where this was already being done (see #120), just not everywhere.

In failure_signal_handler.cc, the fix was embedded in the middle of a function. It seems cleaner to have it near the top of the file, as it is in low_level_alloc.cc, so I added it to the top in the new files and moved it to the top in failure_signal_handler.cc.

In low_level_alloc.cc, the fix was restricted only to Apple platforms, and this had to be expanded to a second platform recently (see be85b347a800c0fcbbc3d901f2784efee3a73e1e):

https://github.com/abseil/abseil-cpp/blob/be85b347a800c0fcbbc3d901f2784efee3a73e1e/absl/base/internal/low_level_alloc.cc#L60-L67

There's no reason to restrict it by platform at all; just define it if it's not defined, on any platform. The comment about `MAP_ANONYMOUS` not existing on Darwin is also outdated; it does exist in Darwin on OS X 10.11 (released 2015) and later. So I've also removed these comments and restrictions and made this block the same as the others.

Maybe there is some central header where this could be addressed once instead of being copied into each file that uses `MAP_ANONYMOUS` but I don't know the abseil code well enough to determine that.

Feel free to edit the code or commit message as required for your standards.