### PR TITLE
Remove bazel cpu constraints usage

### DIFF
--- a/absl/BUILD.bazel
+++ b/absl/BUILD.bazel
@@ -131,3 +131,12 @@ selects.config_setting_group(
     ],
     visibility = [":__subpackages__"],
 )
+
+selects.config_setting_group(
+    name = "windows_x86_64",
+    match_all = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = [":__subpackages__"],
+)

--- a/absl/copts/configure_copts.bzl
+++ b/absl/copts/configure_copts.bzl
@@ -15,7 +15,6 @@ load(
     "ABSL_MSVC_FLAGS",
     "ABSL_MSVC_LINKOPTS",
     "ABSL_MSVC_TEST_FLAGS",
-    "ABSL_RANDOM_HWAES_ARM32_FLAGS",
     "ABSL_RANDOM_HWAES_ARM64_FLAGS",
     "ABSL_RANDOM_HWAES_MSVC_X64_FLAGS",
     "ABSL_RANDOM_HWAES_X64_FLAGS",
@@ -45,38 +44,11 @@ ABSL_DEFAULT_LINKOPTS = select({
 # ABSL_RANDOM_RANDEN_COPTS blaze copts flags which are required by each
 # environment to build an accelerated RandenHwAes library.
 ABSL_RANDOM_RANDEN_COPTS = select({
-    # APPLE
-    ":cpu_darwin_x86_64": ABSL_RANDOM_HWAES_X64_FLAGS,
-    ":cpu_darwin": ABSL_RANDOM_HWAES_X64_FLAGS,
-    ":cpu_x64_windows_msvc": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
-    ":cpu_x64_windows": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
-    ":cpu_k8": ABSL_RANDOM_HWAES_X64_FLAGS,
-    ":cpu_ppc": ["-mcrypto"],
-    ":cpu_aarch64": ABSL_RANDOM_HWAES_ARM64_FLAGS,
+    "//absl:windows_x86_64": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
+    "@platforms//cpu:x86_64": ABSL_RANDOM_HWAES_X64_FLAGS,
+    "@platforms//cpu:ppc": ["-mcrypto"],
+    "@platforms//cpu:aarch64": ABSL_RANDOM_HWAES_ARM64_FLAGS,
 
     # Supported by default or unsupported.
     "//conditions:default": [],
 })
-
-# absl_random_randen_copts_init:
-#  Initialize the config targets based on cpu, os, etc. used to select
-#  the required values for ABSL_RANDOM_RANDEN_COPTS
-def absl_random_randen_copts_init():
-    """Initialize the config_settings used by ABSL_RANDOM_RANDEN_COPTS."""
-
-    # CPU configs.
-    # These configs have consistent flags to enable HWAES intsructions.
-    cpu_configs = [
-        "ppc",
-        "k8",
-        "darwin_x86_64",
-        "darwin",
-        "x64_windows_msvc",
-        "x64_windows",
-        "aarch64",
-    ]
-    for cpu in cpu_configs:
-        native.config_setting(
-            name = "cpu_%s" % cpu,
-            values = {"cpu": cpu},
-        )

--- a/absl/random/internal/BUILD.bazel
+++ b/absl/random/internal/BUILD.bazel
@@ -21,7 +21,6 @@ load(
     "ABSL_DEFAULT_LINKOPTS",
     "ABSL_RANDOM_RANDEN_COPTS",
     "ABSL_TEST_COPTS",
-    "absl_random_randen_copts_init",
 )
 
 default_package_visibility = [
@@ -320,8 +319,6 @@ cc_library(
         "//absl/numeric:int128",
     ],
 )
-
-absl_random_randen_copts_init()
 
 cc_library(
     name = "randen_hwaes",


### PR DESCRIPTION
This fixes a warning in an upcoming version of bazel. This use case
seems to solvable by using platform constraints directly. Fixes:

```
WARNING: @@abseil-cpp+//absl/random/internal:cpu_aarch64: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
```
