### PR TITLE
Disambiguate use of template as per CWG1835

### DIFF
--- a/absl/container/internal/compressed_tuple.h
+++ b/absl/container/internal/compressed_tuple.h
@@ -248,12 +248,14 @@ class ABSL_INTERNAL_COMPRESSED_TUPLE_DECLSPEC CompressedTuple
 
   template <int I>
   constexpr ElemT<I>&& get() && {
-    return std::move(*this).StorageT<I>::get();
+    using StorageInt = StorageT<I>;
+    return std::move(*this).StorageInt::get();
   }
 
   template <int I>
   constexpr const ElemT<I>&& get() const&& {
-    return std::move(*this).StorageT<I>::get();
+    using StorageInt = StorageT<I>;
+    return std::move(*this).StorageInt::get();
   }
 };
 


### PR DESCRIPTION
Clang trunk has recently landed the resolution for https://cplusplus.github.io/CWG/issues/1835.html, yielding the following errors:

In file included from /tmp/abseil-cpp/absl/status/status.cc:14: In file included from /tmp/abseil-cpp/absl/status/status.h:66: In file included from /tmp/abseil-cpp/absl/status/internal/status_internal.h:26: In file included from /tmp/abseil-cpp/absl/container/inlined_vector.h:53: In file included from /tmp/abseil-cpp/absl/container/internal/inlined_vector.h:32: /tmp/abseil-cpp/absl/container/internal/compressed_tuple.h:251:42: error: no member named 'get' in the global namespace
  251 |     return std::move(*this).StorageT<I>::get();
      |                                        ~~^
/tmp/abseil-cpp/absl/container/internal/compressed_tuple.h:256:42: error: no member named 'get' in the global namespace
  256 |     return std::move(*this).StorageT<I>::get();
      |                                        ~~^
2 errors generated.

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
