### PR TITLE
Update cpu_detect.cc  fix hw crc32 and AES capability check, fix undefined

### DIFF
--- a/absl/crc/internal/cpu_detect.cc
+++ b/absl/crc/internal/cpu_detect.cc
@@ -269,7 +269,7 @@ CpuType GetCpuType() {
 }
 
 bool SupportsArmCRC32PMULL() {
-#if defined(HWCAP_CRC32) && defined(HWCAP_CRC32PMULL)
+#if defined(HWCAP_CRC32) && defined(HWCAP_PMULL)
   uint64_t hwcaps = getauxval(AT_HWCAP);
   return (hwcaps & HWCAP_CRC32) && (hwcaps & HWCAP_PMULL);
 #else

--- a/absl/crc/internal/cpu_detect.cc
+++ b/absl/crc/internal/cpu_detect.cc
@@ -269,8 +269,12 @@ CpuType GetCpuType() {
 }
 
 bool SupportsArmCRC32PMULL() {
+#if defined(HWCAP_CRC32) && defined(HWCAP_CRC32PMULL)
   uint64_t hwcaps = getauxval(AT_HWCAP);
   return (hwcaps & HWCAP_CRC32) && (hwcaps & HWCAP_PMULL);
+#else
+  return false;
+#endif
 }
 
 #else


### PR DESCRIPTION
Source and explonation 
https://github.com/JuliaLang/julia/issues/26458
https://github.com/memcached/memcached/pull/744

For build for aarch64 on v22_clang-16.0.6-centos7 
`
abseil-cpp/absl/crc/internal/cpu_detect.cc:273:20: error: use of undeclared identifier 'HWCAP_CRC32'
  return (hwcaps & HWCAP_CRC32) && (hwcaps & HWCAP_PMULL);
                   ^
abseil-cpp/absl/crc/internal/cpu_detect.cc:273:46: error: use of undeclared identifier 'HWCAP_PMULL'
  return (hwcaps & HWCAP_CRC32) && (hwcaps & HWCAP_PMULL);
`
