### PR TITLE
Add option to build with MSVC static runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,17 @@ list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/absl/copts
 )
 
+if(${CMAKE_VERSION} VERSION_GREATER 3.15 OR ${CMAKE_VERSION} VERSION_EQUAL 3.15)
+  option(ABSL_MSVC_STATIC_RUNTIME
+    "Link static runtime libraries"
+    OFF)
+  if(ABSL_MSVC_STATIC_RUNTIME)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  endif()
+endif()
+
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(AbseilDll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,15 +92,13 @@ list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/absl/copts
 )
 
-if(${CMAKE_VERSION} VERSION_GREATER 3.15 OR ${CMAKE_VERSION} VERSION_EQUAL 3.15)
-  option(ABSL_MSVC_STATIC_RUNTIME
-    "Link static runtime libraries"
-    OFF)
-  if(ABSL_MSVC_STATIC_RUNTIME)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  else()
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-  endif()
+option(ABSL_MSVC_STATIC_RUNTIME
+  "Link static runtime libraries"
+  OFF)
+if(ABSL_MSVC_STATIC_RUNTIME)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else()
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
The correct CMake policy is set, but there is no option to switch the msvc runtime when configuring the project.

Since MSVC is a multiconfiguration build tool, we need to set this CMake variable internal to the project to ensure that all of the supported build configurations get properly set (i.e. `Release` builds use `/MT` or `/MD` and `Debug` builds use `/MTd` or `/MDd`).
I tried to explictly set these flags (i.e. -DCMAKE_CXX_FLAGS_XXX) when configuring the project, but these flags were being overwritten due to [explicitly setting compiler flags](https://github.com/abseil/abseil-cpp/blob/master/CMake/AbseilHelpers.cmake#L285).

If we want to support this functionality using MSVC and CMake 3.10 - 3.14, we would need to [manually update the various CMAKE_CXX_FLAGS](https://github.com/protocolbuffers/protobuf/blob/main/CMakeLists.txt#L225), but since this project is explictly setting flag it might require a bit more experimenting. Depends how much we want to support MSVC and CMake < 3.15, which might be a pretty rare edge case.


