### PR TITLE
Use constexpr in container algorithm

### DIFF
--- a/absl/algorithm/container.h
+++ b/absl/algorithm/container.h
@@ -522,7 +522,8 @@ ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
 // Container-based version of the <algorithm> `std::copy()` function to copy a
 // container's elements into an iterator.
 template <typename InputSequence, typename OutputIterator>
-OutputIterator c_copy(const InputSequence& input, OutputIterator output) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_copy(const InputSequence& input, OutputIterator output) {
   return std::copy(container_algorithm_internal::c_begin(input),
                    container_algorithm_internal::c_end(input), output);
 }
@@ -532,7 +533,8 @@ OutputIterator c_copy(const InputSequence& input, OutputIterator output) {
 // Container-based version of the <algorithm> `std::copy_n()` function to copy a
 // container's first N elements into an iterator.
 template <typename C, typename Size, typename OutputIterator>
-OutputIterator c_copy_n(const C& input, Size n, OutputIterator output) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_copy_n(const C& input, Size n, OutputIterator output) {
   return std::copy_n(container_algorithm_internal::c_begin(input), n, output);
 }
 
@@ -541,8 +543,8 @@ OutputIterator c_copy_n(const C& input, Size n, OutputIterator output) {
 // Container-based version of the <algorithm> `std::copy_if()` function to copy
 // a container's elements satisfying some condition into an iterator.
 template <typename InputSequence, typename OutputIterator, typename Pred>
-OutputIterator c_copy_if(const InputSequence& input, OutputIterator output,
-                         Pred&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_copy_if(const InputSequence& input, OutputIterator output, Pred&& pred) {
   return std::copy_if(container_algorithm_internal::c_begin(input),
                       container_algorithm_internal::c_end(input), output,
                       std::forward<Pred>(pred));
@@ -553,8 +555,8 @@ OutputIterator c_copy_if(const InputSequence& input, OutputIterator output,
 // Container-based version of the <algorithm> `std::copy_backward()` function to
 // copy a container's elements in reverse order into an iterator.
 template <typename C, typename BidirectionalIterator>
-BidirectionalIterator c_copy_backward(const C& src,
-                                      BidirectionalIterator dest) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 BidirectionalIterator
+c_copy_backward(const C& src, BidirectionalIterator dest) {
   return std::copy_backward(container_algorithm_internal::c_begin(src),
                             container_algorithm_internal::c_end(src), dest);
 }
@@ -605,8 +607,8 @@ container_algorithm_internal::ContainerIter<C2> c_swap_ranges(C1& c1, C2& c2) {
 // result in an iterator pointing to the last transformed element in the output
 // range.
 template <typename InputSequence, typename OutputIterator, typename UnaryOp>
-OutputIterator c_transform(const InputSequence& input, OutputIterator output,
-                           UnaryOp&& unary_op) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_transform(
+    const InputSequence& input, OutputIterator output, UnaryOp&& unary_op) {
   return std::transform(container_algorithm_internal::c_begin(input),
                         container_algorithm_internal::c_end(input), output,
                         std::forward<UnaryOp>(unary_op));
@@ -638,7 +640,9 @@ OutputIterator c_transform(const InputSequence1& input1,
 // replace a container's elements of some value with a new value. The container
 // is modified in place.
 template <typename Sequence, typename T>
-void c_replace(Sequence& sequence, const T& old_value, const T& new_value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_replace(Sequence& sequence,
+                                                   const T& old_value,
+                                                   const T& new_value) {
   std::replace(container_algorithm_internal::c_begin(sequence),
                container_algorithm_internal::c_end(sequence), old_value,
                new_value);
@@ -650,7 +654,8 @@ void c_replace(Sequence& sequence, const T& old_value, const T& new_value) {
 // replace a container's elements of some value with a new value based on some
 // condition. The container is modified in place.
 template <typename C, typename Pred, typename T>
-void c_replace_if(C& c, Pred&& pred, T&& new_value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_replace_if(C& c, Pred&& pred,
+                                                      T&& new_value) {
   std::replace_if(container_algorithm_internal::c_begin(c),
                   container_algorithm_internal::c_end(c),
                   std::forward<Pred>(pred), std::forward<T>(new_value));
@@ -662,8 +667,8 @@ void c_replace_if(C& c, Pred&& pred, T&& new_value) {
 // replace a container's elements of some value with a new value  and return the
 // results within an iterator.
 template <typename C, typename OutputIterator, typename T>
-OutputIterator c_replace_copy(const C& c, OutputIterator result, T&& old_value,
-                              T&& new_value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_replace_copy(
+    const C& c, OutputIterator result, T&& old_value, T&& new_value) {
   return std::replace_copy(container_algorithm_internal::c_begin(c),
                            container_algorithm_internal::c_end(c), result,
                            std::forward<T>(old_value),
@@ -676,8 +681,8 @@ OutputIterator c_replace_copy(const C& c, OutputIterator result, T&& old_value,
 // to replace a container's elements of some value with a new value based on
 // some condition, and return the results within an iterator.
 template <typename C, typename OutputIterator, typename Pred, typename T>
-OutputIterator c_replace_copy_if(const C& c, OutputIterator result, Pred&& pred,
-                                 const T& new_value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_replace_copy_if(
+    const C& c, OutputIterator result, Pred&& pred, const T& new_value) {
   return std::replace_copy_if(container_algorithm_internal::c_begin(c),
                               container_algorithm_internal::c_end(c), result,
                               std::forward<Pred>(pred), new_value);
@@ -688,7 +693,7 @@ OutputIterator c_replace_copy_if(const C& c, OutputIterator result, Pred&& pred,
 // Container-based version of the <algorithm> `std::fill()` function to fill a
 // container with some value.
 template <typename C, typename T>
-void c_fill(C& c, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_fill(C& c, const T& value) {
   std::fill(container_algorithm_internal::c_begin(c),
             container_algorithm_internal::c_end(c), value);
 }
@@ -698,7 +703,8 @@ void c_fill(C& c, const T& value) {
 // Container-based version of the <algorithm> `std::fill_n()` function to fill
 // the first N elements in a container with some value.
 template <typename C, typename Size, typename T>
-void c_fill_n(C& c, Size n, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_fill_n(C& c, Size n,
+                                                  const T& value) {
   std::fill_n(container_algorithm_internal::c_begin(c), n, value);
 }
 
@@ -707,7 +713,7 @@ void c_fill_n(C& c, Size n, const T& value) {
 // Container-based version of the <algorithm> `std::generate()` function to
 // assign a container's elements to the values provided by the given generator.
 template <typename C, typename Generator>
-void c_generate(C& c, Generator&& gen) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_generate(C& c, Generator&& gen) {
   std::generate(container_algorithm_internal::c_begin(c),
                 container_algorithm_internal::c_end(c),
                 std::forward<Generator>(gen));
@@ -719,8 +725,9 @@ void c_generate(C& c, Generator&& gen) {
 // assign a container's first N elements to the values provided by the given
 // generator.
 template <typename C, typename Size, typename Generator>
-container_algorithm_internal::ContainerIter<C> c_generate_n(C& c, Size n,
-                                                            Generator&& gen) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<C>
+    c_generate_n(C& c, Size n, Generator&& gen) {
   return std::generate_n(container_algorithm_internal::c_begin(c), n,
                          std::forward<Generator>(gen));
 }
@@ -736,8 +743,8 @@ container_algorithm_internal::ContainerIter<C> c_generate_n(C& c, Size n,
 // copy a container's elements while removing any elements matching the given
 // `value`.
 template <typename C, typename OutputIterator, typename T>
-OutputIterator c_remove_copy(const C& c, OutputIterator result,
-                             const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_remove_copy(const C& c, OutputIterator result, const T& value) {
   return std::remove_copy(container_algorithm_internal::c_begin(c),
                           container_algorithm_internal::c_end(c), result,
                           value);
@@ -749,8 +756,8 @@ OutputIterator c_remove_copy(const C& c, OutputIterator result,
 // to copy a container's elements while removing any elements matching the given
 // condition.
 template <typename C, typename OutputIterator, typename Pred>
-OutputIterator c_remove_copy_if(const C& c, OutputIterator result,
-                                Pred&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_remove_copy_if(const C& c, OutputIterator result, Pred&& pred) {
   return std::remove_copy_if(container_algorithm_internal::c_begin(c),
                              container_algorithm_internal::c_end(c), result,
                              std::forward<Pred>(pred));
@@ -762,7 +769,8 @@ OutputIterator c_remove_copy_if(const C& c, OutputIterator result,
 // copy a container's elements while removing any elements containing duplicate
 // values.
 template <typename C, typename OutputIterator>
-OutputIterator c_unique_copy(const C& c, OutputIterator result) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_unique_copy(const C& c, OutputIterator result) {
   return std::unique_copy(container_algorithm_internal::c_begin(c),
                           container_algorithm_internal::c_end(c), result);
 }
@@ -770,8 +778,8 @@ OutputIterator c_unique_copy(const C& c, OutputIterator result) {
 // Overload of c_unique_copy() for using a predicate evaluation other than
 // `==` for comparing uniqueness of the element values.
 template <typename C, typename OutputIterator, typename BinaryPredicate>
-OutputIterator c_unique_copy(const C& c, OutputIterator result,
-                             BinaryPredicate&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_unique_copy(const C& c, OutputIterator result, BinaryPredicate&& pred) {
   return std::unique_copy(container_algorithm_internal::c_begin(c),
                           container_algorithm_internal::c_end(c), result,
                           std::forward<BinaryPredicate>(pred));
@@ -782,7 +790,7 @@ OutputIterator c_unique_copy(const C& c, OutputIterator result,
 // Container-based version of the <algorithm> `std::reverse()` function to
 // reverse a container's elements.
 template <typename Sequence>
-void c_reverse(Sequence& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_reverse(Sequence& sequence) {
   std::reverse(container_algorithm_internal::c_begin(sequence),
                container_algorithm_internal::c_end(sequence));
 }
@@ -792,7 +800,8 @@ void c_reverse(Sequence& sequence) {
 // Container-based version of the <algorithm> `std::reverse()` function to
 // reverse a container's elements and write them to an iterator range.
 template <typename C, typename OutputIterator>
-OutputIterator c_reverse_copy(const C& sequence, OutputIterator result) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_reverse_copy(const C& sequence, OutputIterator result) {
   return std::reverse_copy(container_algorithm_internal::c_begin(sequence),
                            container_algorithm_internal::c_end(sequence),
                            result);
@@ -805,7 +814,8 @@ OutputIterator c_reverse_copy(const C& sequence, OutputIterator result) {
 // the first element in the container.
 template <typename C,
           typename Iterator = container_algorithm_internal::ContainerIter<C>>
-Iterator c_rotate(C& sequence, Iterator middle) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 Iterator c_rotate(C& sequence,
+                                                      Iterator middle) {
   return absl::rotate(container_algorithm_internal::c_begin(sequence), middle,
                       container_algorithm_internal::c_end(sequence));
 }
@@ -816,10 +826,10 @@ Iterator c_rotate(C& sequence, Iterator middle) {
 // shift a container's elements leftward such that the `middle` element becomes
 // the first element in a new iterator range.
 template <typename C, typename OutputIterator>
-OutputIterator c_rotate_copy(
-    const C& sequence,
-    container_algorithm_internal::ContainerIter<const C> middle,
-    OutputIterator result) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_rotate_copy(const C& sequence,
+              container_algorithm_internal::ContainerIter<const C> middle,
+              OutputIterator result) {
   return std::rotate_copy(container_algorithm_internal::c_begin(sequence),
                           middle, container_algorithm_internal::c_end(sequence),
                           result);
@@ -861,7 +871,8 @@ OutputIterator c_sample(const C& c, OutputIterator result, Distance n,
 // to test whether all elements in the container for which `pred` returns `true`
 // precede those for which `pred` is `false`.
 template <typename C, typename Pred>
-bool c_is_partitioned(const C& c, Pred&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_is_partitioned(const C& c,
+                                                          Pred&& pred) {
   return std::is_partitioned(container_algorithm_internal::c_begin(c),
                              container_algorithm_internal::c_end(c),
                              std::forward<Pred>(pred));
@@ -874,7 +885,9 @@ bool c_is_partitioned(const C& c, Pred&& pred) {
 // which `pred` returns `true` precede all those for which it returns `false`,
 // returning an iterator to the first element of the second group.
 template <typename C, typename Pred>
-container_algorithm_internal::ContainerIter<C> c_partition(C& c, Pred&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<C>
+    c_partition(C& c, Pred&& pred) {
   return std::partition(container_algorithm_internal::c_begin(c),
                         container_algorithm_internal::c_end(c),
                         std::forward<Pred>(pred));
@@ -903,9 +916,9 @@ container_algorithm_internal::ContainerIter<C> c_stable_partition(C& c,
 
 template <typename C, typename OutputIterator1, typename OutputIterator2,
           typename Pred>
-std::pair<OutputIterator1, OutputIterator2> c_partition_copy(
-    const C& c, OutputIterator1 out_true, OutputIterator2 out_false,
-    Pred&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 std::pair<OutputIterator1, OutputIterator2>
+c_partition_copy(const C& c, OutputIterator1 out_true,
+                 OutputIterator2 out_false, Pred&& pred) {
   return std::partition_copy(container_algorithm_internal::c_begin(c),
                              container_algorithm_internal::c_end(c), out_true,
                              out_false, std::forward<Pred>(pred));
@@ -917,8 +930,9 @@ std::pair<OutputIterator1, OutputIterator2> c_partition_copy(
 // to return the first element of an already partitioned container for which
 // the given `pred` is not `true`.
 template <typename C, typename Pred>
-container_algorithm_internal::ContainerIter<C> c_partition_point(C& c,
-                                                                 Pred&& pred) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<C>
+    c_partition_point(C& c, Pred&& pred) {
   return std::partition_point(container_algorithm_internal::c_begin(c),
                               container_algorithm_internal::c_end(c),
                               std::forward<Pred>(pred));
@@ -933,7 +947,7 @@ container_algorithm_internal::ContainerIter<C> c_partition_point(C& c,
 // Container-based version of the <algorithm> `std::sort()` function
 // to sort elements in ascending order of their values.
 template <typename C>
-void c_sort(C& c) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_sort(C& c) {
   std::sort(container_algorithm_internal::c_begin(c),
             container_algorithm_internal::c_end(c));
 }
@@ -941,7 +955,7 @@ void c_sort(C& c) {
 // Overload of c_sort() for performing a `comp` comparison other than the
 // default `operator<`.
 template <typename C, typename LessThan>
-void c_sort(C& c, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_sort(C& c, LessThan&& comp) {
   std::sort(container_algorithm_internal::c_begin(c),
             container_algorithm_internal::c_end(c),
             std::forward<LessThan>(comp));
@@ -972,7 +986,7 @@ void c_stable_sort(C& c, LessThan&& comp) {
 // Container-based version of the <algorithm> `std::is_sorted()` function
 // to evaluate whether the given container is sorted in ascending order.
 template <typename C>
-bool c_is_sorted(const C& c) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_is_sorted(const C& c) {
   return std::is_sorted(container_algorithm_internal::c_begin(c),
                         container_algorithm_internal::c_end(c));
 }
@@ -980,7 +994,8 @@ bool c_is_sorted(const C& c) {
 // c_is_sorted() overload for performing a `comp` comparison other than the
 // default `operator<`.
 template <typename C, typename LessThan>
-bool c_is_sorted(const C& c, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_is_sorted(const C& c,
+                                                     LessThan&& comp) {
   return std::is_sorted(container_algorithm_internal::c_begin(c),
                         container_algorithm_internal::c_end(c),
                         std::forward<LessThan>(comp));
@@ -992,7 +1007,7 @@ bool c_is_sorted(const C& c, LessThan&& comp) {
 // to rearrange elements within a container such that elements before `middle`
 // are sorted in ascending order.
 template <typename RandomAccessContainer>
-void c_partial_sort(
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_partial_sort(
     RandomAccessContainer& sequence,
     container_algorithm_internal::ContainerIter<RandomAccessContainer> middle) {
   std::partial_sort(container_algorithm_internal::c_begin(sequence), middle,
@@ -1002,7 +1017,7 @@ void c_partial_sort(
 // Overload of c_partial_sort() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename RandomAccessContainer, typename LessThan>
-void c_partial_sort(
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_partial_sort(
     RandomAccessContainer& sequence,
     container_algorithm_internal::ContainerIter<RandomAccessContainer> middle,
     LessThan&& comp) {
@@ -1019,8 +1034,9 @@ void c_partial_sort(
 // At most min(result.last - result.first, sequence.last - sequence.first)
 // elements from the sequence will be stored in the result.
 template <typename C, typename RandomAccessContainer>
-container_algorithm_internal::ContainerIter<RandomAccessContainer>
-c_partial_sort_copy(const C& sequence, RandomAccessContainer& result) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<RandomAccessContainer>
+    c_partial_sort_copy(const C& sequence, RandomAccessContainer& result) {
   return std::partial_sort_copy(container_algorithm_internal::c_begin(sequence),
                                 container_algorithm_internal::c_end(sequence),
                                 container_algorithm_internal::c_begin(result),
@@ -1030,9 +1046,10 @@ c_partial_sort_copy(const C& sequence, RandomAccessContainer& result) {
 // Overload of c_partial_sort_copy() for performing a `comp` comparison other
 // than the default `operator<`.
 template <typename C, typename RandomAccessContainer, typename LessThan>
-container_algorithm_internal::ContainerIter<RandomAccessContainer>
-c_partial_sort_copy(const C& sequence, RandomAccessContainer& result,
-                    LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<RandomAccessContainer>
+    c_partial_sort_copy(const C& sequence, RandomAccessContainer& result,
+                        LessThan&& comp) {
   return std::partial_sort_copy(container_algorithm_internal::c_begin(sequence),
                                 container_algorithm_internal::c_end(sequence),
                                 container_algorithm_internal::c_begin(result),
@@ -1046,7 +1063,9 @@ c_partial_sort_copy(const C& sequence, RandomAccessContainer& result,
 // to return the first element within a container that is not sorted in
 // ascending order as an iterator.
 template <typename C>
-container_algorithm_internal::ContainerIter<C> c_is_sorted_until(C& c) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<C>
+    c_is_sorted_until(C& c) {
   return std::is_sorted_until(container_algorithm_internal::c_begin(c),
                               container_algorithm_internal::c_end(c));
 }
@@ -1054,8 +1073,9 @@ container_algorithm_internal::ContainerIter<C> c_is_sorted_until(C& c) {
 // Overload of c_is_sorted_until() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename C, typename LessThan>
-container_algorithm_internal::ContainerIter<C> c_is_sorted_until(
-    C& c, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<C>
+    c_is_sorted_until(C& c, LessThan&& comp) {
   return std::is_sorted_until(container_algorithm_internal::c_begin(c),
                               container_algorithm_internal::c_end(c),
                               std::forward<LessThan>(comp));
@@ -1069,7 +1089,7 @@ container_algorithm_internal::ContainerIter<C> c_is_sorted_until(
 // any order, except that all preceding `nth` will be less than that element,
 // and all following `nth` will be greater than that element.
 template <typename RandomAccessContainer>
-void c_nth_element(
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_nth_element(
     RandomAccessContainer& sequence,
     container_algorithm_internal::ContainerIter<RandomAccessContainer> nth) {
   std::nth_element(container_algorithm_internal::c_begin(sequence), nth,
@@ -1079,7 +1099,7 @@ void c_nth_element(
 // Overload of c_nth_element() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename RandomAccessContainer, typename LessThan>
-void c_nth_element(
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_nth_element(
     RandomAccessContainer& sequence,
     container_algorithm_internal::ContainerIter<RandomAccessContainer> nth,
     LessThan&& comp) {
@@ -1098,8 +1118,9 @@ void c_nth_element(
 // to return an iterator pointing to the first element in a sorted container
 // which does not compare less than `value`.
 template <typename Sequence, typename T>
-container_algorithm_internal::ContainerIter<Sequence> c_lower_bound(
-    Sequence& sequence, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<Sequence>
+    c_lower_bound(Sequence& sequence, const T& value) {
   return std::lower_bound(container_algorithm_internal::c_begin(sequence),
                           container_algorithm_internal::c_end(sequence), value);
 }
@@ -1107,8 +1128,9 @@ container_algorithm_internal::ContainerIter<Sequence> c_lower_bound(
 // Overload of c_lower_bound() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename Sequence, typename T, typename LessThan>
-container_algorithm_internal::ContainerIter<Sequence> c_lower_bound(
-    Sequence& sequence, const T& value, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<Sequence>
+    c_lower_bound(Sequence& sequence, const T& value, LessThan&& comp) {
   return std::lower_bound(container_algorithm_internal::c_begin(sequence),
                           container_algorithm_internal::c_end(sequence), value,
                           std::forward<LessThan>(comp));
@@ -1120,8 +1142,9 @@ container_algorithm_internal::ContainerIter<Sequence> c_lower_bound(
 // to return an iterator pointing to the first element in a sorted container
 // which is greater than `value`.
 template <typename Sequence, typename T>
-container_algorithm_internal::ContainerIter<Sequence> c_upper_bound(
-    Sequence& sequence, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<Sequence>
+    c_upper_bound(Sequence& sequence, const T& value) {
   return std::upper_bound(container_algorithm_internal::c_begin(sequence),
                           container_algorithm_internal::c_end(sequence), value);
 }
@@ -1129,8 +1152,9 @@ container_algorithm_internal::ContainerIter<Sequence> c_upper_bound(
 // Overload of c_upper_bound() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename Sequence, typename T, typename LessThan>
-container_algorithm_internal::ContainerIter<Sequence> c_upper_bound(
-    Sequence& sequence, const T& value, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<Sequence>
+    c_upper_bound(Sequence& sequence, const T& value, LessThan&& comp) {
   return std::upper_bound(container_algorithm_internal::c_begin(sequence),
                           container_algorithm_internal::c_end(sequence), value,
                           std::forward<LessThan>(comp));
@@ -1142,8 +1166,9 @@ container_algorithm_internal::ContainerIter<Sequence> c_upper_bound(
 // to return an iterator pair pointing to the first and last elements in a
 // sorted container which compare equal to `value`.
 template <typename Sequence, typename T>
-container_algorithm_internal::ContainerIterPairType<Sequence, Sequence>
-c_equal_range(Sequence& sequence, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIterPairType<Sequence, Sequence>
+    c_equal_range(Sequence& sequence, const T& value) {
   return std::equal_range(container_algorithm_internal::c_begin(sequence),
                           container_algorithm_internal::c_end(sequence), value);
 }
@@ -1151,8 +1176,9 @@ c_equal_range(Sequence& sequence, const T& value) {
 // Overload of c_equal_range() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename Sequence, typename T, typename LessThan>
-container_algorithm_internal::ContainerIterPairType<Sequence, Sequence>
-c_equal_range(Sequence& sequence, const T& value, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIterPairType<Sequence, Sequence>
+    c_equal_range(Sequence& sequence, const T& value, LessThan&& comp) {
   return std::equal_range(container_algorithm_internal::c_begin(sequence),
                           container_algorithm_internal::c_end(sequence), value,
                           std::forward<LessThan>(comp));
@@ -1164,7 +1190,8 @@ c_equal_range(Sequence& sequence, const T& value, LessThan&& comp) {
 // to test if any element in the sorted container contains a value equivalent to
 // 'value'.
 template <typename Sequence, typename T>
-bool c_binary_search(const Sequence& sequence, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_binary_search(
+    const Sequence& sequence, const T& value) {
   return std::binary_search(container_algorithm_internal::c_begin(sequence),
                             container_algorithm_internal::c_end(sequence),
                             value);
@@ -1173,8 +1200,8 @@ bool c_binary_search(const Sequence& sequence, const T& value) {
 // Overload of c_binary_search() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename Sequence, typename T, typename LessThan>
-bool c_binary_search(const Sequence& sequence, const T& value,
-                     LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_binary_search(
+    const Sequence& sequence, const T& value, LessThan&& comp) {
   return std::binary_search(container_algorithm_internal::c_begin(sequence),
                             container_algorithm_internal::c_end(sequence),
                             value, std::forward<LessThan>(comp));
@@ -1189,7 +1216,8 @@ bool c_binary_search(const Sequence& sequence, const T& value,
 // Container-based version of the <algorithm> `std::merge()` function
 // to merge two sorted containers into a single sorted iterator.
 template <typename C1, typename C2, typename OutputIterator>
-OutputIterator c_merge(const C1& c1, const C2& c2, OutputIterator result) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_merge(const C1& c1, const C2& c2, OutputIterator result) {
   return std::merge(container_algorithm_internal::c_begin(c1),
                     container_algorithm_internal::c_end(c1),
                     container_algorithm_internal::c_begin(c2),
@@ -1199,8 +1227,8 @@ OutputIterator c_merge(const C1& c1, const C2& c2, OutputIterator result) {
 // Overload of c_merge() for performing a `comp` comparison other than
 // the default `operator<`.
 template <typename C1, typename C2, typename OutputIterator, typename LessThan>
-OutputIterator c_merge(const C1& c1, const C2& c2, OutputIterator result,
-                       LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_merge(const C1& c1, const C2& c2, OutputIterator result, LessThan&& comp) {
   return std::merge(container_algorithm_internal::c_begin(c1),
                     container_algorithm_internal::c_end(c1),
                     container_algorithm_internal::c_begin(c2),
@@ -1236,7 +1264,8 @@ void c_inplace_merge(C& c,
 // to test whether a sorted container `c1` entirely contains another sorted
 // container `c2`.
 template <typename C1, typename C2>
-bool c_includes(const C1& c1, const C2& c2) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_includes(const C1& c1,
+                                                    const C2& c2) {
   return std::includes(container_algorithm_internal::c_begin(c1),
                        container_algorithm_internal::c_end(c1),
                        container_algorithm_internal::c_begin(c2),
@@ -1246,7 +1275,8 @@ bool c_includes(const C1& c1, const C2& c2) {
 // Overload of c_includes() for performing a merge using a `comp` other than
 // `operator<`.
 template <typename C1, typename C2, typename LessThan>
-bool c_includes(const C1& c1, const C2& c2, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_includes(const C1& c1, const C2& c2,
+                                                    LessThan&& comp) {
   return std::includes(container_algorithm_internal::c_begin(c1),
                        container_algorithm_internal::c_end(c1),
                        container_algorithm_internal::c_begin(c2),
@@ -1266,7 +1296,8 @@ template <typename C1, typename C2, typename OutputIterator,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_union(const C1& c1, const C2& c2, OutputIterator output) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_set_union(const C1& c1, const C2& c2, OutputIterator output) {
   return std::set_union(container_algorithm_internal::c_begin(c1),
                         container_algorithm_internal::c_end(c1),
                         container_algorithm_internal::c_begin(c2),
@@ -1282,8 +1313,8 @@ template <typename C1, typename C2, typename OutputIterator, typename LessThan,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_union(const C1& c1, const C2& c2, OutputIterator output,
-                           LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_set_union(
+    const C1& c1, const C2& c2, OutputIterator output, LessThan&& comp) {
   return std::set_union(container_algorithm_internal::c_begin(c1),
                         container_algorithm_internal::c_end(c1),
                         container_algorithm_internal::c_begin(c2),
@@ -1302,8 +1333,8 @@ template <typename C1, typename C2, typename OutputIterator,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_intersection(const C1& c1, const C2& c2,
-                                  OutputIterator output) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_set_intersection(const C1& c1, const C2& c2, OutputIterator output) {
   // In debug builds, ensure that both containers are sorted with respect to the
   // default comparator. std::set_intersection requires the containers be sorted
   // using operator<.
@@ -1324,8 +1355,8 @@ template <typename C1, typename C2, typename OutputIterator, typename LessThan,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_intersection(const C1& c1, const C2& c2,
-                                  OutputIterator output, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_set_intersection(
+    const C1& c1, const C2& c2, OutputIterator output, LessThan&& comp) {
   // In debug builds, ensure that both containers are sorted with respect to the
   // default comparator. std::set_intersection requires the containers be sorted
   // using the same comparator.
@@ -1350,8 +1381,8 @@ template <typename C1, typename C2, typename OutputIterator,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_difference(const C1& c1, const C2& c2,
-                                OutputIterator output) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_set_difference(const C1& c1, const C2& c2, OutputIterator output) {
   return std::set_difference(container_algorithm_internal::c_begin(c1),
                              container_algorithm_internal::c_end(c1),
                              container_algorithm_internal::c_begin(c2),
@@ -1367,8 +1398,8 @@ template <typename C1, typename C2, typename OutputIterator, typename LessThan,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_difference(const C1& c1, const C2& c2,
-                                OutputIterator output, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_set_difference(
+    const C1& c1, const C2& c2, OutputIterator output, LessThan&& comp) {
   return std::set_difference(container_algorithm_internal::c_begin(c1),
                              container_algorithm_internal::c_end(c1),
                              container_algorithm_internal::c_begin(c2),
@@ -1388,8 +1419,8 @@ template <typename C1, typename C2, typename OutputIterator,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_symmetric_difference(const C1& c1, const C2& c2,
-                                          OutputIterator output) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator
+c_set_symmetric_difference(const C1& c1, const C2& c2, OutputIterator output) {
   return std::set_symmetric_difference(
       container_algorithm_internal::c_begin(c1),
       container_algorithm_internal::c_end(c1),
@@ -1406,9 +1437,8 @@ template <typename C1, typename C2, typename OutputIterator, typename LessThan,
           typename = typename std::enable_if<
               !container_algorithm_internal::IsUnorderedContainer<C2>::value,
               void>::type>
-OutputIterator c_set_symmetric_difference(const C1& c1, const C2& c2,
-                                          OutputIterator output,
-                                          LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIterator c_set_symmetric_difference(
+    const C1& c1, const C2& c2, OutputIterator output, LessThan&& comp) {
   return std::set_symmetric_difference(
       container_algorithm_internal::c_begin(c1),
       container_algorithm_internal::c_end(c1),
@@ -1426,7 +1456,8 @@ OutputIterator c_set_symmetric_difference(const C1& c1, const C2& c2,
 // Container-based version of the <algorithm> `std::push_heap()` function
 // to push a value onto a container heap.
 template <typename RandomAccessContainer>
-void c_push_heap(RandomAccessContainer& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_push_heap(
+    RandomAccessContainer& sequence) {
   std::push_heap(container_algorithm_internal::c_begin(sequence),
                  container_algorithm_internal::c_end(sequence));
 }
@@ -1434,7 +1465,8 @@ void c_push_heap(RandomAccessContainer& sequence) {
 // Overload of c_push_heap() for performing a push operation on a heap using a
 // `comp` other than `operator<`.
 template <typename RandomAccessContainer, typename LessThan>
-void c_push_heap(RandomAccessContainer& sequence, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_push_heap(
+    RandomAccessContainer& sequence, LessThan&& comp) {
   std::push_heap(container_algorithm_internal::c_begin(sequence),
                  container_algorithm_internal::c_end(sequence),
                  std::forward<LessThan>(comp));
@@ -1445,7 +1477,8 @@ void c_push_heap(RandomAccessContainer& sequence, LessThan&& comp) {
 // Container-based version of the <algorithm> `std::pop_heap()` function
 // to pop a value from a heap container.
 template <typename RandomAccessContainer>
-void c_pop_heap(RandomAccessContainer& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_pop_heap(
+    RandomAccessContainer& sequence) {
   std::pop_heap(container_algorithm_internal::c_begin(sequence),
                 container_algorithm_internal::c_end(sequence));
 }
@@ -1453,7 +1486,8 @@ void c_pop_heap(RandomAccessContainer& sequence) {
 // Overload of c_pop_heap() for performing a pop operation on a heap using a
 // `comp` other than `operator<`.
 template <typename RandomAccessContainer, typename LessThan>
-void c_pop_heap(RandomAccessContainer& sequence, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_pop_heap(
+    RandomAccessContainer& sequence, LessThan&& comp) {
   std::pop_heap(container_algorithm_internal::c_begin(sequence),
                 container_algorithm_internal::c_end(sequence),
                 std::forward<LessThan>(comp));
@@ -1464,7 +1498,8 @@ void c_pop_heap(RandomAccessContainer& sequence, LessThan&& comp) {
 // Container-based version of the <algorithm> `std::make_heap()` function
 // to make a container a heap.
 template <typename RandomAccessContainer>
-void c_make_heap(RandomAccessContainer& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_make_heap(
+    RandomAccessContainer& sequence) {
   std::make_heap(container_algorithm_internal::c_begin(sequence),
                  container_algorithm_internal::c_end(sequence));
 }
@@ -1472,7 +1507,8 @@ void c_make_heap(RandomAccessContainer& sequence) {
 // Overload of c_make_heap() for performing heap comparisons using a
 // `comp` other than `operator<`
 template <typename RandomAccessContainer, typename LessThan>
-void c_make_heap(RandomAccessContainer& sequence, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_make_heap(
+    RandomAccessContainer& sequence, LessThan&& comp) {
   std::make_heap(container_algorithm_internal::c_begin(sequence),
                  container_algorithm_internal::c_end(sequence),
                  std::forward<LessThan>(comp));
@@ -1483,7 +1519,8 @@ void c_make_heap(RandomAccessContainer& sequence, LessThan&& comp) {
 // Container-based version of the <algorithm> `std::sort_heap()` function
 // to sort a heap into ascending order (after which it is no longer a heap).
 template <typename RandomAccessContainer>
-void c_sort_heap(RandomAccessContainer& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_sort_heap(
+    RandomAccessContainer& sequence) {
   std::sort_heap(container_algorithm_internal::c_begin(sequence),
                  container_algorithm_internal::c_end(sequence));
 }
@@ -1491,7 +1528,8 @@ void c_sort_heap(RandomAccessContainer& sequence) {
 // Overload of c_sort_heap() for performing heap comparisons using a
 // `comp` other than `operator<`
 template <typename RandomAccessContainer, typename LessThan>
-void c_sort_heap(RandomAccessContainer& sequence, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_sort_heap(
+    RandomAccessContainer& sequence, LessThan&& comp) {
   std::sort_heap(container_algorithm_internal::c_begin(sequence),
                  container_algorithm_internal::c_end(sequence),
                  std::forward<LessThan>(comp));
@@ -1502,7 +1540,8 @@ void c_sort_heap(RandomAccessContainer& sequence, LessThan&& comp) {
 // Container-based version of the <algorithm> `std::is_heap()` function
 // to check whether the given container is a heap.
 template <typename RandomAccessContainer>
-bool c_is_heap(const RandomAccessContainer& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_is_heap(
+    const RandomAccessContainer& sequence) {
   return std::is_heap(container_algorithm_internal::c_begin(sequence),
                       container_algorithm_internal::c_end(sequence));
 }
@@ -1510,7 +1549,8 @@ bool c_is_heap(const RandomAccessContainer& sequence) {
 // Overload of c_is_heap() for performing heap comparisons using a
 // `comp` other than `operator<`
 template <typename RandomAccessContainer, typename LessThan>
-bool c_is_heap(const RandomAccessContainer& sequence, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_is_heap(
+    const RandomAccessContainer& sequence, LessThan&& comp) {
   return std::is_heap(container_algorithm_internal::c_begin(sequence),
                       container_algorithm_internal::c_end(sequence),
                       std::forward<LessThan>(comp));
@@ -1521,8 +1561,9 @@ bool c_is_heap(const RandomAccessContainer& sequence, LessThan&& comp) {
 // Container-based version of the <algorithm> `std::is_heap_until()` function
 // to find the first element in a given container which is not in heap order.
 template <typename RandomAccessContainer>
-container_algorithm_internal::ContainerIter<RandomAccessContainer>
-c_is_heap_until(RandomAccessContainer& sequence) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<RandomAccessContainer>
+    c_is_heap_until(RandomAccessContainer& sequence) {
   return std::is_heap_until(container_algorithm_internal::c_begin(sequence),
                             container_algorithm_internal::c_end(sequence));
 }
@@ -1530,8 +1571,9 @@ c_is_heap_until(RandomAccessContainer& sequence) {
 // Overload of c_is_heap_until() for performing heap comparisons using a
 // `comp` other than `operator<`
 template <typename RandomAccessContainer, typename LessThan>
-container_algorithm_internal::ContainerIter<RandomAccessContainer>
-c_is_heap_until(RandomAccessContainer& sequence, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+    container_algorithm_internal::ContainerIter<RandomAccessContainer>
+    c_is_heap_until(RandomAccessContainer& sequence, LessThan&& comp) {
   return std::is_heap_until(container_algorithm_internal::c_begin(sequence),
                             container_algorithm_internal::c_end(sequence),
                             std::forward<LessThan>(comp));
@@ -1626,8 +1668,8 @@ ABSL_INTERNAL_CONSTEXPR_SINCE_CXX17
 // that capital letters ("A-Z") have ASCII values less than lowercase letters
 // ("a-z").
 template <typename Sequence1, typename Sequence2>
-bool c_lexicographical_compare(const Sequence1& sequence1,
-                               const Sequence2& sequence2) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_lexicographical_compare(
+    const Sequence1& sequence1, const Sequence2& sequence2) {
   return std::lexicographical_compare(
       container_algorithm_internal::c_begin(sequence1),
       container_algorithm_internal::c_end(sequence1),
@@ -1638,8 +1680,8 @@ bool c_lexicographical_compare(const Sequence1& sequence1,
 // Overload of c_lexicographical_compare() for performing a lexicographical
 // comparison using a `comp` operator instead of `operator<`.
 template <typename Sequence1, typename Sequence2, typename LessThan>
-bool c_lexicographical_compare(const Sequence1& sequence1,
-                               const Sequence2& sequence2, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_lexicographical_compare(
+    const Sequence1& sequence1, const Sequence2& sequence2, LessThan&& comp) {
   return std::lexicographical_compare(
       container_algorithm_internal::c_begin(sequence1),
       container_algorithm_internal::c_end(sequence1),
@@ -1654,7 +1696,7 @@ bool c_lexicographical_compare(const Sequence1& sequence1,
 // to rearrange a container's elements into the next lexicographically greater
 // permutation.
 template <typename C>
-bool c_next_permutation(C& c) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_next_permutation(C& c) {
   return std::next_permutation(container_algorithm_internal::c_begin(c),
                                container_algorithm_internal::c_end(c));
 }
@@ -1662,7 +1704,8 @@ bool c_next_permutation(C& c) {
 // Overload of c_next_permutation() for performing a lexicographical
 // comparison using a `comp` operator instead of `operator<`.
 template <typename C, typename LessThan>
-bool c_next_permutation(C& c, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_next_permutation(C& c,
+                                                            LessThan&& comp) {
   return std::next_permutation(container_algorithm_internal::c_begin(c),
                                container_algorithm_internal::c_end(c),
                                std::forward<LessThan>(comp));
@@ -1674,7 +1717,7 @@ bool c_next_permutation(C& c, LessThan&& comp) {
 // to rearrange a container's elements into the next lexicographically lesser
 // permutation.
 template <typename C>
-bool c_prev_permutation(C& c) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_prev_permutation(C& c) {
   return std::prev_permutation(container_algorithm_internal::c_begin(c),
                                container_algorithm_internal::c_end(c));
 }
@@ -1682,7 +1725,8 @@ bool c_prev_permutation(C& c) {
 // Overload of c_prev_permutation() for performing a lexicographical
 // comparison using a `comp` operator instead of `operator<`.
 template <typename C, typename LessThan>
-bool c_prev_permutation(C& c, LessThan&& comp) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 bool c_prev_permutation(C& c,
+                                                            LessThan&& comp) {
   return std::prev_permutation(container_algorithm_internal::c_begin(c),
                                container_algorithm_internal::c_end(c),
                                std::forward<LessThan>(comp));
@@ -1698,7 +1742,8 @@ bool c_prev_permutation(C& c, LessThan&& comp) {
 // to compute successive values of `value`, as if incremented with `++value`
 // after each element is written, and write them to the container.
 template <typename Sequence, typename T>
-void c_iota(Sequence& sequence, const T& value) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 void c_iota(Sequence& sequence,
+                                                const T& value) {
   std::iota(container_algorithm_internal::c_begin(sequence),
             container_algorithm_internal::c_end(sequence), value);
 }
@@ -1713,7 +1758,8 @@ void c_iota(Sequence& sequence, const T& value) {
 // absl::decay_t<T>. As a user of this function you can casually read
 // this as "returns T by value" and assume it does the right thing.
 template <typename Sequence, typename T>
-decay_t<T> c_accumulate(const Sequence& sequence, T&& init) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 decay_t<T> c_accumulate(
+    const Sequence& sequence, T&& init) {
   return std::accumulate(container_algorithm_internal::c_begin(sequence),
                          container_algorithm_internal::c_end(sequence),
                          std::forward<T>(init));
@@ -1722,8 +1768,8 @@ decay_t<T> c_accumulate(const Sequence& sequence, T&& init) {
 // Overload of c_accumulate() for using a binary operations other than
 // addition for computing the accumulation.
 template <typename Sequence, typename T, typename BinaryOp>
-decay_t<T> c_accumulate(const Sequence& sequence, T&& init,
-                        BinaryOp&& binary_op) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 decay_t<T> c_accumulate(
+    const Sequence& sequence, T&& init, BinaryOp&& binary_op) {
   return std::accumulate(container_algorithm_internal::c_begin(sequence),
                          container_algorithm_internal::c_end(sequence),
                          std::forward<T>(init),
@@ -1739,8 +1785,8 @@ decay_t<T> c_accumulate(const Sequence& sequence, T&& init,
 // absl::decay_t<T>. As a user of this function you can casually read
 // this as "returns T by value" and assume it does the right thing.
 template <typename Sequence1, typename Sequence2, typename T>
-decay_t<T> c_inner_product(const Sequence1& factors1, const Sequence2& factors2,
-                           T&& sum) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 decay_t<T> c_inner_product(
+    const Sequence1& factors1, const Sequence2& factors2, T&& sum) {
   return std::inner_product(container_algorithm_internal::c_begin(factors1),
                             container_algorithm_internal::c_end(factors1),
                             container_algorithm_internal::c_begin(factors2),
@@ -1752,8 +1798,9 @@ decay_t<T> c_inner_product(const Sequence1& factors1, const Sequence2& factors2,
 // the product between the two container's element pair).
 template <typename Sequence1, typename Sequence2, typename T,
           typename BinaryOp1, typename BinaryOp2>
-decay_t<T> c_inner_product(const Sequence1& factors1, const Sequence2& factors2,
-                           T&& sum, BinaryOp1&& op1, BinaryOp2&& op2) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 decay_t<T> c_inner_product(
+    const Sequence1& factors1, const Sequence2& factors2, T&& sum,
+    BinaryOp1&& op1, BinaryOp2&& op2) {
   return std::inner_product(container_algorithm_internal::c_begin(factors1),
                             container_algorithm_internal::c_end(factors1),
                             container_algorithm_internal::c_begin(factors2),
@@ -1767,8 +1814,8 @@ decay_t<T> c_inner_product(const Sequence1& factors1, const Sequence2& factors2,
 // function to compute the difference between each element and the one preceding
 // it and write it to an iterator.
 template <typename InputSequence, typename OutputIt>
-OutputIt c_adjacent_difference(const InputSequence& input,
-                               OutputIt output_first) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIt
+c_adjacent_difference(const InputSequence& input, OutputIt output_first) {
   return std::adjacent_difference(container_algorithm_internal::c_begin(input),
                                   container_algorithm_internal::c_end(input),
                                   output_first);
@@ -1777,8 +1824,8 @@ OutputIt c_adjacent_difference(const InputSequence& input,
 // Overload of c_adjacent_difference() for using a binary operation other than
 // subtraction to compute the adjacent difference.
 template <typename InputSequence, typename OutputIt, typename BinaryOp>
-OutputIt c_adjacent_difference(const InputSequence& input,
-                               OutputIt output_first, BinaryOp&& op) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIt c_adjacent_difference(
+    const InputSequence& input, OutputIt output_first, BinaryOp&& op) {
   return std::adjacent_difference(container_algorithm_internal::c_begin(input),
                                   container_algorithm_internal::c_end(input),
                                   output_first, std::forward<BinaryOp>(op));
@@ -1791,7 +1838,8 @@ OutputIt c_adjacent_difference(const InputSequence& input,
 // to an iterator. The partial sum is the sum of all element values so far in
 // the sequence.
 template <typename InputSequence, typename OutputIt>
-OutputIt c_partial_sum(const InputSequence& input, OutputIt output_first) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIt
+c_partial_sum(const InputSequence& input, OutputIt output_first) {
   return std::partial_sum(container_algorithm_internal::c_begin(input),
                           container_algorithm_internal::c_end(input),
                           output_first);
@@ -1800,8 +1848,8 @@ OutputIt c_partial_sum(const InputSequence& input, OutputIt output_first) {
 // Overload of c_partial_sum() for using a binary operation other than addition
 // to compute the "partial sum".
 template <typename InputSequence, typename OutputIt, typename BinaryOp>
-OutputIt c_partial_sum(const InputSequence& input, OutputIt output_first,
-                       BinaryOp&& op) {
+ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 OutputIt c_partial_sum(
+    const InputSequence& input, OutputIt output_first, BinaryOp&& op) {
   return std::partial_sum(container_algorithm_internal::c_begin(input),
                           container_algorithm_internal::c_end(input),
                           output_first, std::forward<BinaryOp>(op));


### PR DESCRIPTION
https://github.com/llvm/llvm-project/blob/main/libcxx/include/algorithm
checked with llvm libc++19 and clang19 (only algorithms which support constexpr since c++20)