### PR TITLE
CMake: Enable CMP0074 so that GTest_ROOT can be specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)
 
+# Honor the GTest_ROOT variable if specified
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif (POLICY CMP0074)
+
 # option() honor variables
 if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)


### PR DESCRIPTION
I am building Abseil with tests enabled and an external GTest build, i.e.
```
-DABSL_BUILD_TESTING=ON
-DABSL_USE_EXTERNAL_GOOGLETEST=ON
-DABSL_FIND_GOOGLETEST=ON
-DGTest_ROOT=/path/to/googletest/1.14.0
```

However, CMake (3.20.2) configuration yielded this result:
```
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
CMake Warning (dev) at CMakeLists.txt:150 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable GTest_ROOT is set to:

    /path/to/googletest/1.14.0

  For compatibility, CMake is ignoring the variable.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR
  GTEST_MAIN_LIBRARY)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindGTest.cmake:255 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:150 (find_package)


-- Configuring incomplete, errors occurred!
See also "/tmp/abseil-build/CMakeFiles/CMakeOutput.log".
See also "/tmp/abseil-build/CMakeFiles/CMakeError.log".
```

This PR sets `CMP0074=NEW` so that the GTest install location can be specified via `GTest_ROOT`.