### PR TITLE
PR #1819: fix compilation with AppleClang

### DIFF
--- a/absl/random/internal/randen_detect.cc
+++ b/absl/random/internal/randen_detect.cc
@@ -120,7 +120,7 @@ static absl::optional<T> ReadSysctlByName(const char* name) {
   size_t val_size = sizeof(T);
   int ret = sysctlbyname(name, &val, &val_size, nullptr, 0);
   if (ret == -1) {
-    return std::nullopt;
+    return absl::nullopt;
   }
   return val;
 }


### PR DESCRIPTION
Imported from GitHub PR https://github.com/abseil/abseil-cpp/pull/1819

Fix the following error:

absl/random/internal/randen_detect.cc:123:12: error: no member named 'nullopt' in namespace 'std'; did you mean 'absl::nullopt'?
  123 |     return std::nullopt;
      |            ^~~~~~~~~~~~
      |            absl::nullopt
absl/types/optional.h:86:43: note: 'absl::nullopt' declared here
   86 | ABSL_INTERNAL_INLINE_CONSTEXPR(nullopt_t, nullopt,
      |                                           ^
Merge b9a2d3920a472af7247876f58513aeb704fd3145 into 7253ff8f9571cf2877067ce11b984b059a0c53b7

Merging this change closes #1819

COPYBARA_INTEGRATE_REVIEW=https://github.com/abseil/abseil-cpp/pull/1819 from clementperon:master b9a2d3920a472af7247876f58513aeb704fd3145 PiperOrigin-RevId: 722599523
Change-Id: Ie66cbf9daf3b115668194da8b74acd6a43e12a03
