### PR TITLE
Prevent redefinition errors on CHECK et al macros

### DIFF
--- a/absl/log/check.h
+++ b/absl/log/check.h
@@ -40,6 +40,36 @@
 #include "absl/log/internal/log_message.h"  // IWYU pragma: export
 #include "absl/log/internal/strip.h"        // IWYU pragma: export
 
+// Undef everything in case we're being mixed with some other Google library
+// which already defined them itself.  Presumably all Google libraries will
+// support the same syntax for these so it should not be a big deal if they
+// end up using our definitions instead.
+#undef CHECK
+#undef CHECK_EQ
+#undef CHECK_NE
+#undef CHECK_LT
+#undef CHECK_LE
+#undef CHECK_GT
+#undef CHECK_GE
+
+#undef DCHECK
+#undef DCHECK_EQ
+#undef DCHECK_NE
+#undef DCHECK_LT
+#undef DCHECK_LE
+#undef DCHECK_GT
+#undef DCHECK_GE
+
+#undef QCHECK
+#undef QCHECK_EQ
+#undef QCHECK_NE
+#undef QCHECK_LT
+#undef QCHECK_LE
+#undef QCHECK_GT
+#undef QCHECK_GE
+
+#undef PCHECK
+
 // CHECK()
 //
 // `CHECK` terminates the program with a fatal error if `condition` is not true.

--- a/absl/log/log.h
+++ b/absl/log/log.h
@@ -200,6 +200,47 @@
 #include "absl/log/internal/log_impl.h"
 #include "absl/log/vlog_is_on.h"  // IWYU pragma: export
 
+// Undef everything in case we're being mixed with some other Google library
+// which already defined them itself.  Presumably all Google libraries will
+// support the same syntax for these so it should not be a big deal if they
+// end up using our definitions instead.
+#undef LOG
+#undef LOG_EVERY_N
+#undef LOG_FIRST_N
+#undef LOG_EVERY_POW_2
+#undef LOG_EVERY_N_SEC
+#undef DLOG
+#undef DLOG_EVERY_N
+#undef DLOG_FIRST_N
+#undef DLOG_EVERY_POW_2
+#undef DLOG_EVERY_N_SEC
+#undef PLOG
+#undef PLOG_EVERY_N
+#undef PLOG_FIRST_N
+#undef PLOG_EVERY_POW_2
+#undef PLOG_EVERY_N_SEC
+#undef VLOG
+#undef VLOG_EVERY_N
+#undef VLOG_FIRST_N
+#undef VLOG_EVERY_POW_2
+#undef VLOG_EVERY_N_SEC
+#undef DVLOG
+#undef LOG_IF
+#undef LOG_IF_EVERY_N
+#undef LOG_IF_FIRST_N
+#undef LOG_IF_EVERY_POW_2
+#undef LOG_IF_EVERY_N_SEC
+#undef DLOG_IF
+#undef DLOG_IF_EVERY_N
+#undef DLOG_IF_FIRST_N
+#undef DLOG_IF_EVERY_POW_2
+#undef DLOG_IF_EVERY_N_SEC
+#undef PLOG_IF
+#undef PLOG_IF_EVERY_N
+#undef PLOG_IF_FIRST_N
+#undef PLOG_IF_EVERY_POW_2
+#undef PLOG_IF_EVERY_N_SEC
+
 // LOG()
 //
 // `LOG` takes a single argument which is a severity level.  Data streamed in


### PR DESCRIPTION
Prevent errors and warnings on redefinition of these macros when abseil is included in a project that also includes another Google project eg tsl that also defines the same macros.