### PR TITLE
Fix potential integer overflow in hash container create/resize

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -112,7 +112,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20230802
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 2
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 3
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -1076,6 +1076,12 @@ inline size_t NormalizeCapacity(size_t n) {
   return n ? ~size_t{} >> countl_zero(n) : 1;
 }
 
+template <size_t kSlotSize>
+size_t MaxValidCapacity() {
+  return NormalizeCapacity((std::numeric_limits<size_t>::max)() / 4 /
+                           kSlotSize);
+}
+
 // General notes on capacity/growth methods below:
 // - We use 7/8th as maximum load factor. For 16-wide groups, that gives an
 //   average of two empty slots per group.
@@ -1717,6 +1723,8 @@ class raw_hash_set {
       const allocator_type& alloc = allocator_type())
       : settings_(CommonFields{}, hash, eq, alloc) {
     if (bucket_count) {
+      ABSL_RAW_CHECK(bucket_count <= MaxValidCapacity<sizeof(slot_type)>(),
+                     "Hash table size overflow");
       common().set_capacity(NormalizeCapacity(bucket_count));
       initialize_slots();
     }
@@ -1916,7 +1924,10 @@ class raw_hash_set {
   bool empty() const { return !size(); }
   size_t size() const { return common().size(); }
   size_t capacity() const { return common().capacity(); }
-  size_t max_size() const { return (std::numeric_limits<size_t>::max)(); }
+  size_t max_size() const {
+    return CapacityToGrowth(MaxValidCapacity<sizeof(slot_type)>());
+  }
+
 
   ABSL_ATTRIBUTE_REINITIALIZES void clear() {
     // Iterating over this container is O(bucket_count()). When bucket_count()
@@ -2266,6 +2277,8 @@ class raw_hash_set {
     auto m = NormalizeCapacity(n | GrowthToLowerboundCapacity(size()));
     // n == 0 unconditionally rehashes as per the standard.
     if (n == 0 || m > capacity()) {
+      ABSL_RAW_CHECK(m <= MaxValidCapacity<sizeof(slot_type)>(),
+                     "Hash table size overflow");
       resize(m);
 
       // This is after resize, to ensure that we have completed the allocation
@@ -2276,6 +2289,7 @@ class raw_hash_set {
 
   void reserve(size_t n) {
     if (n > size() + growth_left()) {
+      ABSL_RAW_CHECK(n <= max_size(), "Hash table size overflow");
       size_t m = GrowthToLowerboundCapacity(n);
       resize(NormalizeCapacity(m));
 

--- a/absl/container/internal/raw_hash_set_test.cc
+++ b/absl/container/internal/raw_hash_set_test.cc
@@ -2510,6 +2510,14 @@ TEST(Iterator, InvalidComparisonDifferentTables) {
                             "Invalid iterator comparison.*non-end");
 }
 
+TEST(Table, MaxSizeOverflow) {
+  size_t overflow = (std::numeric_limits<size_t>::max)();
+  EXPECT_DEATH_IF_SUPPORTED(IntTable t(overflow), "Hash table size overflow");
+  IntTable t;
+  EXPECT_DEATH_IF_SUPPORTED(t.reserve(overflow), "Hash table size overflow");
+  EXPECT_DEATH_IF_SUPPORTED(t.rehash(overflow), "Hash table size overflow");
+}
+
 }  // namespace
 }  // namespace container_internal
 ABSL_NAMESPACE_END


### PR DESCRIPTION
The sized constructors, reserve(), and rehash() methods of absl::{flat,node}_hash_{set,map} did not impose an upper bound on their size argument. As a result, it was possible for a caller to pass a very large size that would cause an integer overflow when computing the size of the container's backing store. Subsequent accesses to the container might then access out-of-bounds memory.

The fix is in two parts:

1) Update max_size() to return the maximum number of items that can be stored in the container

2) Validate the size arguments to the constructors, reserve(), and rehash() methods, and abort the program when the argument is invalid

We've looked at uses of these containers in Google codebases like Chrome, and determined this vulnerability is likely to be difficult to exploit. This is primarily because container sizes are rarely attacker-controlled.

The bug was discovered by Dmitry Vyukov <dvyukov@google.com>.