### PR TITLE
raw_hash_set: fix instanciation for recursive types on MSVC with /Zc:__cplusplus

### DIFF
--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -2390,13 +2390,13 @@ class raw_hash_set {
   //   s.insert({"abc", 42});
   std::pair<iterator, bool> insert(init_type&& value)
       ABSL_ATTRIBUTE_LIFETIME_BOUND
-#if __cplusplus >= 202002L
+#if ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L && (!defined(_MSC_VER) || defined(__clang__))
     requires(!IsLifetimeBoundAssignmentFrom<init_type>::value)
 #endif
   {
     return emplace(std::move(value));
   }
-#if __cplusplus >= 202002L
+#if ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L && (!defined(_MSC_VER) || defined(__clang__))
   std::pair<iterator, bool> insert(
       init_type&& value ABSL_INTERNAL_ATTRIBUTE_CAPTURED_BY(this))
       ABSL_ATTRIBUTE_LIFETIME_BOUND


### PR DESCRIPTION
Fixes the following error:

```
/opt/msvc/bin/x64/cl -Iabsl_node_hash_map_test.exe.p -I. -I.. -I../subprojects/googletest-1.15.2/googletest/include -Isubprojects/googletest-1.15.2/googletest -I../subprojects/googletest-1.15.2/googletest -I../subprojects/googletest-1.15.2/googlemock/include -Isubprojects/googletest-1.15.2/googlemock -I../subprojects/googletest-1.15.2/googlemock -DNDEBUG /MD /nologo /showIncludes /utf-8 /Zc:__cplusplus /W3 /EHsc /std:c++20 /permissive- /O1 /Gw /Zi /D_CRT_SECURE_NO_WARNINGS /D_ENABLE_EXTENDED_ALIGNED_STORAGE /D_SCL_SECURE_NO_WARNINGS /bigobj /wd4005 /wd4068 /wd4180 /wd4503 /wd4800 -DNOMINMAX -DWIN32_LEAN_AND_MEAN /wd4018 /wd4101 /wd4244 /wd4267 /wd4503 /wd4996 /Fdabsl_node_hash_map_test.exe.p/absl_container_node_hash_map_test.cc.pdb /Foabsl_node_hash_map_test.exe.p/absl_container_node_hash_map_test.cc.obj /c ../absl/container/node_hash_map_test.cc
/opt/msvc/vc/tools/msvc/14.44.35207/include/utility(473): error C2079: 'std::pair<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree>::second' uses undefined struct 'absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree'
/opt/msvc/vc/tools/msvc/14.44.35207/include/utility(473): note: the template instantiation context (the oldest one first) is
../absl/container/node_hash_map_test.cc(131): note: see reference to class template instantiation 'absl::lts_20250814::node_hash_map<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree,absl::lts_20250814::hash_internal::Hash<T>,std::equal_to<T>,std::allocator<std::pair<const Key,Value>>>' being compiled
        with
        [
            T=int,
            Key=int,
            Value=absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree
        ]
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/container/node_hash_map.h(129): note: see reference to class template instantiation 'absl::lts_20250814::container_internal::raw_hash_map<absl::lts_20250814::container_internal::NodeHashMapPolicy<Key,Value>,Hash,Eq,Alloc>' being compiled
        with
        [
            Key=int,
            Value=absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree,
            Hash=absl::lts_20250814::hash_internal::Hash<int>,
            Eq=std::equal_to<int>,
            Alloc=std::allocator<std::pair<const int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree>>
        ]
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/container/internal/raw_hash_map.h(35): note: see reference to class template instantiation 'absl::lts_20250814::container_internal::raw_hash_set<Policy,Hash,Eq,Alloc>' being compiled
        with
        [
            Policy=absl::lts_20250814::container_internal::NodeHashMapPolicy<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree>,
            Hash=absl::lts_20250814::hash_internal::Hash<int>,
            Eq=std::equal_to<int>,
            Alloc=std::allocator<std::pair<const int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree>>
        ]
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/container/internal/raw_hash_set.h(2470): note: see reference to class template instantiation 'absl::lts_20250814::type_traits_internal::IsOwner<std::pair<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree>>' being compiled
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/meta/type_traits.h(480): note: see reference to class template instantiation 'std::pair<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_AssignRecursive_Test::TestBody::Tree>' being compiled
/opt/msvc/vc/tools/msvc/14.44.35207/include/utility(473): error C2079: 'std::pair<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType>::second' uses undefined struct 'absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType'
/opt/msvc/vc/tools/msvc/14.44.35207/include/utility(473): note: the template instantiation context (the oldest one first) is
../absl/container/node_hash_map_test.cc(339): note: see reference to class template instantiation 'absl::lts_20250814::node_hash_map<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType,absl::lts_20250814::hash_internal::Hash<T>,std::equal_to<T>,std::allocator<std::pair<const Key,Value>>>' being compiled
        with
        [
            T=int,
            Key=int,
            Value=absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType
        ]
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/container/node_hash_map.h(129): note: see reference to class template instantiation 'absl::lts_20250814::container_internal::raw_hash_map<absl::lts_20250814::container_internal::NodeHashMapPolicy<Key,Value>,Hash,Eq,Alloc>' being compiled
        with
        [
            Key=int,
            Value=absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType,
            Hash=absl::lts_20250814::hash_internal::Hash<int>,
            Eq=std::equal_to<int>,
            Alloc=std::allocator<std::pair<const int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType>>
        ]
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/container/internal/raw_hash_map.h(35): note: see reference to class template instantiation 'absl::lts_20250814::container_internal::raw_hash_set<Policy,Hash,Eq,Alloc>' being compiled
        with
        [
            Policy=absl::lts_20250814::container_internal::NodeHashMapPolicy<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType>,
            Hash=absl::lts_20250814::hash_internal::Hash<int>,
            Eq=std::equal_to<int>,
            Alloc=std::allocator<std::pair<const int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType>>
        ]
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/container/internal/raw_hash_set.h(2470): note: see reference to class template instantiation 'absl::lts_20250814::type_traits_internal::IsOwner<std::pair<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType>>' being compiled
/home/mochaa/ghq/github.com/abseil/abseil-cpp/absl/meta/type_traits.h(480): note: see reference to class template instantiation 'std::pair<int,absl::lts_20250814::container_internal::`anonymous-namespace'::NodeHashMap_RecursiveTypeCompiles_Test::TestBody::RecursiveType>' being compiled
```

closes #1930.