### PR TITLE
Provide absl::Hash for std::filesystem::path

### DIFF
--- a/absl/hash/hash_test.cc
+++ b/absl/hash/hash_test.cc
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <functional>
 #include <initializer_list>
 #include <ios>
@@ -34,6 +35,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <version>
 
 #include "gtest/gtest.h"
 #include "absl/base/config.h"
@@ -477,6 +479,19 @@ TEST(HashValueTest, U32StringView) {
                       std::u32string_view(U"ABC"),
                       std::u32string_view(U"Some other different string_view"),
                       std::u32string_view(U"Iñtërnâtiônàlizætiøn"))));
+#endif
+}
+
+TEST(HashValueTest, StdFilesystemPath) {
+#ifndef __cpp_lib_filesystem
+  GTEST_SKIP()
+#else
+  namespace fs = std::filesystem;
+  EXPECT_TRUE((is_hashable<std::filesystem::path>::value));
+
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      std::make_tuple(fs::path(), fs::path("a/b/c"),
+                      fs::path(u8"Iñ/tër/nât/iôn/àli/zæt/iøn"))));
 #endif
 }
 

--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -42,6 +42,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(__cpp_lib_filesystem)
+#include <filesystem>
+#endif
+
 #include "absl/base/config.h"
 #include "absl/base/internal/unaligned_access.h"
 #include "absl/base/port.h"
@@ -563,6 +567,15 @@ H AbslHashValue(H hash_state, std::basic_string_view<Char> str) {
 }
 
 #endif  // ABSL_HAVE_STD_STRING_VIEW
+
+#if defined(__cpp_lib_filesystem)
+
+template <typename H>
+H AbslHashValue(H hash_state, const std::filesystem::path& path) {
+    return AbslHashValue(std::move(hash_state), path.native());
+}
+
+#endif
 
 // -----------------------------------------------------------------------------
 // AbslHashValue for Sequence Containers

--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -41,6 +41,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <version>
 
 #if defined(__cpp_lib_filesystem)
 #include <filesystem>
@@ -572,7 +573,10 @@ H AbslHashValue(H hash_state, std::basic_string_view<Char> str) {
 
 template <typename H>
 H AbslHashValue(H hash_state, const std::filesystem::path& path) {
-    return AbslHashValue(std::move(hash_state), path.native());
+  using PathView = std::basic_string_view<std::filesystem::path::value_type>;
+  PathView view = path.native();
+  return H::combine(
+      H::combine_contiguous(std::move(hash_state), view.data(), view.size()));
 }
 
 #endif


### PR DESCRIPTION
It turned out to be quite hard to find a way to provide AbslHashValue for a class declared inside `namespace std`.

I am using C++20 feature testing macro to detect if std::filesystem is available.

Fixes #655.