### PR TITLE
[minor] Avoid variable shadowing for absl btree

### DIFF
--- a/absl/container/internal/btree.h
+++ b/absl/container/internal/btree.h
@@ -225,7 +225,7 @@ struct key_compare_adapter {
 
    public:
     using Base::Base;
-    checked_compare(Compare comp) : Base(std::move(comp)) {}  // NOLINT
+    checked_compare(Compare cmp) : Base(std::move(cmp)) {}  // NOLINT
 
     // Allow converting to Compare for use in key_comp()/value_comp().
     explicit operator Compare() const { return comp(); }


### PR DESCRIPTION
When I compile ray codebase with `-Wshadow` option, certain abseil compilation error pops out.
```sh

[2025-03-26T18:02:54Z] external/com_google_absl/absl/container/internal/btree.h:226:29: error: declaration of 'comp' shadows a member of 'absl::lts_20230802::container_internal::key_compare_adapter<Compare, Key>::checked_compare' [-Werror=shadow]
--
  | [2025-03-26T18:02:54Z]   226 \|     checked_compare(Compare comp) : Base(std::move(comp)) {}  // NOLINT
  | [2025-03-26T18:02:54Z]       \|                     ~~~~~~~~^~~~
  | [2025-03-26T18:02:54Z] external/com_google_absl/absl/container/internal/btree.h:208:17: note: shadowed declaration is here
  | [2025-03-26T18:02:54Z]   208 \|     using Base::comp;
  | [2025-03-26T18:02:54Z]       \|                 ^~~~
```
This PR fixes the warning by simple renaming the variable.