### PR TITLE
add xcprivacy to all subspecs

### DIFF
--- a/absl/abseil.podspec.gen.py
+++ b/absl/abseil.podspec.gen.py
@@ -47,6 +47,11 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  s.subspec 'xcprivacy' do |ss|
+    ss.resource_bundles = {
+      ss.module_name => 'PrivacyInfo.xcprivacy',
+    }
+  end
 """
 
 # Rule object representing the rule of Bazel BUILD.
@@ -191,6 +196,9 @@ def write_podspec_rule(f, rule, depth):
     name = get_spec_name(dep.replace(":", "/"))
     f.write("{indent}{var}.dependency '{dep}'\n".format(
         indent=indent, var=spec_var, dep=name))
+  # Writes dependency to xcprivacy
+  f.write("{indent}{var}.dependency '{dep}'\n".format(
+        indent=indent, var=spec_var, dep="abseil/xcprivacy"))
 
 
 def write_indented_list(f, leading, values):


### PR DESCRIPTION
Addressing comments at https://github.com/abseil/abseil-cpp/pull/1604/#pullrequestreview-1937008657
Add a xcprivacy subspec and have all other subspecs depend on it (option 1)

Didn't going with option 3 because there are several levels of subspecs in abseil podspec, it's difficult to track whether all of them directly or indirectly depends on abseil/base/config or ensure they will continue to depend on it.


Example of generated podsped: https://gist.github.com/HannahShiSFB/15d8fb6aa637f2781b7be4218d080f11