### PR TITLE
hash: fix ciso646 deprecated warning for gcc 15.1.1

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -38,7 +38,7 @@
 #endif
 
 // For feature testing and determining which headers can be included.
-#if ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L || \
+#if ABSL_INTERNAL_CPLUSPLUS_LANG >= 2017003L || \
     ABSL_INTERNAL_VERSION_HEADER_AVAILABLE
 #include <version>
 #else


### PR DESCRIPTION
The deprecated warning for including <ciso646> breaks the build of
at least openvpn3 arch linux. With gcc 15.1.1 the pre-proc variables are

__cplusplus 201703
ABSL_INTERNAL_CPLUSPLUS_LANG 201703

Warning:
```
/usr/include/c++/15.1.1/ciso646:46:4: error: #warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-Werror=cpp]
   46 | #  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
```

Not sure if this is related or fixes also https://github.com/abseil/abseil-cpp/issues/1251.


Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
