### PR TITLE
Remove global static in stacktrace_win32-inl.inc

### DIFF
--- a/absl/debugging/internal/stacktrace_win32-inl.inc
+++ b/absl/debugging/internal/stacktrace_win32-inl.inc
@@ -37,39 +37,19 @@
 #ifndef ABSL_DEBUGGING_INTERNAL_STACKTRACE_WIN32_INL_H_
 #define ABSL_DEBUGGING_INTERNAL_STACKTRACE_WIN32_INL_H_
 
-#include <windows.h>    // for GetProcAddress and GetModuleHandle
+#include <windows.h> // CaptureStackBackTrace
 #include <cassert>
-
-typedef USHORT NTAPI RtlCaptureStackBackTrace_Function(
-    IN ULONG frames_to_skip,
-    IN ULONG frames_to_capture,
-    OUT PVOID *backtrace,
-    OUT PULONG backtrace_hash);
-
-// It is not possible to load RtlCaptureStackBackTrace at static init time in
-// UWP. CaptureStackBackTrace is the public version of RtlCaptureStackBackTrace
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-    !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-static RtlCaptureStackBackTrace_Function* const RtlCaptureStackBackTrace_fn =
-    &::CaptureStackBackTrace;
-#else
-// Load the function we need at static init time, where we don't have
-// to worry about someone else holding the loader's lock.
-static RtlCaptureStackBackTrace_Function* const RtlCaptureStackBackTrace_fn =
-    (RtlCaptureStackBackTrace_Function*)GetProcAddress(
-        GetModuleHandleA("ntdll.dll"), "RtlCaptureStackBackTrace");
-#endif  // WINAPI_PARTITION_APP && !WINAPI_PARTITION_DESKTOP
 
 template <bool IS_STACK_FRAMES, bool IS_WITH_CONTEXT>
 static int UnwindImpl(void** result, uintptr_t* frames, int* sizes,
                       int max_depth, int skip_count, const void*,
                       int* min_dropped_frames) {
   USHORT n = 0;
-  if (!RtlCaptureStackBackTrace_fn || skip_count < 0 || max_depth < 0) {
+  if (skip_count < 0 || max_depth < 0) {
     // can't get a stacktrace with no function/invalid args
   } else {
-    n = RtlCaptureStackBackTrace_fn(static_cast<ULONG>(skip_count) + 2,
-                                    static_cast<ULONG>(max_depth), result, 0);
+    n = CaptureStackBackTrace(static_cast<ULONG>(skip_count) + 2,
+                              static_cast<ULONG>(max_depth), result, 0);
   }
   if (IS_STACK_FRAMES) {
     // No implementation for finding out the stack frames yet.


### PR DESCRIPTION
Removes the global static RtlCaptureStackBackTrace_Function and the GetModuleHandle/GetProcAddress calls so they do not impact module load at startup.


