### PR TITLE
Disable ABSL_ATTRIBUTE_TRIVIAL_ABI in open-source builds 

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -298,7 +298,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
     if(ABSL_ENABLE_INSTALL)
       set_target_properties(${_NAME} PROPERTIES
         OUTPUT_NAME "absl_${_NAME}"
-        SOVERSION 0
+        SOVERSION "2401.0.0"
       )
     endif()
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if (POLICY CMP0141)
   cmake_policy(SET CMP0141 NEW)
 endif (POLICY CMP0141)
 
-project(absl LANGUAGES CXX)
+project(absl LANGUAGES CXX VERSION 20240116)
 include(CTest)
 
 # Output directory is correct by default for most build setups. However, when
@@ -186,17 +186,7 @@ endif()
 add_subdirectory(absl)
 
 if(ABSL_ENABLE_INSTALL)
-  # absl:lts-remove-begin(system installation is supported for LTS releases)
-  # We don't support system-wide installation
-  list(APPEND SYSTEM_INSTALL_DIRS "/usr/local" "/usr" "/opt/" "/opt/local" "c:/Program Files/${PROJECT_NAME}")
-  if(NOT DEFINED CMAKE_INSTALL_PREFIX OR CMAKE_INSTALL_PREFIX IN_LIST SYSTEM_INSTALL_DIRS)
-    message(WARNING "\
-  The default and system-level install directories are unsupported except in LTS \
-  releases of Abseil.  Please set CMAKE_INSTALL_PREFIX to install Abseil in your \
-  source or build tree directly.\
-    ")
-  endif()
-  # absl:lts-remove-end
+  
 
   # install as a subdirectory only
   install(EXPORT ${PROJECT_NAME}Targets

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "head",
+    version = "20240116.0",
     compatibility_level = 1,
 )
 

--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -843,15 +843,11 @@
 // See also the upstream documentation:
 // https://clang.llvm.org/docs/AttributeReference.html#trivial-abi
 //
-#if ABSL_HAVE_CPP_ATTRIBUTE(clang::trivial_abi)
-#define ABSL_ATTRIBUTE_TRIVIAL_ABI [[clang::trivial_abi]]
-#define ABSL_HAVE_ATTRIBUTE_TRIVIAL_ABI 1
-#elif ABSL_HAVE_ATTRIBUTE(trivial_abi)
-#define ABSL_ATTRIBUTE_TRIVIAL_ABI __attribute__((trivial_abi))
-#define ABSL_HAVE_ATTRIBUTE_TRIVIAL_ABI 1
-#else
+// b/321691395 - This is currently disabled in open-source builds since
+// compiler support differs. If system libraries compiled with GCC are mixed
+// with libraries compiled with Clang, types will have different ideas about
+// their ABI, leading to hard to debug crashes.
 #define ABSL_ATTRIBUTE_TRIVIAL_ABI
-#endif
 
 // ABSL_ATTRIBUTE_NO_UNIQUE_ADDRESS
 //

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -117,8 +117,8 @@
 //
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
-#undef ABSL_LTS_RELEASE_VERSION
-#undef ABSL_LTS_RELEASE_PATCH_LEVEL
+#define ABSL_LTS_RELEASE_VERSION 20240116
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -225,8 +225,8 @@
 // be changed to a new, unique identifier name.  In particular "head" is not
 // allowed.
 
-#define ABSL_OPTION_USE_INLINE_NAMESPACE 0
-#define ABSL_OPTION_INLINE_NAMESPACE_NAME head
+#define ABSL_OPTION_USE_INLINE_NAMESPACE 1
+#define ABSL_OPTION_INLINE_NAMESPACE_NAME lts_20240116
 
 // ABSL_OPTION_HARDENED
 //


### PR DESCRIPTION
Since compiler support for this attribute differs, if for example
system libraries compiled with GCC are mixed with libraries compiled
with Clang, types will have different ideas about their ABI.

PiperOrigin-RevId: 600467146