### PR TITLE
Port abseil to GNU/Hurd.

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -380,7 +380,8 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
     defined(__asmjs__) || defined(__EMSCRIPTEN__) || defined(__Fuchsia__) || \
     defined(__sun) || defined(__myriad2__) || defined(__HAIKU__) ||          \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) ||       \
-    defined(__VXWORKS__) || defined(__hexagon__) || defined(__XTENSA__)
+    defined(__VXWORKS__) || defined(__hexagon__) || defined(__XTENSA__) ||   \
+    defined(__GNU__)
 #define ABSL_HAVE_MMAP 1
 #endif
 

--- a/absl/base/internal/raw_logging.cc
+++ b/absl/base/internal/raw_logging.cc
@@ -44,7 +44,7 @@
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
     defined(__hexagon__) || defined(__Fuchsia__) ||                     \
     defined(__native_client__) || defined(__OpenBSD__) ||               \
-    defined(__EMSCRIPTEN__) || defined(__ASYLO__)
+    defined(__EMSCRIPTEN__) || defined(__ASYLO__) || defined(__GNU__)
 
 #include <unistd.h>
 

--- a/absl/base/internal/strerror_test.cc
+++ b/absl/base/internal/strerror_test.cc
@@ -39,7 +39,9 @@ TEST(StrErrorTest, ValidErrorCode) {
 TEST(StrErrorTest, InvalidErrorCode) {
   errno = ERANGE;
   EXPECT_THAT(absl::base_internal::StrError(-1),
-              AnyOf(Eq("No error information"), Eq("Unknown error -1")));
+              AnyOf(Eq("No error information"),
+                    Eq("Unknown error -1"),
+                    Eq("Error in unknown error system: FFFFFFFF")));
   EXPECT_THAT(errno, Eq(ERANGE));
 }
 

--- a/absl/debugging/internal/stack_consumption.h
+++ b/absl/debugging/internal/stack_consumption.h
@@ -25,7 +25,8 @@
 #ifdef ABSL_INTERNAL_HAVE_DEBUGGING_STACK_CONSUMPTION
 #error ABSL_INTERNAL_HAVE_DEBUGGING_STACK_CONSUMPTION cannot be set directly
 #elif !defined(__APPLE__) && !defined(_WIN32) && !defined(__Fuchsia__) && \
-    (defined(__i386__) || defined(__x86_64__) || defined(__ppc__) || \
+    !defined(__GNU__) &&                                                  \
+    (defined(__i386__) || defined(__x86_64__) || defined(__ppc__) ||      \
      defined(__aarch64__) || defined(__riscv))
 #define ABSL_INTERNAL_HAVE_DEBUGGING_STACK_CONSUMPTION 1
 

--- a/absl/debugging/internal/symbolize.h
+++ b/absl/debugging/internal/symbolize.h
@@ -29,7 +29,7 @@
 #ifdef ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE
 #error ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE cannot be directly set
 #elif defined(__ELF__) && defined(__GLIBC__) && !defined(__native_client__) \
-      && !defined(__asmjs__) && !defined(__wasm__)
+      && !defined(__asmjs__) && !defined(__wasm__) && !defined(__GNU__)
 #define ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE 1
 
 #include <elf.h>

--- a/absl/debugging/internal/vdso_support.h
+++ b/absl/debugging/internal/vdso_support.h
@@ -48,7 +48,7 @@
 
 #ifdef ABSL_HAVE_VDSO_SUPPORT
 #error ABSL_HAVE_VDSO_SUPPORT cannot be directly set
-#else
+#elif !defined(__GNU__)
 #define ABSL_HAVE_VDSO_SUPPORT 1
 #endif
 

--- a/absl/log/internal/test_helpers.cc
+++ b/absl/log/internal/test_helpers.cc
@@ -18,6 +18,8 @@
 #include <zircon/syscalls.h>
 #endif
 
+#include <signal.h>
+
 #include "gtest/gtest.h"
 #include "absl/base/config.h"
 #include "absl/base/log_severity.h"

--- a/absl/log/log_modifier_methods_test.cc
+++ b/absl/log/log_modifier_methods_test.cc
@@ -181,13 +181,16 @@ TEST(TailCallsModifiesTest, WithPerror) {
       Send(AllOf(
           TextMessage(AnyOf(Eq("hello world: Bad file number [9]"),
                             Eq("hello world: Bad file descriptor [9]"),
-                            Eq("hello world: Bad file descriptor [8]"))),
+                            Eq("hello world: Bad file descriptor [8]"),
+                            Eq("hello world: Bad file descriptor [1073741833]"))),
           ENCODED_MESSAGE(HasValues(ElementsAre(
               ValueWithLiteral(Eq("hello world")), ValueWithLiteral(Eq(": ")),
               AnyOf(ValueWithStr(Eq("Bad file number")),
                     ValueWithStr(Eq("Bad file descriptor"))),
               ValueWithLiteral(Eq(" [")),
-              AnyOf(ValueWithStr(Eq("8")), ValueWithStr(Eq("9"))),
+              AnyOf(ValueWithStr(Eq("8")),
+                    ValueWithStr(Eq("9")),
+                    ValueWithStr(Eq("1073741833"))),
               ValueWithLiteral(Eq("]"))))))));
 
   test_sink.StartCapturingLogs();

