### PR TITLE
Don't log unwanted when not initialized

### DIFF
--- a/absl/log/internal/log_sink_set.cc
+++ b/absl/log/internal/log_sink_set.cc
@@ -90,8 +90,7 @@ class StderrLogSink final : public LogSink {
   ~StderrLogSink() override = default;
 
   void Send(const absl::LogEntry& entry) override {
-    if (entry.log_severity() < absl::StderrThreshold() &&
-        absl::log_internal::IsInitialized()) {
+    if (entry.log_severity() < absl::StderrThreshold()) {
       return;
     }
 


### PR DESCRIPTION
Messages with `severity < treshold `should be  ignored (always)

For now, when not initialized, appears in stderr:
- a warning message (all log...)
- the unwanted message

See https://github.com/grpc/grpc/issues/37178