### PR TITLE
absl/base/internal/poison.cc: Minor build fix

### DIFF
--- a/absl/base/internal/poison.cc
+++ b/absl/base/internal/poison.cc
@@ -57,18 +57,19 @@ size_t GetPageSize() {
 
 void* InitializePoisonedPointerInternal() {
   const size_t block_size = GetPageSize();
+  void* data = nullptr;
 #if defined(ABSL_HAVE_ADDRESS_SANITIZER)
-  void* data = malloc(block_size);
+  data = malloc(block_size);
   ASAN_POISON_MEMORY_REGION(data, block_size);
 #elif defined(ABSL_HAVE_MEMORY_SANITIZER)
-  void* data = malloc(block_size);
+  data = malloc(block_size);
   __msan_poison(data, block_size);
 #elif defined(ABSL_HAVE_MMAP)
-  void* data = DirectMmap(nullptr, block_size, PROT_NONE,
+  data = DirectMmap(nullptr, block_size, PROT_NONE,
                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (data == MAP_FAILED) return GetBadPointerInternal();
 #elif defined(_WIN32)
-  void* data = VirtualAlloc(nullptr, block_size, MEM_RESERVE | MEM_COMMIT,
+  data = VirtualAlloc(nullptr, block_size, MEM_RESERVE | MEM_COMMIT,
                             PAGE_NOACCESS);
   if (data == nullptr) return GetBadPointerInternal();
 #else


### PR DESCRIPTION
Hi,

I was running into a build error in my project that was using abseil-cpp
on the master branch (56945519b5d17dcec0982ac6cdf4b6420f03c9c3).

I don't have any of the specific defines in my build so the void* data is never
declared.

```
: warning: implicit conversion changes signedness: 'int' to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   50 |   return getpagesize();
      |   ~~~~~~ ^~~~~~~~~~~~~
../_deps/absl-src/absl/base/internal/poison.cc:79:29: error: use of undeclared identifier 'data'
   79 |   return static_cast<char*>(data) + block_size / 2;
      |                             ^
1 warning and 1 error generated.
gmake[2]: *** [_deps/absl-build/absl/base/CMakeFiles/poison.dir/build.make:76: _deps/absl-build/absl/base/CMakeFiles/poison.dir/internal/poison.cc.obj] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1843: _deps/absl-build/absl/base/CMakeFiles/poison.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```
