### PR TITLE
Fix mingw compiler error due to missing function declaration

### DIFF
--- a/absl/time/internal/cctz/src/time_zone_lookup.cc
+++ b/absl/time/internal/cctz/src/time_zone_lookup.cc
@@ -47,6 +47,7 @@
 #include <wchar.h>
 #include <windows.globalization.h>
 #include <windows.h>
+#include <winstring.h>
 #endif
 #endif
 


### PR DESCRIPTION
This fixes the following compiler errors.
time_zone_lookup.cc:78:34: error: 'WindowsCreateStringReference' was not declared in this scope time_zone_lookup.cc:84:34: error: 'WindowsDeleteString' was not declared in this scope time_zone_lookup.cc:90:34: error: 'WindowsGetStringRawBuffer' was not declared in this scope

Also, official documentation suggests to include the winstring.h header. https://learn.microsoft.com/en-us/windows/win32/api/winstring/nf-winstring-windowsgetstringrawbuffer
