### PR TITLE
Replace rdcycle instruction with rdtime

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -125,7 +125,7 @@ double UnscaledCycleClock::Frequency() {
 
 int64_t UnscaledCycleClock::Now() {
   int64_t virtual_timer_value;
-  asm volatile("rdcycle %0" : "=r"(virtual_timer_value));
+  asm volatile("rdtime %0" : "=r"(virtual_timer_value));
   return virtual_timer_value;
 }
 


### PR DESCRIPTION
The `rdcycle` instruction causes SIGILL with RISCV_PMU_SBI=y in the kernel[1]

According to a PR for the highway project[2] which fixed the same problem there `rdtime` is the proper equivalent for the x86 `rdtsc` instruction on RISC-V

Using `rdtime` instead of `rdcycle` makes all tests pass on my VisionFive 2 board

[1] https://lists.infradead.org/pipermail/linux-riscv/2022-September/018862.html
[2] https://github.com/google/highway/pull/961
