### PR TITLE
Fix typos in comments

### DIFF
--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -339,7 +339,7 @@
 #ifndef ABSL_ATTRIBUTE_SECTION_VARIABLE
 #ifdef _AIX
 // __attribute__((section(#name))) on AIX is achieved by using the `.csect`
-// psudo op which includes an additional integer as part of its syntax indcating
+// pseudo op which includes an additional integer as part of its syntax indicating
 // alignment. If data fall under different alignments then you might get a
 // compilation error indicating a `Section type conflict`.
 #define ABSL_ATTRIBUTE_SECTION_VARIABLE(name)

--- a/absl/base/internal/sysinfo_test.cc
+++ b/absl/base/internal/sysinfo_test.cc
@@ -41,7 +41,7 @@ TEST(SysinfoTest, GetTID) {
   EXPECT_EQ(GetTID(), GetTID());  // Basic compile and equality test.
 #ifdef __native_client__
   // Native Client has a race condition bug that leads to memory
-  // exaustion when repeatedly creating and joining threads.
+  // exhaustion when repeatedly creating and joining threads.
   // https://bugs.chromium.org/p/nativeclient/issues/detail?id=1027
   return;
 #endif

--- a/absl/container/internal/raw_hash_set.cc
+++ b/absl/container/internal/raw_hash_set.cc
@@ -466,7 +466,7 @@ ABSL_ATTRIBUTE_ALWAYS_INLINE inline void InitializeSingleElementControlBytes(
 
 // Initializes control bytes for growing after SOO to the next capacity.
 // `soo_ctrl` is placed in the position `SooSlotIndex()`.
-// `new_hash` is placed in the postion `new_offset`.
+// `new_hash` is placed in the position `new_offset`.
 // The table must be non-empty SOO.
 ABSL_ATTRIBUTE_ALWAYS_INLINE inline void
 InitializeThreeElementsControlBytesAfterSoo(ctrl_t soo_ctrl, size_t new_hash,

--- a/absl/hash/hash_instantiated_test.cc
+++ b/absl/hash/hash_instantiated_test.cc
@@ -51,7 +51,7 @@ using ::absl::hash_test_internal::TypeErasedContainer;
 
 // Dummy type with unordered equality and hashing semantics.  This preserves
 // input order internally, and is used below to ensure we get test coverage
-// for equal sequences with different iteraton orders.
+// for equal sequences with different iteration orders.
 template <typename T>
 class UnorderedSequence {
  public:

--- a/absl/random/gaussian_distribution.h
+++ b/absl/random/gaussian_distribution.h
@@ -244,7 +244,7 @@ inline double gaussian_distribution_base::zignor(
         bits);  // U(-1, 1)
     const double x = j * zg_.x[i];
 
-    // Retangular box. Handles >97% of all cases.
+    // Rectangular box. Handles >97% of all cases.
     // For any given box, this handles between 75% and 99% of values.
     // Equivalent to U(01) < (x[i+1] / x[i]), and when i == 0, ~93.5%
     if (std::abs(x) < zg_.x[i + 1]) {

--- a/absl/status/statusor_test.cc
+++ b/absl/status/statusor_test.cc
@@ -459,7 +459,7 @@ TEST(StatusOr, TestAssignmentStatusOk) {
     EXPECT_EQ(p, *source);
   }
 
-  // Move asssignment
+  // Move assignment
   {
     const auto p = std::make_shared<int>(17);
     absl::StatusOr<std::shared_ptr<int>> source(p);

--- a/absl/strings/internal/charconv_bigint_test.cc
+++ b/absl/strings/internal/charconv_bigint_test.cc
@@ -176,7 +176,7 @@ TEST(BigUnsigned, MultiplyByBigUnsigned) {
 
 TEST(BigUnsigned, MultiplyByOverflow) {
   {
-    // Check that multiplcation overflow predictably truncates.
+    // Check that multiplication overflow predictably truncates.
 
     // A big int with all bits on.
     BigUnsigned<4> all_bits_on("340282366920938463463374607431768211455");

--- a/absl/strings/str_format.h
+++ b/absl/strings/str_format.h
@@ -609,7 +609,7 @@ using FormatArg = str_format_internal::FormatArgImpl;
 //
 // Note that unlike with AbslFormatConvert(), AbslStringify() does not allow
 // customization of allowed conversion characters. AbslStringify() uses `%v` as
-// the underlying conversion specififer. Additionally, AbslStringify() supports
+// the underlying conversion specifier. Additionally, AbslStringify() supports
 // use with absl::StrCat while AbslFormatConvert() does not.
 //
 // Example:

--- a/absl/time/internal/cctz/include/cctz/time_zone.h
+++ b/absl/time/internal/cctz/include/cctz/time_zone.h
@@ -200,7 +200,7 @@ class time_zone {
   // version() and description() provide additional information about the
   // time zone. The content of each of the returned strings is unspecified,
   // however, when the IANA Time Zone Database is the underlying data source
-  // the version() string will be in the familar form (e.g, "2018e") or
+  // the version() string will be in the familiar form (e.g, "2018e") or
   // empty when unavailable.
   //
   // Note: These functions are for informational or testing purposes only.


### PR DESCRIPTION
Fix typos in comments found by codespell command.