### PR TITLE
Abseil LTS branch, August 2025, Patch 1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "20250814.0",
+    version = "20250814.1",
     compatibility_level = 1,
 )
 

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -118,7 +118,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20250814
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/log/CMakeLists.txt
+++ b/absl/log/CMakeLists.txt
@@ -47,6 +47,7 @@ absl_cc_library(
     absl::base
     absl::config
     absl::core_headers
+    absl::has_ostream_operator
     absl::leak_check
     absl::log_internal_nullguard
     absl::log_internal_nullstream

--- a/absl/log/check_test_impl.inc
+++ b/absl/log/check_test_impl.inc
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+
 #ifndef ABSL_LOG_CHECK_TEST_IMPL_H_
 #define ABSL_LOG_CHECK_TEST_IMPL_H_
 
@@ -239,6 +241,18 @@ TEST(CHECKTest, TestBinaryChecksWithPrimitives) {
   ABSL_TEST_CHECK_LE(1, 2);
   ABSL_TEST_CHECK_GT(2, 1);
   ABSL_TEST_CHECK_LT(1, 2);
+}
+
+TEST(CHECKTest, TestBinaryChecksWithStringComparison) {
+  const std::string a = "a";
+  ABSL_TEST_CHECK_EQ(a, "a");
+  ABSL_TEST_CHECK_NE(a, "b");
+  ABSL_TEST_CHECK_GE(a, a);
+  ABSL_TEST_CHECK_GE("b", a);
+  ABSL_TEST_CHECK_LE(a, "a");
+  ABSL_TEST_CHECK_LE(a, "b");
+  ABSL_TEST_CHECK_GT("b", a);
+  ABSL_TEST_CHECK_LT(a, "b");
 }
 
 // For testing using CHECK*() on anonymous enums.

--- a/absl/log/internal/BUILD.bazel
+++ b/absl/log/internal/BUILD.bazel
@@ -82,6 +82,7 @@ cc_library(
         "//absl/base:nullability",
         "//absl/debugging:leak_check",
         "//absl/strings",
+        "//absl/strings:has_ostream_operator",
     ],
 )
 


### PR DESCRIPTION
Fix `CHECK_<OP>` ambiguous overload for `operator<<` in older versions of GCC when C-style strings are compared

Regression introduced in 57bc7edd87008f484ce82009ae88faf9633f0fbb
