### PR TITLE
Simplify ConvertSpecialToEmptyAndFullToDeleted

### DIFF
--- a/absl/container/internal/hashtable_control_bytes.h
+++ b/absl/container/internal/hashtable_control_bytes.h
@@ -330,14 +330,8 @@ struct GroupSse2Impl {
 
   void ConvertSpecialToEmptyAndFullToDeleted(ctrl_t* dst) const {
     auto msbs = _mm_set1_epi8(static_cast<char>(-128));
-    auto x126 = _mm_set1_epi8(126);
-#ifdef ABSL_INTERNAL_HAVE_SSSE3
-    auto res = _mm_or_si128(_mm_shuffle_epi8(x126, ctrl), msbs);
-#else
-    auto zero = _mm_setzero_si128();
-    auto special_mask = _mm_cmpgt_epi8_fixed(zero, ctrl);
-    auto res = _mm_or_si128(msbs, _mm_andnot_si128(special_mask, x126));
-#endif
+    auto twos = _mm_set1_epi8(static_cast<char>(2));
+    auto res = _mm_subs_epi8(_mm_and_si128(msbs, ctrl), twos);
     _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), res);
   }
 

--- a/absl/container/internal/hashtable_control_bytes.h
+++ b/absl/container/internal/hashtable_control_bytes.h
@@ -212,6 +212,9 @@ static_assert(
 static_assert(ctrl_t::kDeleted == static_cast<ctrl_t>(-2),
               "ctrl_t::kDeleted must be -2 to make the implementation of "
               "ConvertSpecialToEmptyAndFullToDeleted efficient");
+static_assert(ctrl_t::kEmpty == static_cast<ctrl_t>(-128),
+              "ctrl_t::kEmpty must be -128 to use saturated subtraction in"
+              " ConvertSpecialToEmptyAndFullToDeleted");
 
 // Helpers for checking the state of a control byte.
 inline bool IsEmpty(ctrl_t c) { return c == ctrl_t::kEmpty; }
@@ -329,6 +332,12 @@ struct GroupSse2Impl {
   }
 
   void ConvertSpecialToEmptyAndFullToDeleted(ctrl_t* dst) const {
+    // Take advantage of the fact that kEmpty is already the smallest signed
+    // char value, and using a saturated subtraction will not affect it.
+    // All special values have the MSB set, so after an AND with MSBS, we
+    // are left with -128 for special values and 0 for full. After applying
+    // subs 2, we arrive at the result of -128(kEmpty) for special and
+    // -2(kDeleted) for full.
     auto msbs = _mm_set1_epi8(static_cast<char>(-128));
     auto twos = _mm_set1_epi8(static_cast<char>(2));
     auto res = _mm_subs_epi8(_mm_and_si128(msbs, ctrl), twos);


### PR DESCRIPTION
Take advantage of the fact that kEmpty is already the smallest signed char value, and using a saturated subtraction will not affect it.

All special values have the MSB set, so after an AND with MSBS, we are left with -128 for special values and 0 for full. After applying subs 2, we arrive at the result of -128(kEmpty) for special and -2(kDeleted) for full.

According to Intel specifications, the subs(PSUBSB) instruction has equal or better CPI and latency than shuffle(PSHUFB), so there is no need to keep the SSSE3 alternative.