--- a/absl/log/stripping_test.cc
+++ b/absl/log/stripping_test.cc
@@ -33,7 +33,7 @@
 
 #include <stdio.h>
 
-#if defined(__MACH__)
+#if defined(__APPLE__)
 #include <mach-o/dyld.h>
 #elif defined(_WIN32)
 #include <Windows.h>
@@ -191,7 +191,7 @@ class StrippingTest : public ::testing::Test {
       absl::FPrintF(stderr, "Failed to open /pkg/bin/<binary name>: %s\n", err);
     }
     return fp;
-#elif defined(__MACH__)
+#elif defined(__APPLE__)
     uint32_t size = 0;
     int ret = _NSGetExecutablePath(nullptr, &size);
     if (ret != -1) {


### PR DESCRIPTION
This pr is to port abseil to [GNU/Hurd](https://www.gnu.org/software/hurd/index.html). It might be a little hard for you to thoroughly review and test the patch on GNU/Hurd manually. But feel free to talk about any problems on it. I'm here willing to explain as much as I can. Here are some info that might be helpful.

- I have succeeded to package it to `.deb` on [GNU/Hurd Debian distribution](https://www.debian.org/ports/hurd/index). One step of the `.deb` packaging process is to run the unit tests, just like Debian on other platforms. And they passed.

- I have recently submitted [a patch to `libgav1`](https://chromium-review.googlesource.com/c/codecs/libgav1/+/6239812), which is the av1 decoder used in Chromium (maybe), and depends on abseil. I fixed its compiling failure on GNU/Hurd and built it with ported abseil. It works well and I can use it to decode real av1 videos.

- This patch was firstly posted to GNU/Hurd Debian mailing list for review, and some of the maintainers of GNU/Hurd have checked it. Some discussions also took place on irc channel. If you are interested, check here [[1]](https://lists.debian.org/debian-hurd/2025/02/msg00011.html) [[2]](https://lists.debian.org/debian-hurd/2025/02/msg00035.html) [[3]](https://lists.debian.org/debian-hurd/2025/02/msg00016.html).

Following is the commit message. Most platform technical details are described on it.

---

abseil has failed to build on GNU/Hurd for a long time. Now let's make it work! :)

Note that `__GNU__` is the macro for detecting GNU/Hurd. And `__MACH__` is also defined there besides on Apple platform. They are both "mach" but with different implementation and platform details. Here are the works,

* Mark platform features (not) supported by GNU/Hurd.

  * Supports `mmap` and `write`.

  * Not supports `vdso`. It's specific to Linux.

  * Not supports `ELF_SYMBOLIZE` for now. GNU/Hurd uses ELF as the binary format. But symbolizing in abseil relies on reading object file path from `/proc/self/task/<pid>/maps` (Linux specific) or `/proc/self/maps`. GNU/Hurd does have the latter. However, due to its micro-kernel design, it's currently unable to get the file path info there.

  * Disable stack consumption measurement. The problem behind it is that GNU/Hurd uses a very different way to implement signal handling. Due to compiler behavior, it is impossible to get a stable, valid and reliable statictic data. In my test environment, it's 96 bytes (< 100) for current codes.

* GNU/Hurd uses different errno and messages than Linux. So related things are adjusted accordingly.

* Fix a misuse of `__MACH__`, which should actually be `__APPLE__`.

* Fix a missing including of `signal.h` for using `SIGABRT`. Otherwise compilation will fail with undefined symbol error on GNU/Hurd.
