### PR TITLE
Optimize StrJoin with tuple without user defined formatter

### DIFF
--- a/absl/strings/internal/str_join_internal.h
+++ b/absl/strings/internal/str_join_internal.h
@@ -33,6 +33,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -319,6 +320,15 @@ std::string JoinRange(const Range& range, absl::string_view separator) {
   using std::begin;
   using std::end;
   return JoinRange(begin(range), end(range), separator);
+}
+
+template <typename Tuple, std::size_t... I>
+std::string JoinTuple(const Tuple& value, absl::string_view separator,
+                      std::index_sequence<I...>) {
+  return JoinRange(
+      std::initializer_list<absl::string_view>{
+          static_cast<const AlphaNum&>(std::get<I>(value)).Piece()...},
+      separator);
 }
 
 }  // namespace strings_internal

--- a/absl/strings/str_join.h
+++ b/absl/strings/str_join.h
@@ -270,15 +270,15 @@ std::string StrJoin(const Range& range, absl::string_view separator) {
 }
 
 template <typename T>
-std::string StrJoin(std::initializer_list<T> il,
-                    absl::string_view separator) {
+std::string StrJoin(std::initializer_list<T> il, absl::string_view separator) {
   return strings_internal::JoinRange(il, separator);
 }
 
 template <typename... T>
 std::string StrJoin(const std::tuple<T...>& value,
                     absl::string_view separator) {
-  return strings_internal::JoinAlgorithm(value, separator, AlphaNumFormatter());
+  return strings_internal::JoinTuple(value, separator,
+                                     std::index_sequence_for<T...>{});
 }
 
 ABSL_NAMESPACE_END


### PR DESCRIPTION
https://github.com/abseil/abseil-cpp/discussions/1671

Unfortunately the benchmarks can't be used with CMake and I don't have time to fix that or figure out how to use Bazel.