### PR TITLE
Remove containers' dependency on cord library.

### DIFF
--- a/absl/container/BUILD.bazel
+++ b/absl/container/BUILD.bazel
@@ -451,7 +451,6 @@ cc_library(
         "//absl/hash",
         "//absl/meta:type_traits",
         "//absl/strings",
-        "//absl/strings:cord",
     ],
 )
 
@@ -1115,7 +1114,6 @@ cc_library(
         "//absl/memory",
         "//absl/meta:type_traits",
         "//absl/strings",
-        "//absl/strings:cord",
         "//absl/types:compare",
     ],
 )

--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -33,7 +33,6 @@ absl_cc_library(
     absl::config
     absl::container_common
     absl::container_memory
-    absl::cord
     absl::core_headers
     absl::layout
     absl::memory
@@ -503,7 +502,6 @@ absl_cc_library(
   DEPS
     absl::config
     absl::container_common
-    absl::cord
     absl::hash
     absl::strings
     absl::type_traits

--- a/absl/container/internal/btree.h
+++ b/absl/container/internal/btree.h
@@ -68,7 +68,7 @@
 #include "absl/container/internal/layout.h"
 #include "absl/memory/memory.h"
 #include "absl/meta/type_traits.h"
-#include "absl/strings/cord.h"
+#include "absl/strings/internal/cord_lookup_support.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/compare.h"
 
@@ -124,15 +124,18 @@ struct StringBtreeDefaultLess {
   StringBtreeDefaultLess(std::less<absl::Cord>) {}  // NOLINT
   absl::weak_ordering operator()(const absl::Cord &lhs,
                                  const absl::Cord &rhs) const {
-    return compare_internal::compare_result_as_ordering(lhs.Compare(rhs));
+    return compare_internal::compare_result_as_ordering(
+        cord_internal::CordCompare(lhs, rhs));
   }
   absl::weak_ordering operator()(const absl::Cord &lhs,
                                  absl::string_view rhs) const {
-    return compare_internal::compare_result_as_ordering(lhs.Compare(rhs));
+    return compare_internal::compare_result_as_ordering(
+        cord_internal::CordCompare(lhs, rhs));
   }
   absl::weak_ordering operator()(absl::string_view lhs,
                                  const absl::Cord &rhs) const {
-    return compare_internal::compare_result_as_ordering(-rhs.Compare(lhs));
+    return compare_internal::compare_result_as_ordering(
+        -cord_internal::CordCompare(rhs, lhs));
   }
 };
 
@@ -156,15 +159,18 @@ struct StringBtreeDefaultGreater {
   StringBtreeDefaultGreater(std::greater<absl::Cord>) {}  // NOLINT
   absl::weak_ordering operator()(const absl::Cord &lhs,
                                  const absl::Cord &rhs) const {
-    return compare_internal::compare_result_as_ordering(rhs.Compare(lhs));
+    return compare_internal::compare_result_as_ordering(
+        cord_internal::CordCompare(rhs, lhs));
   }
   absl::weak_ordering operator()(const absl::Cord &lhs,
                                  absl::string_view rhs) const {
-    return compare_internal::compare_result_as_ordering(-lhs.Compare(rhs));
+    return compare_internal::compare_result_as_ordering(
+        -cord_internal::CordCompare(lhs, rhs));
   }
   absl::weak_ordering operator()(absl::string_view lhs,
                                  const absl::Cord &rhs) const {
-    return compare_internal::compare_result_as_ordering(rhs.Compare(lhs));
+    return compare_internal::compare_result_as_ordering(
+        cord_internal::CordCompare(rhs, lhs));
   }
 };
 

--- a/absl/container/internal/hash_function_defaults.h
+++ b/absl/container/internal/hash_function_defaults.h
@@ -56,7 +56,7 @@
 #include "absl/container/internal/common.h"
 #include "absl/hash/hash.h"
 #include "absl/meta/type_traits.h"
-#include "absl/strings/cord.h"
+#include "absl/strings/internal/cord_lookup_support.h"
 #include "absl/strings/string_view.h"
 
 namespace absl {
@@ -77,7 +77,7 @@ struct StringHash {
     return absl::Hash<absl::string_view>{}(v);
   }
   size_t operator()(const absl::Cord& v) const {
-    return absl::Hash<absl::Cord>{}(v);
+    return cord_internal::HashOfCord(v);
   }
 
  private:
@@ -88,8 +88,7 @@ struct StringHash {
         absl::Hash<absl::string_view>{}, v, seed);
   }
   size_t hash_with_seed(const absl::Cord& v, size_t seed) const {
-    return absl::hash_internal::HashWithSeed().hash(absl::Hash<absl::Cord>{}, v,
-                                                    seed);
+    return cord_internal::HashOfCordWithSeed(v, seed);
   }
 };
 
@@ -99,13 +98,13 @@ struct StringEq {
     return lhs == rhs;
   }
   bool operator()(const absl::Cord& lhs, const absl::Cord& rhs) const {
-    return lhs == rhs;
+    return cord_internal::CordEquals(lhs, rhs);
   }
   bool operator()(const absl::Cord& lhs, absl::string_view rhs) const {
-    return lhs == rhs;
+    return cord_internal::CordEquals(lhs, rhs);
   }
   bool operator()(absl::string_view lhs, const absl::Cord& rhs) const {
-    return lhs == rhs;
+    return cord_internal::CordEquals(rhs, lhs);
   }
 };
 

