### PR TITLE
Remove unnecessary limitation for clang-cl or icx

### DIFF
--- a/absl/crc/internal/crc32_x86_arm_combined_simd.h
+++ b/absl/crc/internal/crc32_x86_arm_combined_simd.h
@@ -33,8 +33,7 @@
 #include <x86intrin.h>
 #define ABSL_CRC_INTERNAL_HAVE_X86_SIMD
 
-#elif defined(_MSC_VER) && !defined(__clang__) && defined(__AVX__) && \
-    defined(_M_AMD64)
+#elif defined(_MSC_VER) && defined(__AVX__)
 
 // MSVC AVX (/arch:AVX) implies SSE 4.2 and PCLMULQDQ.
 #include <intrin.h>


### PR DESCRIPTION
clang-cl or icx (Intel's new llvm-based compiler) both define _MSC_VER on windows. Both compile this code without issues.