### PR TITLE
Abseil LTS branch, Aug 2025, Patch 1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "abseil-cpp",
-    version = "20250814.0",
+    version = "20250814.1",
     compatibility_level = 1,
 )
 

--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -118,7 +118,7 @@
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
 #define ABSL_LTS_RELEASE_VERSION 20250814
-#define ABSL_LTS_RELEASE_PATCH_LEVEL 0
+#define ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define ABSL_INTERNAL_DO_TOKEN_STR(x) #x

--- a/absl/container/internal/raw_hash_set.cc
+++ b/absl/container/internal/raw_hash_set.cc
@@ -679,7 +679,7 @@ void ResizeNonSooImpl(CommonFields& common,
   ABSL_SWISSTABLE_ASSERT(IsValidCapacity(new_capacity));
   ABSL_SWISSTABLE_ASSERT(new_capacity > policy.soo_capacity());
 
-  const size_t old_capacity = common.capacity();
+  [[maybe_unused]] const size_t old_capacity = common.capacity();
   [[maybe_unused]] ctrl_t* old_ctrl;
   [[maybe_unused]] void* old_slots;
   if constexpr (kMode == ResizeNonSooMode::kGuaranteedAllocated) {
@@ -688,7 +688,7 @@ void ResizeNonSooImpl(CommonFields& common,
   }
 
   const size_t slot_size = policy.slot_size;
-  const size_t slot_align = policy.slot_align;
+  [[maybe_unused]] const size_t slot_align = policy.slot_align;
   const bool has_infoz = infoz.IsSampled();
   void* alloc = policy.get_char_alloc(common);
 

--- a/absl/debugging/BUILD.bazel
+++ b/absl/debugging/BUILD.bazel
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load(
     "//absl:copts/configure_copts.bzl",
     "ABSL_DEFAULT_COPTS",

--- a/absl/log/CMakeLists.txt
+++ b/absl/log/CMakeLists.txt
@@ -47,6 +47,7 @@ absl_cc_library(
     absl::base
     absl::config
     absl::core_headers
+    absl::has_ostream_operator
     absl::leak_check
     absl::log_internal_nullguard
     absl::log_internal_nullstream

--- a/absl/log/check_test_impl.inc
+++ b/absl/log/check_test_impl.inc
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+
 #ifndef ABSL_LOG_CHECK_TEST_IMPL_H_
 #define ABSL_LOG_CHECK_TEST_IMPL_H_
 
@@ -239,6 +241,18 @@ TEST(CHECKTest, TestBinaryChecksWithPrimitives) {
   ABSL_TEST_CHECK_LE(1, 2);
   ABSL_TEST_CHECK_GT(2, 1);
   ABSL_TEST_CHECK_LT(1, 2);
+}
+
+TEST(CHECKTest, TestBinaryChecksWithStringComparison) {
+  const std::string a = "a";
+  ABSL_TEST_CHECK_EQ(a, "a");
+  ABSL_TEST_CHECK_NE(a, "b");
+  ABSL_TEST_CHECK_GE(a, a);
+  ABSL_TEST_CHECK_GE("b", a);
+  ABSL_TEST_CHECK_LE(a, "a");
+  ABSL_TEST_CHECK_LE(a, "b");
+  ABSL_TEST_CHECK_GT("b", a);
+  ABSL_TEST_CHECK_LT(a, "b");
 }
 
 // For testing using CHECK*() on anonymous enums.

--- a/absl/log/internal/BUILD.bazel
+++ b/absl/log/internal/BUILD.bazel
@@ -82,6 +82,7 @@ cc_library(
         "//absl/base:nullability",
         "//absl/debugging:leak_check",
         "//absl/strings",
+        "//absl/strings:has_ostream_operator",
     ],
 )
 

--- a/absl/log/internal/check_op.h
+++ b/absl/log/internal/check_op.h
@@ -40,6 +40,7 @@
 #include "absl/log/internal/nullstream.h"
 #include "absl/log/internal/strip.h"
 #include "absl/strings/has_absl_stringify.h"
+#include "absl/strings/has_ostream_operator.h"
 #include "absl/strings/string_view.h"
 
 // `ABSL_LOG_INTERNAL_STRIP_STRING_LITERAL` wraps string literals that
@@ -357,23 +358,26 @@ std::enable_if_t<HasAbslStringify<T>::value,
                  StringifyToStreamWrapper<T>>
 Detect(...);  // Ellipsis has lowest preference when int passed.
 
-// is_streamable is true for types that have an output stream operator<<.
-template <class T, class = void>
-struct is_streamable : std::false_type {};
-
-template <class T>
-struct is_streamable<T, std::void_t<decltype(std::declval<std::ostream&>()
-                                             << std::declval<T>())>>
-    : std::true_type {};
-
 // This overload triggers when T is neither possible to print nor an enum.
 template <typename T>
 std::enable_if_t<std::negation_v<std::disjunction<
                      std::is_convertible<T, int>, std::is_enum<T>,
                      std::is_pointer<T>, std::is_same<T, std::nullptr_t>,
-                     is_streamable<T>, HasAbslStringify<T>>>,
+                     HasOstreamOperator<T>, HasAbslStringify<T>>>,
                  UnprintableWrapper>
 Detect(...);
+
+// Equivalent to the updated std::underlying_type from C++20, which is no
+// longer undefined behavior for non-enum types.
+template <typename T, typename EnableT = void>
+struct UnderlyingType {};
+
+template <typename T>
+struct UnderlyingType<T, std::enable_if_t<std::is_enum_v<T>>> {
+  using type = std::underlying_type_t<T>;
+};
+template <typename T>
+using UnderlyingTypeT = typename UnderlyingType<T>::type;
 
 // This overload triggers when T is a scoped enum that has not defined an output
 // stream operator (operator<<) or AbslStringify. It causes the enum value to be
@@ -382,17 +386,17 @@ Detect(...);
 // one backed by another integer is converted to (u)int64_t.
 template <typename T>
 std::enable_if_t<
-    std::conjunction_v<
-        std::is_enum<T>, std::negation<std::is_convertible<T, int>>,
-        std::negation<is_streamable<T>>, std::negation<HasAbslStringify<T>>>,
-    std::conditional_t<
-        std::is_same_v<std::underlying_type_t<T>, bool> ||
-            std::is_same_v<std::underlying_type_t<T>, char> ||
-            std::is_same_v<std::underlying_type_t<T>, signed char> ||
-            std::is_same_v<std::underlying_type_t<T>, unsigned char>,
-        std::underlying_type_t<T>,
-        std::conditional_t<std::is_signed_v<std::underlying_type_t<T>>, int64_t,
-                           uint64_t>>>
+    std::conjunction_v<std::is_enum<T>,
+                       std::negation<std::is_convertible<T, int>>,
+                       std::negation<HasOstreamOperator<T>>,
+                       std::negation<HasAbslStringify<T>>>,
+    std::conditional_t<std::is_same_v<UnderlyingTypeT<T>, bool> ||
+                           std::is_same_v<UnderlyingTypeT<T>, char> ||
+                           std::is_same_v<UnderlyingTypeT<T>, signed char> ||
+                           std::is_same_v<UnderlyingTypeT<T>, unsigned char>,
+                       UnderlyingTypeT<T>,
+                       std::conditional_t<std::is_signed_v<UnderlyingTypeT<T>>,
+                                          int64_t, uint64_t>>>
 Detect(...);
 }  // namespace detect_specialization
 


### PR DESCRIPTION
* Fix `CHECK_<OP>` ambiguous overload for `operator<<` in older versions of GCC (ba9a180d22e62edcd5f6c56b50287b286f96fc33)
* Fix `CHECK_<OP>` compilation failures on older versions of GCC which eagerly tries to instantiate `std::underlying_type` for non-enum types (e8c1a5ff2346d40be5f2450044c01c845777cc02)
* Add missing rules_cc loads (2370ccf579bd0fb4484c343389b8121c6b7f9bb8)