### PR TITLE
Adjust Table.GrowExtremelyLargeTable to avoid OOM on i386

### DIFF
--- a/absl/container/internal/raw_hash_set_test.cc
+++ b/absl/container/internal/raw_hash_set_test.cc
@@ -4267,8 +4267,8 @@ struct ConstUint8Hash {
 // 5. Finally we will catch up and go to overflow codepath.
 TEST(Table, GrowExtremelyLargeTable) {
   constexpr size_t kTargetCapacity =
-#if defined(__wasm__) || defined(__asmjs__)
-      NextCapacity(ProbedItem4Bytes::kMaxNewCapacity);  // OOMs on WASM.
+#if defined(__wasm__) || defined(__asmjs__) || defined(__i386__)
+      NextCapacity(ProbedItem4Bytes::kMaxNewCapacity);  // OOMs on WASM, 32-bit.
 #else
       NextCapacity(ProbedItem8Bytes::kMaxNewCapacity);
 #endif


### PR DESCRIPTION
While this only covers `i386`/`i686`, which is the motivation for this PR, this test can be expected to OOM on any 32-bit platform. Are there other supported 32-bit platforms, or can you suggest a better approach than enumerating platforms? (I searched for something like this that might already exist elsewhere in the code, but came up empty-handed.) Answers to those questions might help me improve this PR. For now, this is the minimal change that avoids the problem [in the Fedora package](https://src.fedoraproject.org/rpms/abseil-cpp/).

This fixes one of the two test failures reported in https://github.com/abseil/abseil-cpp/issues/1887.