### PR TITLE
add arm64ec support

### DIFF
--- a/absl/numeric/internal/bits.h
+++ b/absl/numeric/internal/bits.h
@@ -223,7 +223,7 @@ CountLeadingZeroes64(uint64_t x) {
   // Handle 0 as a special case because __builtin_clzll(0) is undefined.
   return x == 0 ? 64 : __builtin_clzll(x);
 #elif defined(_MSC_VER) && !defined(__clang__) && \
-    (defined(_M_X64) || defined(_M_ARM64))
+    (defined(_M_X64) || defined(_M_ARM64)|| defined(_M_ARM64EC))
   // MSVC does not have __buitin_clzll. Use _BitScanReverse64.
   unsigned long result = 0;  // NOLINT(runtime/int)
   if (_BitScanReverse64(&result, x)) {
@@ -310,7 +310,7 @@ CountTrailingZeroesNonzero64(uint64_t x) {
                 "__builtin_ctzll does not take 64-bit arg");
   return __builtin_ctzll(x);
 #elif defined(_MSC_VER) && !defined(__clang__) && \
-    (defined(_M_X64) || defined(_M_ARM64))
+    (defined(_M_X64) || defined(_M_ARM64)|| defined(_M_ARM64EC))
   unsigned long result = 0;  // NOLINT(runtime/int)
   _BitScanForward64(&result, x);
   return result;

--- a/absl/random/internal/platform.h
+++ b/absl/random/internal/platform.h
@@ -61,11 +61,11 @@
 //
 // ABSL_ARCH_{X86/PPC/ARM} macros determine the platform.
 #if defined(__x86_64__) || defined(__x86_64) || defined(_M_AMD64) || \
-    defined(_M_X64)
+    defined(_M_X64) && !defined(_M_ARM64EC)
 #define ABSL_ARCH_X86_64
 #elif defined(__i386) || defined(_M_IX86)
 #define ABSL_ARCH_X86_32
-#elif defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+#elif defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)|| defined(_M_ARM64EC)
 #define ABSL_ARCH_AARCH64
 #elif defined(__arm__) || defined(__ARMEL__) || defined(_M_ARM)
 #define ABSL_ARCH_ARM

--- a/absl/time/internal/cctz/src/zone_info_source.cc
+++ b/absl/time/internal/cctz/src/zone_info_source.cc
@@ -84,7 +84,7 @@ ZoneInfoSourceFactory default_factory = DefaultFactory;
     "@@U?$default_delete@VZoneInfoSource@cctz@time_internal@" ABSL_INTERNAL_MANGLED_NS                                   \
     "@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@" ABSL_INTERNAL_MANGLED_BACKREFERENCE \
     "@@ZA")
-#elif defined(_M_IA_64) || defined(_M_AMD64) || defined(_M_ARM64)
+#elif defined(_M_IA_64) || defined(_M_AMD64) || defined(_M_ARM64)|| defined(_M_ARM64EC)
 #pragma comment(                                                                                                          \
     linker,                                                                                                               \
     "/alternatename:?zone_info_source_factory@cctz_extension@time_internal@" ABSL_INTERNAL_MANGLED_NS                     \


### PR DESCRIPTION
### Fix: Add ARM64EC-WINDOWS Build Support

This patch adds support for compiling Abseil on Windows using the ARM64EC architecture.

#### Changes:
- Updated platform-specific macros to detect ARM64EC.
- Adjusted build configuration to support mixed x64/ARM64EC binaries.

#### Motivation:
ARM64EC is a key technology for enabling gradual migration of Windows applications to ARM64. This patch ensures Abseil can be used in such environments.

#### Testing:
- Verified build success on Windows 11 with ARM64EC toolchain.
