### PR TITLE
Added absl::string_view constructor from std::string view

### DIFF
--- a/absl/strings/string_view.h
+++ b/absl/strings/string_view.h
@@ -43,9 +43,11 @@
 #include "absl/base/optimization.h"
 #include "absl/base/port.h"
 
-#ifdef ABSL_USES_STD_STRING_VIEW
-
+#ifdef ABSL_HAVE_STD_STRING_VIEW
 #include <string_view>  // IWYU pragma: export
+#endif
+
+#ifdef ABSL_USES_STD_STRING_VIEW
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN
@@ -200,6 +202,12 @@ class string_view {
   // Implicit constructor of a `string_view` from a `const char*` and length.
   constexpr string_view(const char* data, size_type len)
       : ptr_(data), length_(CheckLengthInternal(len)) {}
+
+#ifdef ABSL_HAVE_STD_STRING_VIEW
+  // Implicit constructor from std::string view
+  constexpr string_view(std::string_view str)
+      : ptr_(str.data ()), length_(CheckLengthInternal(str.size())) {}  
+#endif
 
   // NOTE: Harmlessly omitted to work around gdb bug.
   //   constexpr string_view(const string_view&) noexcept = default;


### PR DESCRIPTION
absl compiled with ABSL_OPTION_USE_STD_STRING_VIEW=0 treats absl::string_view and std::string_view as distinct types, which makes challenging use of std::string_view where absl::string_view is acceptable

this mod adds implicit absl::string_view constructor from std::string_view under circumstances