### PR TITLE
Add missing #ifdef pp directive to the TypeName() function in the layout.h

### DIFF
--- a/absl/container/internal/layout.h
+++ b/absl/container/internal/layout.h
@@ -306,7 +306,7 @@ constexpr size_t Max(size_t a, size_t b, Ts... rest) {
 template <class T>
 std::string TypeName() {
   std::string out;
-#if ABSL_INTERNAL_HAS_RTTI
+#ifdef ABSL_INTERNAL_HAS_RTTI
   absl::StrAppend(&out, "<",
                   absl::debugging_internal::DemangleString(typeid(T).name()),
                   ">");


### PR DESCRIPTION
If code is being compiled without support for the RTTI, ABSL_INTERNAL_HAS_RTTI pp macro is not defined in the absl/base/config.h (otherwise, if RTTI is supported, it is defined to 1)

Rn this macro is used in the absl/flags/internal/flag.h, absl/flags/internal/flag.cc, absl/types/any.h and absl/container/internal/layout.h. In the first three files it is used like `#ifdef ABSL_INTERNAL_HAS_RTTI`. In the layout.h it is used like `#if ABSL_INTERNAL_HAS_RTTI` which causes trouble if code that uses absl is being compiled with the Wundef warning flag (at least when gcc or clang are used)

Since ABSL_INTERNAL_HAS_RTTI is not defined when RTTI is not used, it seems like it should be used as `#ifdef ABSL_INTERNAL_HAS_RTTI` in the layout.h