### PR TITLE
Avoid export internal target in non-test builds

### DIFF
--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -212,6 +212,7 @@ absl_cc_library(
   DEPS
     absl::config
     GTest::gmock
+  TESTONLY
 )
 
 absl_cc_test(


### PR DESCRIPTION
The target is test_allocator associated with the containers