### PR TITLE
base: add musl + ppc64le fallback for UnscaledCycleClock::Frequency

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -85,6 +85,9 @@ int64_t UnscaledCycleClock::Now() {
 double UnscaledCycleClock::Frequency() {
 #ifdef __GLIBC__
   return __ppc_get_timebase_freq();
+#elif defined(__linux__) && (defined(__powerpc__) || defined(__ppc__))
+  // Fallback for musl + ppc64le: use constant timebase frequency (512 MHz)
+  return static_cast<double>(512000000);
 #elif defined(_AIX)
   // This is the same constant value as returned by
   // __ppc_get_timebase_freq().


### PR DESCRIPTION
Fixes build failures on ppc64le with musl libc, where UnscaledCycleClock::Frequency() had no implementation.

This patch adds a fallback for __linux__ + __powerpc64__ when glibc is not present, using a constant 512 MHz timebase frequency. This matches the existing AIX implementation and unblocks projects like Node.js/V8 from building on Alpine Linux (musl).

Tested by building Node.js 24.x on ppc64le + musl.

Issue- https://github.com/abseil/abseil-cpp/issues/1917


