### PR TITLE
Cherry-picks for Release Candidate 2

### DIFF
--- a/CMake/AbseilDll.cmake
+++ b/CMake/AbseilDll.cmake
@@ -486,6 +486,7 @@ endif()
 set(ABSL_INTERNAL_DLL_TARGETS
   "absl_check"
   "absl_log"
+  "absl_vlog_is_on"
   "algorithm"
   "algorithm_container"
   "any"
@@ -643,6 +644,7 @@ set(ABSL_INTERNAL_DLL_TARGETS
   "utility"
   "variant"
   "vlog_config_internal"
+  "vlog_is_on"
 )
 
 if(NOT MSVC)

--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -258,6 +258,13 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
     elseif(_build_type STREQUAL "static" OR _build_type STREQUAL "shared")
       add_library(${_NAME} "")
       target_sources(${_NAME} PRIVATE ${ABSL_CC_LIB_SRCS} ${ABSL_CC_LIB_HDRS})
+      if(APPLE)
+        set_target_properties(${_NAME} PROPERTIES
+          INSTALL_RPATH "@loader_path")
+      elseif(UNIX)
+        set_target_properties(${_NAME} PROPERTIES
+          INSTALL_RPATH "$ORIGIN")
+      endif()
       target_link_libraries(${_NAME}
       PUBLIC ${ABSL_CC_LIB_DEPS}
       PRIVATE


### PR DESCRIPTION
cmake: Fix RUNPATH when using BUILD_WITH_INSTALL_RPATH=True (21385900073e3ca2c4aefb13fd05ca2da40d5ff1)

Add absl_vlog_is_on and vlog_is_on to ABSL_INTERNAL_DLL_TARGETS (9a0743ac27df5ec018974e605cf61db7652b26c1)
