### PR TITLE
Respect the allocator's .destroy method in ~InlinedVector

### DIFF
--- a/absl/container/internal/inlined_vector.h
+++ b/absl/container/internal/inlined_vector.h
@@ -84,7 +84,8 @@ template <typename A>
 using IsSwapOk = absl::type_traits_internal::IsSwappable<ValueType<A>>;
 
 template <typename A, bool IsTriviallyDestructible =
-                          absl::is_trivially_destructible<ValueType<A>>::value>
+                          absl::is_trivially_destructible<ValueType<A>>::value &&
+                          std::is_same<A, std::allocator<ValueType<A>>>::value>
 struct DestroyAdapter;
 
 template <typename A>


### PR DESCRIPTION
InlinedVector goes out of its way to use `A::construct` to construct new elements, so it should not skip the `A::destroy` call for those elements, either. Most codepaths seem fine (I didn't exhaustively explore this), but `DestroyAdapter` specifically failed to check whether the allocator had a non-trivial `destroy` method: it checked only whether the element type was trivially destructible in the absence of any `destroy` method.

Use the same condition in `DestroyAdapter` as we already use in the special short-circuit case on line 357 and in the conditions for the relocation optimizations on lines 304 and 324.

Note to Abseil maintainer: You'll want to make sure this passes all the tests, and probably add a newly-green test for it. Something like this Godbolt: https://godbolt.org/z/aoTar9vdT

```
template<class T>
struct A {
    int i_ = 0;
    using value_type = T;
    explicit A(int i) : i_(i) {}
    template<class U> A(A<U>& a) : i_(a.i_) {}
    T *allocate(size_t n) { return std::allocator<T>().allocate(n); }
    void deallocate(T *p, size_t n) { return std::allocator<T>().deallocate(p, n); }
    template<class... Args> T *construct(T *p, Args&&... args) { printf("constructing(%d) %s at %p\n", i_, __PRETTY_FUNCTION__, p); return ::new(p) T(std::forward<Args>(args)...); }
    void destroy(T *p) { printf("destroying(%d) %s at %p\n", i_, __PRETTY_FUNCTION__, p); }
};

int main() {
    absl::InlinedVector<int, 2, A<int>> v1(A<int>(42));
    v1.emplace_back(1);
    v1.insert(v1.begin(), 2);
    puts("Where are the corresponding destroy calls??");
}
```
(which currently prints)
```
constructing(42) T *A<int>::construct(T *, Args &&...) [T = int, Args = <int>] at 0x7ffc8b8fca80
constructing(42) T *A<int>::construct(T *, Args &&...) [T = int, Args = <int>] at 0x7ffc8b8fca84
Where are the corresponding destroy calls??
```

After this patch, it prints:
```
constructing(42) T *A<int>::construct(T *, Args &&...) [T = int, Args = <int>] at 0x16d9b7448
constructing(42) T *A<int>::construct(T *, Args &&...) [T = int, Args = <int>] at 0x16d9b744c
Where are the corresponding destroy calls??
destroying(42) void A<int>::destroy(T *) [T = int] at 0x16d9b744c
destroying(42) void A<int>::destroy(T *) [T = int] at 0x16d9b7448
```