### PR TITLE
Fix build on big endian

### DIFF
--- a/absl/hash/internal/low_level_hash_test.cc
+++ b/absl/hash/internal/low_level_hash_test.cc
@@ -362,7 +362,7 @@ TEST(LowLevelHashTest, VerifyGolden) {
   };
 
 #if defined(ABSL_IS_BIG_ENDIAN)
-  constexpr uint64_t kGolden[kNumGoldenOutputs];
+  constexpr uint64_t kGolden[kNumGoldenOutputs] = {0};
   GTEST_SKIP() << "We only maintain golden data for little endian systems.";
 #else
   constexpr uint64_t kGolden[kNumGoldenOutputs] = {


### PR DESCRIPTION
Currently getting the following compilation error:
```
 error: uninitialized 'const kGolden' [-fpermissive]
```