### PR TITLE
move absl namespace to int128 inc files

### DIFF
--- a/absl/numeric/int128.h
+++ b/absl/numeric/int128.h
@@ -1190,14 +1190,14 @@ constexpr int64_t BitCastToSigned(uint64_t v) {
 
 }  // namespace int128_internal
 
+ABSL_NAMESPACE_END
+}  // namespace absl
+
 #if defined(ABSL_HAVE_INTRINSIC_INT128)
 #include "absl/numeric/int128_have_intrinsic.inc"  // IWYU pragma: export
 #else  // ABSL_HAVE_INTRINSIC_INT128
 #include "absl/numeric/int128_no_intrinsic.inc"  // IWYU pragma: export
 #endif  // ABSL_HAVE_INTRINSIC_INT128
-
-ABSL_NAMESPACE_END
-}  // namespace absl
 
 #undef ABSL_INTERNAL_WCHAR_T
 

--- a/absl/numeric/int128_have_intrinsic.inc
+++ b/absl/numeric/int128_have_intrinsic.inc
@@ -17,6 +17,9 @@
 // representation when ABSL_HAVE_INTRINSIC_INT128 is defined. This file is
 // included by int128.h and relies on ABSL_INTERNAL_WCHAR_T being defined.
 
+namespace absl {
+ABSL_NAMESPACE_BEGIN
+
 namespace int128_internal {
 
 // Casts from unsigned to signed while preserving the underlying binary
@@ -307,3 +310,6 @@ constexpr int128 operator<<(int128 lhs, int amount) {
 constexpr int128 operator>>(int128 lhs, int amount) {
   return static_cast<__int128>(lhs) >> amount;
 }
+
+ABSL_NAMESPACE_END
+}  // namespace absl

--- a/absl/numeric/int128_no_intrinsic.inc
+++ b/absl/numeric/int128_no_intrinsic.inc
@@ -17,6 +17,9 @@
 // representation when ABSL_HAVE_INTRINSIC_INT128 is *not* defined. This file
 // is included by int128.h and relies on ABSL_INTERNAL_WCHAR_T being defined.
 
+namespace absl {
+ABSL_NAMESPACE_BEGIN
+
 constexpr uint64_t Int128Low64(int128 v) { return v.lo_; }
 
 constexpr int64_t Int128High64(int128 v) { return v.hi_; }
@@ -347,3 +350,6 @@ constexpr int128 operator>>(int128 lhs, int amount) {
         static_cast<uint64_t>(Int128High64(lhs) >> (amount - 64)));
   }
 }
+
+ABSL_NAMESPACE_END
+}  // namespace absl


### PR DESCRIPTION
This fixes the modules-import-nested-redundant error in grpc swift [build](https://btx.cloud.google.com/invocations/38be1a1a-01c2-44b4-8792-c11913adaeab/targets/github%2Fgrpc%2Frun_tests%2Fobjc_macos_opt_native%2Fios-buildtest-example-switft-package;config=default/tests)
```
[/absl/numeric/int128.h:1182](https://cs.corp.google.com/piper///depot/google3/Users/kbuilder/Library/Developer/Xcode/DerivedData/workspace_objc_macos_opt_native-auypnimqokfdevhekumkyzytzaba/SourcePackages/checkouts/abseil-cpp-SwiftPM/absl/numeric/int128.h?l=1182&ws&snapshot=0):1: error: redundant #include of module 'abseil' appears within namespace 'absl::lts_20240722' [-Wmodules-import-nested-redundant]
#include "absl/numeric/int128_have_intrinsic.inc"  // IWYU pragma: export
^
/[Users/kbuilder/Library/Developer/Xcode/DerivedData/workspace_objc_macos_opt_native-auypnimqokfdevhekumkyzytzaba/SourcePackages/checkouts/abseil-cpp-SwiftPM/absl/numeric/int128.h:557](https://cs.corp.google.com/piper///depot/google3/Users/kbuilder/Library/Developer/Xcode/DerivedData/workspace_objc_macos_opt_native-auypnimqokfdevhekumkyzytzaba/SourcePackages/checkouts/abseil-cpp-SwiftPM/absl/numeric/int128.h?l=557&ws&snapshot=0):1: note: namespace 'absl::lts_20240722' begins here
ABSL_NAMESPACE_BEGIN
^
```

CC: @sampajano 