### PR TITLE
container/internal: Explicitly include <cstdint>

### DIFF
--- a/absl/container/internal/container_memory.h
+++ b/absl/container/internal/container_memory.h
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <new>


### PR DESCRIPTION
GCC 15 will no longer include <cstdint> by default, resulting in build failures in projects that do not explicitly include it.

Error:
```
absl/container/internal/container_memory.h:66:27: error: ‘uintptr_t’ does not name a type
   66 |   assert(reinterpret_cast<uintptr_t>(p) % Alignment == 0 &&
      |                           ^~~~~~~~~
absl/container/internal/container_memory.h:31:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   30 | #include "absl/utility/utility.h"
  +++ |+#include <cstdint>
   31 |
```

See-also: https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
