### PR TITLE
Fix shorten-64-to-32 warning in stacktrace_riscv-inl.inc

### DIFF
--- a/absl/debugging/internal/stacktrace_riscv-inl.inc
+++ b/absl/debugging/internal/stacktrace_riscv-inl.inc
@@ -162,7 +162,8 @@ static int UnwindImpl(void **result, uintptr_t *frames, int *sizes,
               absl::debugging_internal::StripPointerMetadata(frame_pointer);
         }
         if (sizes != nullptr) {
-          sizes[n] = ComputeStackFrameSize(frame_pointer, next_frame_pointer);
+          sizes[n] = static_cast<int>(
+              ComputeStackFrameSize(frame_pointer, next_frame_pointer));
         }
       }
       n++;


### PR DESCRIPTION
`ComputeStackFrameSize` returns `ptrdiff_t` which is `long` while `sizes[n]` is `int`.

This would become an error in chromium build as chromium enables warnings_as_error by default.

```
In file included from ../../third_party/abseil-cpp/absl/debugging/stacktrace.cc:76:
../../third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc:165:22: warning: implicit conversion loses integer precision: 'ptrdiff_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
  165 |           sizes[n] = ComputeStackFrameSize(frame_pointer, next_frame_pointer);
      |                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc:165:22: warning: implicit conversion loses integer precision: 'ptrdiff_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
  165 |           sizes[n] = ComputeStackFrameSize(frame_pointer, next_frame_pointer);
      |                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/abseil-cpp/absl/debugging/stacktrace.cc:199:12: note: in instantiation of function template specialization 'UnwindImpl<true, false>' requested here
  199 |       f = &UnwindImpl<true, false>;
      |            ^
In file included from ../../third_party/abseil-cpp/absl/debugging/stacktrace.cc:76:
../../third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc:165:22: warning: implicit conversion loses integer precision: 'ptrdiff_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
  165 |           sizes[n] = ComputeStackFrameSize(frame_pointer, next_frame_pointer);
      |                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/abseil-cpp/absl/debugging/stacktrace.cc:201:12: note: in instantiation of function template specialization 'UnwindImpl<true, true>' requested here
  201 |       f = &UnwindImpl<true, true>;
      |            ^
3 warnings generated.
```
