### PR TITLE
Random: use getauxval() via <sys/auxv.h>

### DIFF
--- a/absl/random/internal/randen_detect.cc
+++ b/absl/random/internal/randen_detect.cc
@@ -74,7 +74,7 @@ static void __cpuid(int cpu_info[4], int info_type) {
 // On linux, just use the c-library getauxval call.
 #if defined(ABSL_INTERNAL_USE_LINUX_GETAUXVAL)
 
-extern "C" unsigned long getauxval(unsigned long type);  // NOLINT(runtime/int)
+#include <sys/auxv.h>
 
 static uint32_t GetAuxval(uint32_t hwcap_type) {
   return static_cast<uint32_t>(getauxval(hwcap_type));


### PR DESCRIPTION
Make the use of  `getauxval()` consistent with other parts of abseil and use it via the `<sys/auxv.h>` header instead of a local declaration.

The current situation is causing some weird symbol visibility issues at least in Firefox, see https://bugzilla.mozilla.org/show_bug.cgi?id=1942917 for details.