### PR TITLE
Fetch local_config_cc from rules_cc instead of bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,23 +20,34 @@ module(
     compatibility_level = 1,
 )
 
-cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")
-use_repo(cc_configure, "local_config_cc")
-
 # Only direct dependencies need to be listed below.
 # Please keep the versions in sync with the versions in the WORKSPACE file.
 
-bazel_dep(name = "bazel_skylib",
-          version = "1.5.0")
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.5.0",
+)
 
-bazel_dep(name = "google_benchmark",
-          version = "1.8.3",
-          repo_name = "com_github_google_benchmark",
-          dev_dependency = True)
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.8.3",
+    dev_dependency = True,
+    repo_name = "com_github_google_benchmark",
+)
 
-bazel_dep(name = "googletest",
-          version = "1.15.2",
-          repo_name = "com_google_googletest")
+bazel_dep(
+    name = "googletest",
+    version = "1.15.2",
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "platforms",
+    version = "0.0.10",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.13",
+)
 
-bazel_dep(name = "platforms",
-          version = "0.0.10")
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,10 +31,10 @@ http_archive(
 # RE2 (the regular expression library used by GoogleTest)
 http_archive(
     name = "com_googlesource_code_re2",
+    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
     sha256 = "eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b",
     strip_prefix = "re2-2024-07-02",
     urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.tar.gz"],
-    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
 )
 
 # Google benchmark.
@@ -55,9 +55,19 @@ http_archive(
 # Bazel platform rules.
 http_archive(
     name = "platforms",
+    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
         "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
     ],
-    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+)
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
+    strip_prefix = "rules_cc-0.0.13",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz",
+        "https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz",
+    ],
 )


### PR DESCRIPTION
With bazel 8.x cc_configure.bzl has moved to rules_cc
