### PR TITLE
Backport to lts_2024_01_16: PR #1739: container/internal: Explicitly include <cstdint>

### DIFF
--- a/absl/container/internal/container_memory.h
+++ b/absl/container/internal/container_memory.h
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <new>


### PR DESCRIPTION
This is a fast-forward cherry-pick of https://github.com/abseil/abseil-cpp/commit/809e5de7b92950849289236a5a09e9cb4f32c7b

With this one line it compiles with GCC-15.