### PR TITLE
Abseil LTS Branch, May 2025, Patch 1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "20250512.0",
+    version = "20250512.1",
     compatibility_level = 1,
 )
 

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -118,7 +118,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20250512
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -39,7 +39,7 @@
 
 // For feature testing and determining which headers can be included.
 #if ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L || \
-    ABSL_INTERNAL_VERSION_HEADER_AVAILABLE
+    defined(ABSL_INTERNAL_VERSION_HEADER_AVAILABLE)
 #include <version>
 #else
 #include <ciso646>

--- a/absl/time/time.h
+++ b/absl/time/time.h
@@ -1869,8 +1869,9 @@ ABSL_ATTRIBUTE_CONST_FUNCTION constexpr int64_t ToInt64Nanoseconds(Duration d) {
       time_internal::GetRepHi(d) >> 33 == 0) {
     return (time_internal::GetRepHi(d) * 1000 * 1000 * 1000) +
            (time_internal::GetRepLo(d) / time_internal::kTicksPerNanosecond);
+  } else {
+    return d / Nanoseconds(1);
   }
-  return d / Nanoseconds(1);
 }
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr int64_t ToInt64Microseconds(
@@ -1880,8 +1881,9 @@ ABSL_ATTRIBUTE_CONST_FUNCTION constexpr int64_t ToInt64Microseconds(
     return (time_internal::GetRepHi(d) * 1000 * 1000) +
            (time_internal::GetRepLo(d) /
             (time_internal::kTicksPerNanosecond * 1000));
+  } else {
+    return d / Microseconds(1);
   }
-  return d / Microseconds(1);
 }
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr int64_t ToInt64Milliseconds(
@@ -1891,8 +1893,9 @@ ABSL_ATTRIBUTE_CONST_FUNCTION constexpr int64_t ToInt64Milliseconds(
     return (time_internal::GetRepHi(d) * 1000) +
            (time_internal::GetRepLo(d) /
             (time_internal::kTicksPerNanosecond * 1000 * 1000));
+  } else {
+    return d / Milliseconds(1);
   }
-  return d / Milliseconds(1);
 }
 
 ABSL_ATTRIBUTE_CONST_FUNCTION constexpr int64_t ToInt64Seconds(Duration d) {


### PR DESCRIPTION
Fix conditional constexpr in ToInt64{Nano|Micro|Milli}seconds under
GCC7 and GCC8 using an else clause as a workaround

Fix -Wundef warning