### PR TITLE
add github workflow action to build and install abseil with CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  action:
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-13
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./

--- a/action.yml
+++ b/action.yml
@@ -31,13 +31,10 @@ runs:
         path: ./_abseil-cpp/build/
         key: abseil-cpp-${{ runner.os }}-${{ runner.arch }}
     - shell: bash
-      run: cmake -DCMAKE_CXX_STANDARD=${{ inputs.cmake-cxx-standard }} ..
-      working-directory: ./_abseil-cpp/build/
-    - shell: bash
-      run: cmake --build . --target install
-      working-directory: ./_abseil-cpp/build/
-    - shell: bash
-      run: cmake --install .
+      run: |
+        cmake -DCMAKE_CXX_STANDARD=${{ inputs.cmake-cxx-standard }} ..
+        cmake --build . --target install
+        cmake --install .
       working-directory: ./_abseil-cpp/build/
     - shell: bash
       run: rm -rf ./_abseil-cpp/

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,43 @@
+name: abseil-cpp
+description: 'Builds and install abseil-cpp using CMake on the current runner'
+branding:
+  icon: package
+  color: yellow
+
+inputs:
+  cmake-version:
+    description: "version of CMake to use"
+    required: false
+    default: ""
+  cmake-cxx-standard:
+    description: "standard to pass to CMake"
+    required: false
+    default: "14"
+
+runs:
+  using: composite
+  steps:
+    - uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
+      with:
+        cmake-version: ${{ inputs.cmake-version }}
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: abseil/abseil-cpp
+        path: ./_abseil-cpp/
+    - shell: bash
+      run: mkdir ./_abseil-cpp/build/
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      with:
+        path: ./_abseil-cpp/build/
+        key: abseil-cpp-${{ runner.os }}-${{ runner.arch }}
+    - shell: bash
+      run: cmake -DCMAKE_CXX_STANDARD=${{ inputs.cmake-cxx-standard }} ..
+      working-directory: ./_abseil-cpp/build/
+    - shell: bash
+      run: cmake --build . --target install
+      working-directory: ./_abseil-cpp/build/
+    - shell: bash
+      run: cmake --install .
+      working-directory: ./_abseil-cpp/build/
+    - shell: bash
+      run: rm -rf ./_abseil-cpp/


### PR DESCRIPTION
adds an `action.yml` with the goal that a GitHub workflow could use Abseil to build their project by doing
```yaml
  - uses: abseil/abseil-cpp
    with:
      cmake-version: "X.X.X"
      cmake-cxx-standard: 14
```