### PR TITLE
Fix potential integer overflow in hash container create/resize

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "20240116.2",
+    version = "20240116.3",
     compatibility_level = 1,
 )
 

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -118,7 +118,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20240116
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 2
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 3
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/container/internal/raw_hash_set_test.cc
+++ b/absl/container/internal/raw_hash_set_test.cc
@@ -2678,6 +2678,14 @@ TEST(Table, CountedHash) {
   }
 }
 
+TEST(Table, MaxSizeOverflow) {
+  size_t overflow = (std::numeric_limits<size_t>::max)();
+  EXPECT_DEATH_IF_SUPPORTED(IntTable t(overflow), "Hash table size overflow");
+  IntTable t;
+  EXPECT_DEATH_IF_SUPPORTED(t.reserve(overflow), "Hash table size overflow");
+  EXPECT_DEATH_IF_SUPPORTED(t.rehash(overflow), "Hash table size overflow");
+}
+
 }  // namespace
 }  // namespace container_internal
 ABSL_NAMESPACE_END


### PR DESCRIPTION
The sized constructors, reserve(), and rehash() methods of absl::{flat,node}_hash_{set,map} did not impose an upper bound on their size argument. As a result, it was possible for a caller to pass a very large size that would cause an integer overflow when computing the size of the container's backing store. Subsequent accesses to the container might then access out-of-bounds memory.

The fix is in two parts:

1) Update max_size() to return the maximum number of items that can be stored in the container

2) Validate the size arguments to the constructors, reserve(), and rehash() methods, and abort the program when the argument is invalid

We've looked at uses of these containers in Google codebases like Chrome, and determined this vulnerability is likely to be difficult to exploit. This is primarily because container sizes are rarely attacker-controlled.

The bug was discovered by Dmitry Vyukov <dvyukov@google.com>.