--- a/absl/strings/BUILD.bazel
+++ b/absl/strings/BUILD.bazel
@@ -646,10 +646,12 @@ cc_library(
         "cord.cc",
         "cord_analysis.cc",
         "cord_analysis.h",
+        "internal/cord_lookup_support.cc",
     ],
     hdrs = [
         "cord.h",
         "cord_buffer.h",
+        "internal/cord_lookup_support.h",
     ],
     copts = ABSL_DEFAULT_COPTS,
     linkopts = ABSL_DEFAULT_LINKOPTS,

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -1034,10 +1034,12 @@ absl_cc_library(
   HDRS
     "cord.h"
     "cord_buffer.h"
+    "internal/cord_lookup_support.h"
   SRCS
     "cord.cc"
     "cord_analysis.cc"
     "cord_analysis.h"
+    "internal/cord_lookup_support.cc"
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS

--- a/absl/strings/internal/cord_lookup_support.cc
+++ b/absl/strings/internal/cord_lookup_support.cc
@@ -1,0 +1,47 @@
+// Copyright 2025 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/strings/internal/cord_lookup_support.h"
+
+#include "absl/hash/hash.h"
+#include "absl/strings/cord.h"
+#include "absl/strings/string_view.h"
+
+namespace absl {
+ABSL_NAMESPACE_BEGIN
+namespace cord_internal {
+
+size_t HashOfCord(const Cord& v) {
+  absl::Hash<Cord> hasher;
+  return hasher(v);
+}
+
+size_t HashOfCordWithSeed(const Cord& v, size_t seed) {
+  absl::Hash<Cord> hasher;
+  return absl::hash_internal::HashWithSeed().hash(hasher, v, seed);
+}
+
+bool CordEquals(const Cord& lhs, const Cord& rhs) { return lhs == rhs; }
+
+bool CordEquals(const Cord& lhs, absl::string_view rhs) { return lhs == rhs; }
+
+int CordCompare(const Cord& lhs, const Cord& rhs) { return lhs.Compare(rhs); }
+
+int CordCompare(const Cord& lhs, absl::string_view rhs) {
+  return lhs.Compare(rhs);
+}
+
+}  // namespace cord_internal
+ABSL_NAMESPACE_END
+}  // namespace absl

--- a/absl/strings/internal/cord_lookup_support.h
+++ b/absl/strings/internal/cord_lookup_support.h
@@ -1,0 +1,54 @@
+// Copyright 2025 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: cord_lookup_support.h
+// -----------------------------------------------------------------------------
+//
+// Functions to support heterogeneous lookup of `absL::Cord` values within
+// associative containers having string keys.
+
+#ifndef ABSL_STRINGS_INTERNAL_CORD_LOOKUP_SUPPORT_H_
+#define ABSL_STRINGS_INTERNAL_CORD_LOOKUP_SUPPORT_H_
+
+#include <stdint.h>
+
+#include "absl/base/config.h"
+#include "absl/strings/string_view.h"
+
+namespace absl {
+ABSL_NAMESPACE_BEGIN
+
+class Cord;
+
+namespace cord_internal {
+
+size_t HashOfCord(const Cord& v);
+
+size_t HashOfCordWithSeed(const Cord& v, size_t seed);
+
+bool CordEquals(const Cord& lhs, const Cord& rhs);
+
+bool CordEquals(const Cord& lhs, absl::string_view rhs);
+
+int CordCompare(const Cord& lhs, const Cord& rhs);
+
+int CordCompare(const Cord& lhs, absl::string_view rhs);
+
+}  // namespace cord_internal
+
+ABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // ABSL_STRINGS_INTERNAL_CORD_LOOKUP_SUPPORT_H_


### PR DESCRIPTION
Abseil associative containers having keys of a string type provide so-called heterogeneous lookup: they allow either `std::string`, `std::string_view`, or `absl::Cord` values in lookup.

On the other hand, using either of associative containers should not require compiling the cord library unless the use of `absl::Cord` is explicitly requested.

The solution is to forward-declare `absl::Cord` and a few functions just to support heterogeneous lookup, make the associative containers use these functions only, and require users of `absl::Cord` to link with the cord library explicitly.

fixes #1868
