### PR TITLE
remove duplicate dependency

### DIFF
--- a/absl/synchronization/CMakeLists.txt
+++ b/absl/synchronization/CMakeLists.txt
@@ -113,7 +113,6 @@ absl_cc_library(
     absl::raw_logging_internal
     absl::stacktrace
     absl::symbolize
-    absl::tracing_internal
     absl::time
     absl::tracing_internal
     Threads::Threads


### PR DESCRIPTION
Remove a duplicated dependency to `absl::tracing_internal`.