### PR TITLE
fix compilation with AppleClang

### DIFF
--- a/absl/random/internal/randen_detect.cc
+++ b/absl/random/internal/randen_detect.cc
@@ -120,7 +120,7 @@ static absl::optional<T> ReadSysctlByName(const char* name) {
   size_t val_size = sizeof(T);
   int ret = sysctlbyname(name, &val, &val_size, nullptr, 0);
   if (ret == -1) {
-    return std::nullopt;
+    return absl::nullopt;
   }
   return val;
 }


### PR DESCRIPTION
Fix the following error:

absl/random/internal/randen_detect.cc:123:12: error: no member named 'nullopt' in namespace 'std'; did you mean 'absl::nullopt'?
  123 |     return std::nullopt;
      |            ^~~~~~~~~~~~
      |            absl::nullopt
absl/types/optional.h:86:43: note: 'absl::nullopt' declared here
   86 | ABSL_INTERNAL_INLINE_CONSTEXPR(nullopt_t, nullopt,
      |                                           ^