### PR TITLE
fixup! PR #1707: Fixup absl_random compile breakage in Apple ARM64 targets

### DIFF
--- a/absl/copts/AbseilConfigureCopts.cmake
+++ b/absl/copts/AbseilConfigureCopts.cmake
@@ -42,7 +42,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
     string(TOUPPER "${_arch}" _arch_uppercase)
     string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
     foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch} ${_flag}")
+      list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
     endforeach()
   endforeach()
   # If a compiler happens to deal with an argument for a currently unused


### PR DESCRIPTION
Use the SHELL: prefix in compile flag string to avoid passing it as quoted string
Introduced in CMake 3.12, but as CMake 3.16 is required by this project it will be ok.

According to [this link](https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication), CMake's target_compile_options ignores duplicate items, like from the quote of the link:

> While beneficial for individual options, the de-duplication step can break up option groups. For example, -option A -option B becomes -option A B. One may specify a group of options using shell-like quoting along with a SHELL: prefix.

This was our problem, -option A -option B should be there, but CMake just made it like -option A B, B was not guarded by -Xarch which led to a compilation error.

I originally tried the fix with quoting the "-option A", but it led to the quoted string passed to the compiler, and therefore ignored.
Now I am using the SHELL: suffix supported by CMake, and it shows differences:

> Current build command with quotes:
> ... -DNOMINMAX "-Xarch_x86_64 -maes" "-Xarch_x86_64 -msse4.1" ... (Wrong)

> With the SHELL: prefix applied:
> ... -DNOMINMAX -Xarch_x86_64 -maes -Xarch_x86_64 -msse4.1 ... (Correct)