### PR TITLE
Fixup absl_random compile breakage in Apple ARM64 targets

### DIFF
--- a/absl/copts/AbseilConfigureCopts.cmake
+++ b/absl/copts/AbseilConfigureCopts.cmake
@@ -42,7 +42,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
     string(TOUPPER "${_arch}" _arch_uppercase)
     string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
     foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")
+      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch} ${_flag}")
     endforeach()
   endforeach()
   # If a compiler happens to deal with an argument for a currently unused


### PR DESCRIPTION
Switched to append a full string of "-Xarch_x86_64 -maes" instead of " -Xarch_x86_64" "-maes", for example. Now cmake correctly appends -Xarch_x86_64 to each x64 specific compile option, removing the error caused in recent clang releases:

clang++: error: unsupported option '-msse4.1' for target 'arm64-apple-darwin23.5.0'
