### PR TITLE
Add 8/16-bit integer support to SimpleAtoi

### DIFF
--- a/absl/strings/numbers.cc
+++ b/absl/strings/numbers.cc
@@ -1110,6 +1110,16 @@ ABSL_CONST_INIT ABSL_DLL const char kHexTable[513] =
     "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
     "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
 
+bool safe_strto8_base(absl::string_view text, absl::Nonnull<int8_t*> value,
+                      int base) {
+  return safe_int_internal<int8_t>(text, value, base);
+}
+
+bool safe_strto16_base(absl::string_view text, absl::Nonnull<int16_t*> value,
+                       int base) {
+  return safe_int_internal<int16_t>(text, value, base);
+}
+
 bool safe_strto32_base(absl::string_view text, absl::Nonnull<int32_t*> value,
                        int base) {
   return safe_int_internal<int32_t>(text, value, base);
@@ -1123,6 +1133,16 @@ bool safe_strto64_base(absl::string_view text, absl::Nonnull<int64_t*> value,
 bool safe_strto128_base(absl::string_view text, absl::Nonnull<int128*> value,
                         int base) {
   return safe_int_internal<absl::int128>(text, value, base);
+}
+
+bool safe_strtou8_base(absl::string_view text, absl::Nonnull<uint8_t*> value,
+                       int base) {
+  return safe_uint_internal<uint8_t>(text, value, base);
+}
+
+bool safe_strtou16_base(absl::string_view text, absl::Nonnull<uint16_t*> value,
+                        int base) {
+  return safe_uint_internal<uint16_t>(text, value, base);
 }
 
 bool safe_strtou32_base(absl::string_view text, absl::Nonnull<uint32_t*> value,

--- a/absl/strings/numbers.h
+++ b/absl/strings/numbers.h
@@ -222,7 +222,7 @@ ABSL_MUST_USE_RESULT bool safe_strtoi_base(absl::string_view s,
   // with enums, and it also serves to check that int_type is not a pointer.
   // If one day something like std::is_signed<enum E> works, switch to it.
   // These conditions are constexpr bools to suppress MSVC warning C4127.
-  constexpr bool kIsSigned = static_cast<int_type>(1) - 2 < 0;
+  constexpr bool kIsSigned = static_cast<int_type>(-1) < 0;
   constexpr bool kUse64Bit = sizeof(*out) == 64 / 8;
   if (kIsSigned) {
     if (kUse64Bit) {

--- a/absl/strings/numbers.h
+++ b/absl/strings/numbers.h
@@ -142,12 +142,20 @@ void PutTwoDigits(uint32_t i, absl::Nonnull<char*> buf);
 
 // safe_strto?() functions for implementing SimpleAtoi()
 
+bool safe_strto8_base(absl::string_view text, absl::Nonnull<int8_t*> value,
+                      int base);
+bool safe_strto16_base(absl::string_view text, absl::Nonnull<int16_t*> value,
+                       int base);
 bool safe_strto32_base(absl::string_view text, absl::Nonnull<int32_t*> value,
                        int base);
 bool safe_strto64_base(absl::string_view text, absl::Nonnull<int64_t*> value,
                        int base);
 bool safe_strto128_base(absl::string_view text,
                         absl::Nonnull<absl::int128*> value, int base);
+bool safe_strtou8_base(absl::string_view text, absl::Nonnull<uint8_t*> value,
+                       int base);
+bool safe_strtou16_base(absl::string_view text, absl::Nonnull<uint16_t*> value,
+                        int base);
 bool safe_strtou32_base(absl::string_view text, absl::Nonnull<uint32_t*> value,
                         int base);
 bool safe_strtou64_base(absl::string_view text, absl::Nonnull<uint64_t*> value,
@@ -213,8 +221,9 @@ template <typename int_type>
 ABSL_MUST_USE_RESULT bool safe_strtoi_base(absl::string_view s,
                                            absl::Nonnull<int_type*> out,
                                            int base) {
-  static_assert(sizeof(*out) == 4 || sizeof(*out) == 8,
-                "SimpleAtoi works only with 32-bit or 64-bit integers.");
+  static_assert(sizeof(*out) == 1 || sizeof(*out) == 2 ||
+                sizeof(*out) == 4 || sizeof(*out) == 8,
+                "SimpleAtoi works only with 8, 16, 32, or 64-bit integers.");
   static_assert(!std::is_floating_point<int_type>::value,
                 "Use SimpleAtof or SimpleAtod instead.");
   bool parsed;
@@ -223,25 +232,41 @@ ABSL_MUST_USE_RESULT bool safe_strtoi_base(absl::string_view s,
   // If one day something like std::is_signed<enum E> works, switch to it.
   // These conditions are constexpr bools to suppress MSVC warning C4127.
   constexpr bool kIsSigned = static_cast<int_type>(-1) < 0;
-  constexpr bool kUse64Bit = sizeof(*out) == 64 / 8;
+  constexpr int kIntTypeSize = sizeof(*out) * 8;
   if (kIsSigned) {
-    if (kUse64Bit) {
+    if (kIntTypeSize == 64) {
       int64_t val;
       parsed = numbers_internal::safe_strto64_base(s, &val, base);
       *out = static_cast<int_type>(val);
-    } else {
+    } else if (kIntTypeSize == 32) {
       int32_t val;
       parsed = numbers_internal::safe_strto32_base(s, &val, base);
       *out = static_cast<int_type>(val);
+    } else if (kIntTypeSize == 16) {
+      int16_t val;
+      parsed = numbers_internal::safe_strto16_base(s, &val, base);
+      *out = static_cast<int_type>(val);
+    } else if (kIntTypeSize == 8) {
+      int8_t val;
+      parsed = numbers_internal::safe_strto8_base(s, &val, base);
+      *out = static_cast<int_type>(val);
     }
   } else {
-    if (kUse64Bit) {
+    if (kIntTypeSize == 64) {
       uint64_t val;
       parsed = numbers_internal::safe_strtou64_base(s, &val, base);
       *out = static_cast<int_type>(val);
-    } else {
+    } else if (kIntTypeSize == 32) {
       uint32_t val;
       parsed = numbers_internal::safe_strtou32_base(s, &val, base);
+      *out = static_cast<int_type>(val);
+    } else if (kIntTypeSize == 16) {
+      uint16_t val;
+      parsed = numbers_internal::safe_strtou16_base(s, &val, base);
+      *out = static_cast<int_type>(val);
+    } else if (kIntTypeSize == 8) {
+      uint8_t val;
+      parsed = numbers_internal::safe_strtou8_base(s, &val, base);
       *out = static_cast<int_type>(val);
     }
   }

--- a/absl/strings/numbers_test.cc
+++ b/absl/strings/numbers_test.cc
@@ -279,6 +279,64 @@ void VerifySimpleAtoiBad(in_val_type in_value) {
 }
 
 TEST(NumbersTest, Atoi) {
+  // SimpleAtoi(absl::string_view, int8_t)
+  VerifySimpleAtoiGood<int8_t, int64_t>(0, 0);
+  VerifySimpleAtoiGood<int8_t, int64_t>(42, 42);
+  VerifySimpleAtoiGood<int8_t, int64_t>(-42, -42);
+
+  VerifySimpleAtoiGood<int8_t, int64_t>(std::numeric_limits<int8_t>::min(),
+                                        std::numeric_limits<int8_t>::min());
+  VerifySimpleAtoiGood<int8_t, int64_t>(std::numeric_limits<int8_t>::max(),
+                                        std::numeric_limits<int8_t>::max());
+
+  VerifySimpleAtoiBad<int8_t, int64_t>(std::numeric_limits<uint8_t>::max());
+  VerifySimpleAtoiBad<int8_t, int64_t>(std::numeric_limits<int16_t>::min());
+  VerifySimpleAtoiBad<int8_t, int64_t>(std::numeric_limits<int16_t>::max());
+
+
+  // SimpleAtoi(absl::string_view, uint8_t)
+  VerifySimpleAtoiGood<uint8_t, int64_t>(0, 0);
+  VerifySimpleAtoiGood<uint8_t, int64_t>(42, 42);
+  VerifySimpleAtoiBad<uint8_t, int64_t>(-42);
+
+  VerifySimpleAtoiBad<uint8_t, int64_t>(std::numeric_limits<int8_t>::min());
+  VerifySimpleAtoiGood<uint8_t, int64_t>(std::numeric_limits<int8_t>::max(),
+                                         std::numeric_limits<int8_t>::max());
+  VerifySimpleAtoiGood<uint8_t, int64_t>(std::numeric_limits<uint8_t>::max(),
+                                         std::numeric_limits<uint8_t>::max());
+
+  VerifySimpleAtoiBad<uint8_t, int64_t>(std::numeric_limits<int16_t>::min());
+  VerifySimpleAtoiBad<uint8_t, int64_t>(std::numeric_limits<int16_t>::max());
+  VerifySimpleAtoiBad<uint8_t, int64_t>(std::numeric_limits<uint16_t>::max());
+
+  // SimpleAtoi(absl::string_view, int16_t)
+  VerifySimpleAtoiGood<int16_t>(0, 0);
+  VerifySimpleAtoiGood<int16_t>(42, 42);
+  VerifySimpleAtoiGood<int16_t>(-42, -42);
+
+  VerifySimpleAtoiGood<int16_t>(std::numeric_limits<int16_t>::min(),
+                                std::numeric_limits<int16_t>::min());
+  VerifySimpleAtoiGood<int16_t>(std::numeric_limits<int16_t>::max(),
+                                std::numeric_limits<int16_t>::max());
+
+  VerifySimpleAtoiBad<int16_t>(std::numeric_limits<uint16_t>::max());
+  VerifySimpleAtoiBad<int16_t>(std::numeric_limits<int32_t>::min());
+  VerifySimpleAtoiBad<int16_t>(std::numeric_limits<int32_t>::max());
+
+  // SimpleAtoi(absl::string_view, uint16_t)
+  VerifySimpleAtoiGood<uint16_t>(0, 0);
+  VerifySimpleAtoiGood<uint16_t>(42, 42);
+  VerifySimpleAtoiBad<uint16_t>(-42);
+
+  VerifySimpleAtoiBad<uint16_t>(std::numeric_limits<int16_t>::min());
+  VerifySimpleAtoiGood<uint16_t>(std::numeric_limits<int16_t>::max(),
+                                 std::numeric_limits<int16_t>::max());
+  VerifySimpleAtoiGood<uint16_t>(std::numeric_limits<uint16_t>::max(),
+                                 std::numeric_limits<uint16_t>::max());
+  VerifySimpleAtoiBad<uint16_t>(std::numeric_limits<int32_t>::min());
+  VerifySimpleAtoiBad<uint16_t>(std::numeric_limits<int32_t>::max());
+  VerifySimpleAtoiBad<uint16_t>(std::numeric_limits<uint32_t>::max());
+
   // SimpleAtoi(absl::string_view, int32_t)
   VerifySimpleAtoiGood<int32_t>(0, 0);
   VerifySimpleAtoiGood<int32_t>(42, 42);


### PR DESCRIPTION
This makes `SimpleAtoi` more ergonomic for tasks like parsing port numbers. These changes were mostly trivial copies of existing code paths. Two spots worth looking more closely at are:
- The signed-ness check (`kIsSigned`) which didn't work properly for these new narrower types, and has been updated.
- The change from a boolean for type width, to the value of the width (`kUse64Bit` vs `kIntTypeSize`).

A bit of previous discussion was [here](https://github.com/abseil/abseil-cpp/discussions/1753). Even if these changes aren't merged via this PR, I'd love for this to expedite the process of getting them made internally.