### PR TITLE
Fix time library build for Apple platforms

### DIFF
--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -83,7 +83,7 @@ absl_cc_library(
     Threads::Threads
     # TODO(#1495): Use $<LINK_LIBRARY:FRAMEWORK,CoreFoundation> once our
     # minimum CMake version >= 3.24
-    $<$<PLATFORM_ID:Darwin>:-Wl,-framework,CoreFoundation>
+    $<$<PLATFORM_ID:Darwin,iOS,tvOS,visionOS,watchOS>:-Wl,-framework,CoreFoundation>
 )
 
 # Internal-only target, do not depend on directly.


### PR DESCRIPTION
#1495 converted the `if (APPLE)` check for linking against `CoreFoundation` to  generator expressions, which is fine and all.
The issue is that they forgot the other Apple platforms, making builds for iOS impossible.
This patch fixes this issue by adding the other Apple platforms that CMake support to the generator expression.