### PR TITLE
Update GoogleTest dependency to 1.15.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,7 +35,7 @@ bazel_dep(name = "google_benchmark",
           dev_dependency = True)
 
 bazel_dep(name = "googletest",
-          version = "1.15.0",
+          version = "1.15.2",
           repo_name = "com_google_googletest")
 
 bazel_dep(name = "platforms",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,11 +21,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # GoogleTest/GoogleMock framework. Used by most unit-tests.
 http_archive(
     name = "com_google_googletest",
-    sha256 = "7315acb6bf10e99f332c8a43f00d5fbb1ee6ca48c52f6b936991b216c586aaad",
-    strip_prefix = "googletest-1.15.0",
+    sha256 = "7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926",
+    strip_prefix = "googletest-1.15.2",
     # Keep this URL in sync with the version in ci/cmake_common.sh and
     # ci/windows_msvc_cmake.bat.
-    urls = ["https://github.com/google/googletest/releases/download/v1.15.0/googletest-1.15.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
 )
 
 # RE2 (the regular expression library used by GoogleTest)

--- a/ci/cmake_common.sh
+++ b/ci/cmake_common.sh
@@ -14,6 +14,6 @@
 
 # The commit of GoogleTest to be used in the CMake tests in this directory.
 # Keep this in sync with the commit in the WORKSPACE file.
-readonly ABSL_GOOGLETEST_VERSION="1.15.0"
+readonly ABSL_GOOGLETEST_VERSION="1.15.2"
 
 readonly ABSL_GOOGLETEST_DOWNLOAD_URL="https://github.com/google/googletest/releases/download/v${ABSL_GOOGLETEST_VERSION}/googletest-${ABSL_GOOGLETEST_VERSION}.tar.gz"

--- a/ci/windows_msvc_cmake.bat
+++ b/ci/windows_msvc_cmake.bat
@@ -16,7 +16,7 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 
 :: The version of GoogleTest to be used in the CMake tests in this directory.
 :: Keep this in sync with the version in the WORKSPACE file.
-SET ABSL_GOOGLETEST_VERSION=1.15.0
+SET ABSL_GOOGLETEST_VERSION=1.15.2
 SET ABSL_GOOGLETEST_DOWNLOAD_URL=https://github.com/google/googletest/releases/download/v%ABSL_GOOGLETEST_VERSION%/googletest-%ABSL_GOOGLETEST_VERSION%.tar.gz
 
 :: Replace '\' with '/' in Windows paths for CMake.


### PR DESCRIPTION
This updates to a version of GoogleTest that fixes https://github.com/google/googletest/issues/4581
for downstream users of rules_python

Cherry-pick of d0159eab5985aa8561ccda9ee9987d6b2726fd76
