### PR TITLE
_mm_prefetch is not an intrinsic in Arm64EC compilation

### DIFF
--- a/absl/base/prefetch.h
+++ b/absl/base/prefetch.h
@@ -34,7 +34,9 @@
 #if defined(_MSC_VER) && _MSC_VER >= 1900 && \
     (defined(_M_X64) || defined(_M_IX86))
 #include <intrin.h>
+#if !defined(_M_ARM64EC)
 #pragma intrinsic(_mm_prefetch)
+#endif
 #endif
 
 namespace absl {


### PR DESCRIPTION
In Arm64 compilation, _mm_prefetch is a macro instead of an intrinsic. Hence, we should exclude #pragma intrinsic(_mm_prefetch) from Arm64EC compilation.
