### PR TITLE
Avoid `int` to `bool` conversion warning

### DIFF
--- a/absl/debugging/leak_check.cc
+++ b/absl/debugging/leak_check.cc
@@ -43,7 +43,7 @@ bool LeakCheckerIsActive() {
 bool LeakCheckerIsActive() { return true; }
 #endif
 
-bool FindAndReportLeaks() { return __lsan_do_recoverable_leak_check(); }
+bool FindAndReportLeaks() { return __lsan_do_recoverable_leak_check() != 0; }
 void DoIgnoreLeak(const void* ptr) { __lsan_ignore_object(ptr); }
 void RegisterLivePointers(const void* ptr, size_t size) {
   __lsan_register_root_region(ptr, size);


### PR DESCRIPTION
If asan is enabled with VS, the following warning is issued by the compiler:

1>C:\work\abseil-cpp\absl\debugging\leak_check.cc(46,68): error C4800: Implicit conversion from 'int' to bool. Possible information loss
1>    C:\work\abseil-cpp\absl\debugging\leak_check.cc(46,68):
1>    consider using explicit cast or comparison to 0 to avoid this warning