### PR TITLE
MSVC version greater 17.7.1 would give errors for civil_time_detail.h…

### DIFF
--- a/absl/time/internal/cctz/include/cctz/civil_time_detail.h
+++ b/absl/time/internal/cctz/include/cctz/civil_time_detail.h
@@ -401,11 +401,11 @@ class civil_time {
       : civil_time(ct.f_) {}
 
   // Factories for the maximum/minimum representable civil_time.
-  static CONSTEXPR_F civil_time(max)() {
+  static CONSTEXPR_F auto (max)->civil_time() {
     const auto max_year = (std::numeric_limits<std::int_least64_t>::max)();
     return civil_time(max_year, 12, 31, 23, 59, 59);
   }
-  static CONSTEXPR_F civil_time(min)() {
+  static CONSTEXPR_F auto (min)->civil_time() {
     const auto min_year = (std::numeric_limits<std::int_least64_t>::min)();
     return civil_time(min_year, 1, 1, 0, 0, 0);
   }


### PR DESCRIPTION
MSVC version greater 17.7.1 would give errors for civil_time_detail.h Line 404 and Line 408. The compiler cannot identify (max) as a trick to prevent MACRO treatment.  A trailing return type would fix this. 

Otherwise,  MSVC 17.7.1 or newer would have the following errors (that previous MSVC versions are good):

C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(400): error C2059: syntax error: ''symbol''
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(468): note: see reference to class template instantiation 'absl::lts_20210324::time_internal::cctz::detail::civil_time<T>' being compiled
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(400): error C2091: function returns function
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(400): error C2574: '(__cdecl *absl::lts_20210324::time_internal::cctz::detail::civil_time<T>::civil_time(void))(void)': cannot be declared static
C:\develop\VcPkg\installed\x64-windows\include\absl/time/internal/cctz/include/cctz/civil_time_detail.h(404): error C2059: syntax error: ''symbol''


