### PR TITLE
Workaround broken compilation against NDK r25

### DIFF
--- a/absl/time/duration_test.cc
+++ b/absl/time/duration_test.cc
@@ -20,9 +20,9 @@
 #include <cfloat>
 #include <chrono>  // NOLINT(build/c++11)
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 #include <compare>
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 #include <cmath>
 #include <cstdint>
@@ -437,14 +437,14 @@ TEST(Duration, InfinityComparison) {
   EXPECT_LT(-inf, inf);
   EXPECT_GT(inf, -inf);
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
   EXPECT_EQ(inf <=> inf, std::strong_ordering::equal);
   EXPECT_EQ(-inf <=> -inf, std::strong_ordering::equal);
   EXPECT_EQ(-inf <=> inf, std::strong_ordering::less);
   EXPECT_EQ(inf <=> -inf, std::strong_ordering::greater);
   EXPECT_EQ(any_dur <=> inf, std::strong_ordering::less);
   EXPECT_EQ(any_dur <=> -inf, std::strong_ordering::greater);
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 }
 
 TEST(Duration, InfinityAddition) {
@@ -511,18 +511,18 @@ TEST(Duration, InfinitySubtraction) {
   absl::Duration almost_neg_inf = sec_min;
   EXPECT_LT(-inf, almost_neg_inf);
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
   EXPECT_EQ(-inf <=> almost_neg_inf, std::strong_ordering::less);
   EXPECT_EQ(almost_neg_inf <=> -inf, std::strong_ordering::greater);
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
   almost_neg_inf -= -absl::Nanoseconds(1);
   EXPECT_LT(-inf, almost_neg_inf);
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
   EXPECT_EQ(-inf <=> almost_neg_inf, std::strong_ordering::less);
   EXPECT_EQ(almost_neg_inf <=> -inf, std::strong_ordering::greater);
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
   // For reference: IEEE 754 behavior
   const double dbl_inf = std::numeric_limits<double>::infinity();
@@ -883,7 +883,7 @@ TEST(Duration, Range) {
   EXPECT_LT(neg_full_range, full_range);
   EXPECT_EQ(neg_full_range, -full_range);
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
   EXPECT_EQ(range_future <=> absl::InfiniteDuration(),
             std::strong_ordering::less);
   EXPECT_EQ(range_past <=> -absl::InfiniteDuration(),
@@ -896,7 +896,7 @@ TEST(Duration, Range) {
             std::strong_ordering::greater);
   EXPECT_EQ(neg_full_range <=> full_range, std::strong_ordering::less);
   EXPECT_EQ(neg_full_range <=> -full_range, std::strong_ordering::equal);
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 }
 
 TEST(Duration, RelationalOperators) {
@@ -921,7 +921,7 @@ TEST(Duration, RelationalOperators) {
 }
 
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
 TEST(Duration, SpaceshipOperators) {
 #define TEST_REL_OPS(UNIT)               \
@@ -939,7 +939,7 @@ TEST(Duration, SpaceshipOperators) {
 #undef TEST_REL_OPS
 }
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 TEST(Duration, Addition) {
 #define TEST_ADD_OPS(UNIT)                  \

--- a/absl/time/time.h
+++ b/absl/time/time.h
@@ -89,6 +89,7 @@ struct timeval;
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <version>
 
 #include "absl/base/attributes.h"
 #include "absl/base/config.h"

--- a/absl/time/time.h
+++ b/absl/time/time.h
@@ -76,9 +76,9 @@ struct timeval;
 #endif
 #include <chrono>  // NOLINT(build/c++11)
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 #include <compare>
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 #include <cmath>
 #include <cstdint>
@@ -313,12 +313,12 @@ class Duration {
 
 // Relational Operators
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr std::strong_ordering operator<=>(
     Duration lhs, Duration rhs);
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr bool operator<(Duration lhs,
                                                        Duration rhs);
@@ -853,9 +853,9 @@ class Time {
   friend constexpr Time time_internal::FromUnixDuration(Duration d);
   friend constexpr Duration time_internal::ToUnixDuration(Time t);
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
   friend constexpr std::strong_ordering operator<=>(Time lhs, Time rhs);
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
   friend constexpr bool operator<(Time lhs, Time rhs);
   friend constexpr bool operator==(Time lhs, Time rhs);
@@ -868,14 +868,14 @@ class Time {
 };
 
 // Relational Operators
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr std::strong_ordering operator<=>(
     Time lhs, Time rhs) {
   return lhs.rep_ <=> rhs.rep_;
 }
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr bool operator<(Time lhs, Time rhs) {
   return lhs.rep_ < rhs.rep_;
@@ -1753,7 +1753,7 @@ ABSL_ATTRIBUTE_CONST_FUNCTION constexpr bool operator<(Duration lhs,
 }
 
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr std::strong_ordering operator<=>(
     Duration lhs, Duration rhs) {
@@ -1769,7 +1769,7 @@ ABSL_ATTRIBUTE_CONST_FUNCTION constexpr std::strong_ordering operator<=>(
              : lhs_lo <=> rhs_lo;
 }
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr bool operator==(Duration lhs,
                                                         Duration rhs) {

--- a/absl/time/time_test.cc
+++ b/absl/time/time_test.cc
@@ -25,9 +25,9 @@
 
 #include <chrono>  // NOLINT(build/c++11)
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 #include <compare>
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
 #include <cstring>
 #include <ctime>
@@ -213,7 +213,7 @@ TEST(Time, RelationalOperators) {
   static_assert(t1 >= t1, "");
   static_assert(t3 >= t1, "");
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
   static_assert((t1 <=> t1) == std::strong_ordering::equal, "");
   static_assert((t2 <=> t2) == std::strong_ordering::equal, "");
@@ -227,7 +227,7 @@ TEST(Time, RelationalOperators) {
   static_assert((t3 <=> t2) == std::strong_ordering::greater, "");
   static_assert((t3 <=> t1) == std::strong_ordering::greater, "");
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 }
 
 TEST(Time, Infinity) {
@@ -239,14 +239,14 @@ TEST(Time, Infinity) {
   static_assert(ipast < ifuture, "");
   static_assert(ifuture > ipast, "");
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
   static_assert((ifuture <=> ifuture) == std::strong_ordering::equal, "");
   static_assert((ipast <=> ipast) == std::strong_ordering::equal, "");
   static_assert((ipast <=> ifuture) == std::strong_ordering::less, "");
   static_assert((ifuture <=> ipast) == std::strong_ordering::greater, "");
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
   // Arithmetic saturates
   EXPECT_EQ(ifuture, ifuture + absl::Seconds(1));
@@ -263,14 +263,14 @@ TEST(Time, Infinity) {
   static_assert(t < ifuture, "");
   static_assert(t > ipast, "");
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 
   static_assert((t <=> ifuture) == std::strong_ordering::less, "");
   static_assert((t <=> ipast) == std::strong_ordering::greater, "");
   static_assert((ipast <=> t) == std::strong_ordering::less, "");
   static_assert((ifuture <=> t) == std::strong_ordering::greater, "");
 
-#endif  // __cpp_impl_three_way_comparison
+#endif  // __cpp_lib_three_way_comparison
 
   EXPECT_EQ(ifuture, t + absl::InfiniteDuration());
   EXPECT_EQ(ipast, t - absl::InfiniteDuration());


### PR DESCRIPTION
When targeting Android NDK r25 (reached EOL now, but still in some use) one gets the following error:
```
$(SOURCE_ROOT)/contrib/restricted/abseil-cpp/absl/time/time.h:1762:37: error: invalid operands to binary expression ('std::strong_ordering' and 'const std::strong_ordering')
  if (auto c = lhs_hi <=> rhs_hi; c != std::strong_ordering::equal) {
```

The error indicates the lack of `operator<=>` between two `std::strong_ordering` items.
I believe that this should be controlled by `__cpp_lib_three_way_comparison` (_Three-way comparison (library support)_, see [this article](https://en.cppreference.com/w/cpp/feature_test)), not by `__cpp_impl_three_way_comparison` (which stands for _Three-way comparison (compiler support)_).

Fixes #1725.
The problem was introduced in a27662352e9caafc264747562162a8a32ef36cb9.
