### PR TITLE
Support QNX 7.1 build

### DIFF
--- a/absl/flags/internal/flag.h
+++ b/absl/flags/internal/flag.h
@@ -373,6 +373,9 @@ class MaskedPointer {
 
   static constexpr int RequiredAlignment() { return 4; }
 
+#ifdef __QNX__
+  constexpr explicit MaskedPointer() : ptr_(nullptr) {}
+#endif
   constexpr explicit MaskedPointer(ptr_t rhs) : ptr_(rhs) {}
   MaskedPointer(ptr_t rhs, bool is_candidate);
 


### PR DESCRIPTION
Support for QNX 7.1.  I understand this is not a supported platform

On QNX 7.1 ntoaarch64le, I hit the two build issue:
- `error: no matching function for call to 'absl::lts_20240722::flags_internal::MaskedPointer::MaskedPointer()'`
  - For this I defined a constructor, quite sure this was the wrong approach though.

I've built code using this, in particular the `flat_has_map`, it seems to work really well.  Hoping for feedback to get the PR up to merging quality.