### PR TITLE
Fix shell option group handling in pkgconfig files

### DIFF
--- a/CMake/AbseilHelpers.cmake
+++ b/CMake/AbseilHelpers.cmake
@@ -186,15 +186,15 @@ function(absl_cc_library)
         endif()
       endif()
     endforeach()
-    set(skip_next_cflag OFF)
     foreach(cflag ${ABSL_CC_LIB_COPTS})
-      if(skip_next_cflag)
-        set(skip_next_cflag OFF)
-      elseif(${cflag} MATCHES "^-Xarch_")
+      # Strip out the CMake-specific `SHELL:` prefix, which is used to construct
+      # a group of space-separated options.
+      # https://cmake.org/cmake/help/v3.30/command/target_compile_options.html#option-de-duplication
+      string(REGEX REPLACE "^SHELL:" "" cflag "${cflag}")
+      if(${cflag} MATCHES "^-Xarch_")
         # An -Xarch_ flag implies that its successor only applies to the
-        # specified platform. Filter both of them out before the successor
-        # reaches the "^-m" filter.
-        set(skip_next_cflag ON)
+        # specified platform. Such option groups are each specified in a single
+        # `SHELL:`-prefixed string in the COPTS list, which we simply ignore.
       elseif(${cflag} MATCHES "^(-Wno-|/wd)")
         # These flags are needed to suppress warnings that might fire in our headers.
         set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")


### PR DESCRIPTION
Since #1707 and #1710, `-Xarch_` option groups are present as single elements in the libraries' COPTS, and a `SHELL:` prefix is added to each of them. While these addressed certain build issues, they broke the handling of `-Xarch_` option groups in pkgconfig files.

Fix that by taking care of the `SHELL:` prefix in COPTS when generating pkgconfig files. The skip-next-flag mechanism is also removed as the option groups are now present as single elements.

Cc: @Royna2544 @anpol @derekmauro
