### PR TITLE
Add workaround for MinGW build failure

### DIFF
--- a/absl/synchronization/internal/win32_waiter.h
+++ b/absl/synchronization/internal/win32_waiter.h
@@ -17,6 +17,7 @@
 #define ABSL_SYNCHRONIZATION_INTERNAL_WIN32_WAITER_H_
 
 #ifdef _WIN32
+#include <windows.h>
 #include <sdkddkver.h>
 #endif
 


### PR DESCRIPTION
Add extra include so that _WIN32_WINNT gets defined to correct version when building with MinGW.

Fixes #1510
