### PR TITLE
Bump deployment_target version and add visionos to podspec

### DIFF
--- a/absl/abseil.podspec.gen.py
+++ b/absl/abseil.podspec.gen.py
@@ -43,10 +43,11 @@ Pod::Spec.new do |s|
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
   }
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
-  s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '4.0'
+  s.visionos.deployment_target = '1.0'
   s.subspec 'xcprivacy' do |ss|
     ss.resource_bundles = {
       ss.module_name => 'PrivacyInfo.xcprivacy',


### PR DESCRIPTION
Add visionos support.

Bump deployment_target versions to supported version, e.g. 
'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 18.2.99.

This also fixes podspec validation error:
xcodebuild:  abseil/absl/base/internal/thread_identity.h:238:24: error: thread-local storage is not supported for the current target


CC: @sampajano 
