### PR TITLE
absl synchronization in readerlock should be weak compare

### DIFF
--- a/absl/synchronization/mutex.cc
+++ b/absl/synchronization/mutex.cc
@@ -1551,7 +1551,7 @@ void Mutex::ReaderLock() {
     }
     // We can avoid the loop and only use the CAS when the lock is free or
     // only held by readers.
-    if (ABSL_PREDICT_TRUE(mu_.compare_exchange_strong(
+    if (ABSL_PREDICT_TRUE(mu_.compare_exchange_weak(
             v, (kMuReader | v) + kMuOne, std::memory_order_acquire,
             std::memory_order_relaxed))) {
       break;


### PR DESCRIPTION
It makes sense because even if it fails spuriously, we can just try again since we have to check for other readers anyway.