### PR TITLE
Abseil LTS Branch, Jan 2024, Patch 2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "20240116.0",
+    version = "20240116.2",
     compatibility_level = 1,
 )
 

--- a/absl/abseil.podspec.gen.py
+++ b/absl/abseil.podspec.gen.py
@@ -44,9 +44,14 @@ Pod::Spec.new do |s|
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
   }
   s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
+  s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  s.subspec 'xcprivacy' do |ss|
+    ss.resource_bundles = {
+      ss.module_name => 'PrivacyInfo.xcprivacy',
+    }
+  end
 """
 
 # Rule object representing the rule of Bazel BUILD.
@@ -191,6 +196,12 @@ def write_podspec_rule(f, rule, depth):
     name = get_spec_name(dep.replace(":", "/"))
     f.write("{indent}{var}.dependency '{dep}'\n".format(
         indent=indent, var=spec_var, dep=name))
+  # Writes dependency to xcprivacy
+  f.write(
+      "{indent}{var}.dependency '{dep}'\n".format(
+          indent=indent, var=spec_var, dep="abseil/xcprivacy"
+      )
+  )
 
 
 def write_indented_list(f, leading, values):

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -118,7 +118,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20240116
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 2
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/strings/str_cat.h
+++ b/absl/strings/str_cat.h
@@ -601,18 +601,17 @@ StrAppend(absl::Nonnull<String*> str, T... args) {
   ptrdiff_t n;   // The length of the current argument
   typename String::pointer pos = &(*str)[old_size];
   using SomeTrivialEmptyType = std::false_type;
-  // Ugly code due to the lack of C++14 fold expression makes us.
-  const SomeTrivialEmptyType dummy1;
-  for (const SomeTrivialEmptyType& dummy2 :
-       {(/* Comma expressions are poor man's C++17 fold expression for C++14 */
-         (void)(n = lengths[i]),
-         (void)(n < 0 ? (void)(*pos++ = '-'), (n = ~n) : 0),
-         (void)absl::numbers_internal::FastIntToBufferBackward(
-             absl::numbers_internal::UnsignedAbsoluteValue(std::move(args)),
-             pos += n, static_cast<uint32_t>(n)),
-         (void)++i, dummy1)...}) {
-    (void)dummy2;  // Remove & migrate to fold expressions in C++17
-  }
+  const SomeTrivialEmptyType dummy;
+  // Ugly code due to the lack of C++17 fold expressions
+  const SomeTrivialEmptyType dummies[] = {
+      (/* Comma expressions are poor man's C++17 fold expression for C++14 */
+       (void)(n = lengths[i]),
+       (void)(n < 0 ? (void)(*pos++ = '-'), (n = ~n) : 0),
+       (void)absl::numbers_internal::FastIntToBufferBackward(
+           absl::numbers_internal::UnsignedAbsoluteValue(std::move(args)),
+           pos += n, static_cast<uint32_t>(n)),
+       (void)++i, dummy)...};
+  (void)dummies;  // Remove & migrate to fold expressions in C++17
 }
 
 // Helper function for the future StrCat default floating-point format, %.6g


### PR DESCRIPTION
* Prevent overflow in absl::CEscape() Strings larger than 1 GiB on a platform with a 32-bit size_t could potentially overflow size_t in `CEscapedLength()`, resulting in an undersized allocation. The resulting write in
`CEscapeAndAppendInternal()` would then write beyond the bounds of the output buffer.

A second overflow, where the calculated escaped length is added to the size of the string being appended to, is also fixed.

In both cases the program will now abort prior to the overflow.

Credit goes to Ronald Crane (Zippenhop LLC) for reporting this issue.

PiperOrigin-RevId: 607019573
Change-Id: I97bf246cde96102a793d2db49446cccae08abf59

* Workaround for NVIDIA C++ compiler being unable to parse variadic expansions in range of range-based for loop

Fixes: #1629
PiperOrigin-RevId: 611131201
Change-Id: I787731e00207b544ee16055e6e0d323a5094a433

* Fix OSX support with CocoaPods and Xcode 15

PiperOrigin-RevId: 615090942
Change-Id: I7cc20a0129dcfbbddedd9e6d816bb6234bff14b3

* PR 1643: add xcprivacy to all subspecs

Addressing comments at #1604
Add a xcprivacy subspec and have all other subspecs depend on it (option 1)

Didn't going with option 3 because there are several levels of subspecs in abseil podspec, it's difficult to track whether all of them directly or indirectly depends on abseil/base/config or ensure they will continue to depend on it.

Example of generated podspec: https://gist.github.com/HannahShiSFB/15d8fb6aa637f2781b7be4218d080f11 Merge 4405cdf into 4539c54

COPYBARA_INTEGRATE_REVIEW=#1643 from HannahShiSFB:privacy-manifests 4405cdf PiperOrigin-RevId: 616914674
Change-Id: If56d5a4f1a7cc6f9fac7a2d8e95b55d140e645fc
