### PR TITLE
Adapt to syscall(2) removal in OpenBSD

### DIFF
--- a/absl/base/internal/raw_logging.cc
+++ b/absl/base/internal/raw_logging.cc
@@ -56,7 +56,7 @@
 // ABSL_HAVE_SYSCALL_WRITE is defined when the platform provides the syscall
 //   syscall(SYS_write, /*int*/ fd, /*char* */ buf, /*size_t*/ len);
 // for low level operations that want to avoid libc.
-#if (defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)) && \
+#if (defined(__linux__) || defined(__FreeBSD__)) && \
     !defined(__ANDROID__)
 #include <sys/syscall.h>
 #define ABSL_HAVE_SYSCALL_WRITE 1


### PR DESCRIPTION
OpenBSD will remove its generic syscall(2) interface, so setting the ABSL_HAVE_SYSCALL_WRITE define will result in a linking failure soon.

Make direct use of the write(2) syscall instead. OpenBSD's libc does not do any buffering for write, so there is no change of behavior.

A [variant of this patch][1] has been in use since early this year in OpenBSD's ports. There's no need to set ABSL_LOW_LEVEL_WRITE_SUPPORTED since that's already done a few lines up.

[1]: https://github.com/openbsd/ports/commit/5f9e56cd982c1f1fa5af867e56355091e1817786