### PR TITLE
absl::is_trivially_relocatable now respects assignment operators

### DIFF
--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -471,12 +471,17 @@ using swap_internal::StdSwapIsUnconstrained;
 // absl::is_trivially_relocatable<T>
 //
 // Detects whether a type is known to be "trivially relocatable" -- meaning it
-// can be relocated without invoking the constructor/destructor, using a form of
-// move elision.
+// can be relocated from one place to another as if by memcpy/memmove.
+// This implies that its object representation doesn't depend on its address,
+// and also its move constructor and destructor don't do anything strange.
 //
-// This trait is conservative, for backwards compatibility. If it's true then
-// the type is definitely trivially relocatable, but if it's false then the type
-// may or may not be.
+// This trait is conservative. If it's true then the type is definitely
+// trivially relocatable, but there are many types which are "Platonically"
+// trivially relocatable but for which the type trait returns false because
+// it can't introspect into the special members and see that they're not
+// doing anything strange. (For example, std::vector<int> is trivially
+// relocatable on every known STL implementation, but
+// absl::is_trivially_relocatable<std::vector<int>> remains false.)
 //
 // Example:
 //

--- a/absl/meta/type_traits_test.cc
+++ b/absl/meta/type_traits_test.cc
@@ -751,7 +751,7 @@ TEST(TriviallyRelocatable, PrimitiveTypes) {
 
 // User-defined types can be trivially relocatable as long as they don't have a
 // user-provided move constructor or destructor.
-TEST(TriviallyRelocatable, UserDefinedTriviallyReconstructible) {
+TEST(TriviallyRelocatable, UserDefinedTriviallyRelocatable) {
   struct S {
     int x;
     int y;
@@ -799,12 +799,13 @@ TEST(TriviallyRelocatable, UserProvidedDestructor) {
     !(defined(__clang__) && (defined(_WIN32) || defined(_WIN64))) && \
     !defined(__APPLE__)
 // A type marked with the "trivial ABI" attribute is trivially relocatable even
-// if it has user-provided move/copy constructors and a user-provided
-// destructor.
-TEST(TrivallyRelocatable, TrivialAbi) {
+// if it has user-provided special members.
+TEST(TriviallyRelocatable, TrivialAbi) {
   struct ABSL_ATTRIBUTE_TRIVIAL_ABI S {
     S(S&&) {}       // NOLINT(modernize-use-equals-default)
     S(const S&) {}  // NOLINT(modernize-use-equals-default)
+    void operator=(S&&) {}
+    void operator=(const S&) {}
     ~S() {}         // NOLINT(modernize-use-equals-default)
   };
 
@@ -824,7 +825,7 @@ constexpr int64_t NegateIfConstantEvaluated(int64_t i) {
 
 #endif  // ABSL_HAVE_CONSTANT_EVALUATED
 
-TEST(TrivallyRelocatable, is_constant_evaluated) {
+TEST(IsConstantEvaluated, is_constant_evaluated) {
 #ifdef ABSL_HAVE_CONSTANT_EVALUATED
   constexpr int64_t constant = NegateIfConstantEvaluated(42);
   EXPECT_EQ(constant, -42);


### PR DESCRIPTION
Trivial relocatability also requires that the type not do anything weird with its assignment operator; update the type-trait to reflect this. (This is the definition used by BSL, Folly, HPX, Thrust, Parlay, Amadeus, and P1144.)

This is important if we want to use `absl::is_trivially_relocatable` as a gate for memcpy optimizations in `inlined_vector::erase` and/or `inlined_vector::swap`, because in those cases relocation is used to replace part of a sequence involving assignment; the optimization requires an assignment operator that behaves value-semantically.

Clang's builtin currently fails to check the assignment operator, so we stop using it entirely for now. We already refused to use it on Win32, Win64, and Apple, for various unrelated reasons. I'm working on giving Clang's builtin the behavior that would let us re-enable it here.

Assume that any compiler providing both `__cpp_impl_trivially_relocatable` and a builtin `__is_trivially_relocatable(T)` will use the appropriate (P1144) definition for its builtin. Right now there's only one such compiler (the P1144 reference implementation, which forks Clang), so this is largely a moot point, but I'm being optimistic.