### PR TITLE
Retry SymInitialize on STATUS_INFO_LENGTH_MISMATCH

### DIFF
--- a/absl/debugging/symbolize_win32.inc
+++ b/absl/debugging/symbolize_win32.inc
@@ -53,7 +53,9 @@ void InitializeSymbolizer(const char*) {
     }
 
     // SymInitialize can fail sometimes with STATUS_INFO_LENGTH_MISMATCH
-    // (0xC0000004). In this case, we should try calling SymInitialize again.
+    // (0xC0000004), which can happen when a module load occurs during the
+    // SymInitialize call. In this case, we should try calling SymInitialize
+    // again.
     syminitialize_error = GetLastError();
     if (syminitialize_error != 0xC0000004) {
       break; 

--- a/absl/debugging/symbolize_win32.inc
+++ b/absl/debugging/symbolize_win32.inc
@@ -46,8 +46,8 @@ void InitializeSymbolizer(const char*) {
   // the symbol handler.
   SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME);
   DWORD syminitialize_error;
-  int syminitialize_remaining_retries = 5;
-  while (syminitialize_remaining_retries > 0) {
+  constexpr int kSymInitializeRetries = 5;
+  for(int i = 0; i < kSymInitializeRetries; i++) {
     if (SymInitialize(process, nullptr, true)) {
       return;
     }
@@ -55,10 +55,9 @@ void InitializeSymbolizer(const char*) {
     // SymInitialize can fail sometimes with STATUS_INFO_LENGTH_MISMATCH
     // (0xC0000004). In this case, we should try calling SymInitialize again.
     syminitialize_error = GetLastError();
-    if (syminitialize_error != 3221225476) {
+    if (syminitialize_error != 0xC0000004) {
       break; 
     }
-    syminitialize_remaining_retries--;
   }
 
   // GetLastError() returns a Win32 DWORD, but we assign to

--- a/absl/debugging/symbolize_win32.inc
+++ b/absl/debugging/symbolize_win32.inc
@@ -15,7 +15,9 @@
 // See "Retrieving Symbol Information by Address":
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680578(v=vs.85).aspx
 
+#include <ntstatus.h>
 #include <windows.h>
+#include <winternl.h>
 
 // MSVC header dbghelp.h has a warning for an ignored typedef.
 #pragma warning(push)
@@ -52,12 +54,13 @@ void InitializeSymbolizer(const char*) {
       return;
     }
 
-    // SymInitialize can fail sometimes with STATUS_INFO_LENGTH_MISMATCH
-    // (0xC0000004), which can happen when a module load occurs during the
-    // SymInitialize call. In this case, we should try calling SymInitialize
+    // SymInitialize can fail sometimes with a STATUS_INFO_LENGTH_MISMATCH
+    // NTSTATUS (0xC0000004), which can happen when a module load occurs during
+    // the SymInitialize call. In this case, we should try calling SymInitialize
     // again.
     syminitialize_error = GetLastError();
-    if (syminitialize_error != 0xC0000004) {
+    // Both NTSTATUS and DWORD are 32-bit numbers, which makes the cast safe.
+    if (syminitialize_error != static_cast<DWORD>(STATUS_INFO_LENGTH_MISMATCH)) {
       break; 
     }
   }

--- a/absl/debugging/symbolize_win32.inc
+++ b/absl/debugging/symbolize_win32.inc
@@ -45,13 +45,27 @@ void InitializeSymbolizer(const char*) {
   // symbols be loaded. This is the fastest, most efficient way to use
   // the symbol handler.
   SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME);
-  if (!SymInitialize(process, nullptr, true)) {
-    // GetLastError() returns a Win32 DWORD, but we assign to
-    // unsigned long long to simplify the ABSL_RAW_LOG case below.  The uniform
-    // initialization guarantees this is not a narrowing conversion.
-    const unsigned long long error{GetLastError()};  // NOLINT(runtime/int)
-    ABSL_RAW_LOG(FATAL, "SymInitialize() failed: %llu", error);
+  DWORD syminitialize_error;
+  int syminitialize_remaining_retries = 5;
+  while (syminitialize_remaining_retries > 0) {
+    if (SymInitialize(process, nullptr, true)) {
+      return;
+    }
+
+    // SymInitialize can fail sometimes with STATUS_INFO_LENGTH_MISMATCH
+    // (0xC0000004). In this case, we should try calling SymInitialize again.
+    syminitialize_error = GetLastError();
+    if (syminitialize_error != 3221225476) {
+      break; 
+    }
+    syminitialize_remaining_retries--;
   }
+
+  // GetLastError() returns a Win32 DWORD, but we assign to
+  // unsigned long long to simplify the ABSL_RAW_LOG case below.  The uniform
+  // initialization guarantees this is not a narrowing conversion.
+  const unsigned long long error{syminitialize_error};
+  ABSL_RAW_LOG(FATAL, "SymInitialize() failed: %llu", error);
 }
 
 bool Symbolize(const void* pc, char* out, int out_size) {


### PR DESCRIPTION
This PR addresses #1871

Sometimes `SymInitialize` might fail with a STATUS_INFO_LENGTH_MISMATCH. In this case, we should retry calling it a couple of times before raising a fatal error.