### PR TITLE
Fix Clang warnings on powerpc

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -62,7 +62,7 @@ double UnscaledCycleClock::Frequency() {
 
 int64_t UnscaledCycleClock::Now() {
 #ifdef __GLIBC__
-  return __ppc_get_timebase();
+  return static_cast<int64_t>(__ppc_get_timebase());
 #else
 #ifdef __powerpc64__
   int64_t tbr;

--- a/absl/debugging/internal/stacktrace_powerpc-inl.inc
+++ b/absl/debugging/internal/stacktrace_powerpc-inl.inc
@@ -223,8 +223,8 @@ static int UnwindImpl(void **result, uintptr_t *frames, int *sizes,
         }
         if (sizes != nullptr) {
           if (next_sp > sp) {
-            sizes[n] = absl::debugging_internal::StripPointerMetadata(next_sp) -
-                       absl::debugging_internal::StripPointerMetadata(sp);
+            sizes[n] = static_cast<int>(absl::debugging_internal::StripPointerMetadata(next_sp) -
+                       absl::debugging_internal::StripPointerMetadata(sp));
           } else {
             // A frame-size of 0 is used to indicate unknown frame size.
             sizes[n] = 0;


### PR DESCRIPTION
We maintain the V8 Js Compiler on IBM platforms which uses abseil as a dependency. We have recently switched to using Clang and need to create this patch to fix two warnings:
```
warning: implicit conversion changes signedness: 'uint64_t' (aka 'unsigned long') to 'int64_t' (aka 'long') [-Wsign-conversion]
warning: implicit conversion loses integer precision: 'uintptr_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
```