### PR TITLE
Remove unncessary <iostream> includes

### DIFF
--- a/absl/random/internal/randen_engine.h
+++ b/absl/random/internal/randen_engine.h
@@ -18,9 +18,10 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstdlib>
-#include <iostream>
+#include <istream>
 #include <iterator>
 #include <limits>
+#include <ostream>
 #include <type_traits>
 
 #include "absl/base/internal/endian.h"

--- a/absl/random/seed_gen_exception.cc
+++ b/absl/random/seed_gen_exception.cc
@@ -14,9 +14,11 @@
 
 #include "absl/random/seed_gen_exception.h"
 
-#include <iostream>
-
 #include "absl/base/config.h"
+
+#ifndef ABSL_HAVE_EXCEPTIONS
+#include <iostream>
+#endif
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN

--- a/absl/strings/cord.cc
+++ b/absl/strings/cord.cc
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <iomanip>
 #include <ios>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <ostream>

--- a/absl/strings/internal/charconv_bigint.h
+++ b/absl/strings/internal/charconv_bigint.h
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <iostream>
+#include <ostream>
 #include <string>
 
 #include "absl/base/config.h"

--- a/absl/strings/internal/cord_rep_btree.cc
+++ b/absl/strings/internal/cord_rep_btree.cc
@@ -17,9 +17,12 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
-#include <iostream>
 #include <ostream>
 #include <string>
+
+#ifndef NDEBUG
+#include <iostream>
+#endif
 
 #include "absl/base/attributes.h"
 #include "absl/base/config.h"

--- a/absl/strings/internal/cord_rep_btree_navigator.h
+++ b/absl/strings/internal/cord_rep_btree_navigator.h
@@ -16,7 +16,6 @@
 #define ABSL_STRINGS_INTERNAL_CORD_REP_BTREE_NAVIGATOR_H_
 
 #include <cassert>
-#include <iostream>
 
 #include "absl/strings/internal/cord_internal.h"
 #include "absl/strings/internal/cord_rep_btree.h"


### PR DESCRIPTION
Including `<iostream>` means introducing the static (global) constructors and destructors for `std::cin`, `std::cerr`, and `std::cout`. That extra `init` and `fini` code is [undesirable](https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables) when those streams are not actually used.