### PR TITLE
Fix poisoned pointer on powerpc

### DIFF
--- a/absl/base/internal/poison.cc
+++ b/absl/base/internal/poison.cc
@@ -35,7 +35,11 @@ namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace base_internal {
 namespace {
+#if defined(__powerpc64__)
+constexpr size_t kPageSize = 1 << 16;
+#else
 constexpr size_t kPageSize = 1 << 12;
+#endif
 alignas(kPageSize) static char poison_page[kPageSize];
 }  // namespace
 


### PR DESCRIPTION
PPC has 64K pages instead of 4k, fix is needed for mprotect as it needs a page aligned input.
We build and test abseil as it's a dependency of V8 which we maintain on PPC.