### PR TITLE
Abseil LTS Branch, Jan 2025, Patch 1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "20250127.0",
+    version = "20250127.1",
     compatibility_level = 1,
 )
 

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -118,7 +118,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20250127
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/debugging/internal/demangle.cc
+++ b/absl/debugging/internal/demangle.cc
@@ -2816,7 +2816,8 @@ static bool ParseLocalNameSuffix(State *state) {
     // On late parse failure, roll back not only the input but also the output,
     // whose trailing NUL was overwritten.
     state->parse_state = copy;
-    if (state->parse_state.append) {
+    if (state->parse_state.append &&
+        state->parse_state.out_cur_idx < state->out_end_idx) {
       state->out[state->parse_state.out_cur_idx] = '\0';
     }
     return false;
@@ -2829,7 +2830,8 @@ static bool ParseLocalNameSuffix(State *state) {
     return true;
   }
   state->parse_state = copy;
-  if (state->parse_state.append) {
+  if (state->parse_state.append &&
+      state->parse_state.out_cur_idx < state->out_end_idx) {
     state->out[state->parse_state.out_cur_idx] = '\0';
   }
 

--- a/absl/debugging/internal/demangle_test.cc
+++ b/absl/debugging/internal/demangle_test.cc
@@ -2017,6 +2017,13 @@ TEST(DemangleRegression, DeeplyNestedArrayType) {
   TestOnInput(data.c_str());
 }
 
+TEST(DemangleRegression, ShortOutputBuffer) {
+  // This should not crash.
+  char buffer[1];
+  EXPECT_FALSE(
+      absl::debugging_internal::Demangle("_ZZ2wwE", buffer, sizeof(buffer)));
+}
+
 struct Base {
   virtual ~Base() = default;
 };

--- a/absl/debugging/internal/stacktrace_aarch64-inl.inc
+++ b/absl/debugging/internal/stacktrace_aarch64-inl.inc
@@ -188,7 +188,9 @@ inline void* ClearPacBits(void* ptr) {
   // compatibility with ARM platforms that do not support pointer
   // authentication, we use the hint space instruction XPACLRI instead. Hint
   // space instructions behave as NOPs on unsupported platforms.
-  asm("xpaclri" : "+r"(x30));
+#define ABSL_XPACLRI_HINT "hint #0x7;"
+  asm(ABSL_XPACLRI_HINT : "+r"(x30));  // asm("xpaclri" : "+r"(x30));
+#undef ABSL_XPACLRI_HINT
   return x30;
 }
 


### PR DESCRIPTION
---

Fix buffer overflow the internal demangling function The overflow can happen during rollback after a parsing failure, where the null terminator is written without verifying the buffer bounds.

Credit to www.code-intelligence.com for reporting this issue

PiperOrigin-RevId: 732995553
Change-Id: Ic5075f53e510d270e1784d593defcd53f9121d02

---

Actually use the hint space instruction to strip PAC bits for return addresses in stack traces as the comment says

https://android.googlesource.com/platform/libcore/+/71f2c75111e87091616f0f3b86bea6c4d345dad1/src/hotspot/os_cpu/linux_aarch64/pauth_linux_aarch64.inline.hpp

PiperOrigin-RevId: 724360415
Change-Id: I691160e43354131a04919765ce283e07c3c933a9