### PR TITLE
Fix SYCL Build Compatibility with Intel LLVM Compiler on Windows for abseil

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -237,6 +237,8 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #error ABSL_HAVE_TLS cannot be directly set
 #elif (defined(__linux__)) && (defined(__clang__) || defined(_GLIBCXX_HAVE_TLS))
 #define ABSL_HAVE_TLS 1
+#elif defined(__INTEL_LLVM_COMPILER)
+#define ABSL_HAVE_TLS 1
 #endif
 
 // ABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE

--- a/absl/base/internal/per_thread_tls.h
+++ b/absl/base/internal/per_thread_tls.h
@@ -41,6 +41,9 @@
 #elif defined(ABSL_HAVE_TLS)
 #define ABSL_PER_THREAD_TLS_KEYWORD __thread
 #define ABSL_PER_THREAD_TLS 1
+#elif defined(__INTEL_LLVM_COMPILER) && defined(__SYCL_DEVICE_ONLY__)
+#define ABSL_PER_THREAD_TLS_KEYWORD __thread
+#define ABSL_PER_THREAD_TLS 1
 #elif defined(_MSC_VER)
 #define ABSL_PER_THREAD_TLS_KEYWORD __declspec(thread)
 #define ABSL_PER_THREAD_TLS 1

--- a/absl/base/internal/per_thread_tls.h
+++ b/absl/base/internal/per_thread_tls.h
@@ -41,9 +41,6 @@
 #elif defined(ABSL_HAVE_TLS)
 #define ABSL_PER_THREAD_TLS_KEYWORD __thread
 #define ABSL_PER_THREAD_TLS 1
-#elif defined(__INTEL_LLVM_COMPILER) && defined(__SYCL_DEVICE_ONLY__)
-#define ABSL_PER_THREAD_TLS_KEYWORD __thread
-#define ABSL_PER_THREAD_TLS 1
 #elif defined(_MSC_VER)
 #define ABSL_PER_THREAD_TLS_KEYWORD __declspec(thread)
 #define ABSL_PER_THREAD_TLS 1


### PR DESCRIPTION
Add platform-specific thread-local storage definition for Intel's LLVM  compiler when building with SYCL. The Intel LLVM compiler (icx) with  SYCL enabled requires GCC-style thread-local storage (__thread) rather  than Windows-specific __declspec(thread) when compiling for SYCL device code.

This resolves the build error: "thread-local storage is not supported for  the current target" when building with Intel oneAPI env on Windows systems.

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
