### PR TITLE
Enable mmap for WASI if it supports the mman header

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -364,6 +364,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 //   AsmJS                             __asmjs__
 //   WebAssembly (Emscripten)          __EMSCRIPTEN__
 //   Fuchsia                           __Fuchsia__
+//   WebAssembly (WASI)                _WASI_EMULATED_MMAN (implies __wasi__)
 //
 // Note that since Android defines both __ANDROID__ and __linux__, one
 // may probe for either Linux or Android by simply testing for __linux__.
@@ -379,7 +380,8 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
     defined(__asmjs__) || defined(__EMSCRIPTEN__) || defined(__Fuchsia__) || \
     defined(__sun) || defined(__myriad2__) || defined(__HAIKU__) ||          \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) ||       \
-    defined(__VXWORKS__) || defined(__hexagon__) || defined(__XTENSA__)
+    defined(__VXWORKS__) || defined(__hexagon__) || defined(__XTENSA__) ||   \
+    defined(_WASI_EMULATED_MMAN)
 #define ABSL_HAVE_MMAP 1
 #endif
 


### PR DESCRIPTION
#1509 completely removed the mmap support when targeting WASI. wasi-libc supports an optional emulated mmap implementation if [`_WASI_EMULATED_MMAN`](https://github.com/WebAssembly/wasi-libc/blob/main/libc-top-half/musl/include/sys/mman.h) is set. Emulated mmap calls in wasi-libc come with a few restrictions, but users are aware of them as the feature is opt-in.

This PR enables mmap support for WASI if `_WASI_EMULATED_MMAN` is defined.