### PR TITLE
fix(wasi): update wasi stubs

### DIFF
--- a/absl/base/internal/low_level_alloc.cc
+++ b/absl/base/internal/low_level_alloc.cc
@@ -659,3 +659,48 @@ ABSL_NAMESPACE_END
 }  // namespace absl
 
 #endif  // ABSL_LOW_LEVEL_ALLOC_MISSING
+
+// WASI stubs: WASI doesn't have mmap, so use malloc/free instead
+#if defined(__wasi__)
+
+namespace absl {
+ABSL_NAMESPACE_BEGIN
+namespace base_internal {
+
+void *LowLevelAlloc::Alloc(size_t request) {
+  return malloc(request);
+}
+
+void LowLevelAlloc::Free(void *v) {
+  free(v);
+}
+
+void *LowLevelAlloc::AllocWithArena(size_t request, Arena* /*arena*/) {
+  // Ignore arena parameter and use malloc
+  return malloc(request);
+}
+
+LowLevelAlloc::Arena *LowLevelAlloc::DefaultArena() {
+  return nullptr;
+}
+
+LowLevelAlloc::Arena *LowLevelAlloc::NewArena(uint32_t /*flags*/) {
+  return nullptr;
+}
+
+bool LowLevelAlloc::DeleteArena(Arena* /*arena*/) {
+  return true;
+}
+
+LowLevelAlloc::Arena *SigSafeArena() {
+  // Return nullptr - arenas are ignored in WASI's AllocWithArena
+  return nullptr;
+}
+
+void InitSigSafeArena() {}
+
+}  // namespace base_internal
+ABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // __wasi__

--- a/absl/base/internal/low_level_alloc.h
+++ b/absl/base/internal/low_level_alloc.h
@@ -36,6 +36,8 @@
 // LowLevelAlloc.
 #ifdef ABSL_LOW_LEVEL_ALLOC_MISSING
 #error ABSL_LOW_LEVEL_ALLOC_MISSING cannot be directly set
+#elif defined(__wasi__)
+#define ABSL_LOW_LEVEL_ALLOC_MISSING 1
 #elif !defined(ABSL_HAVE_MMAP) && !defined(_WIN32)
 #define ABSL_LOW_LEVEL_ALLOC_MISSING 1
 #endif

--- a/absl/synchronization/internal/create_thread_identity.cc
+++ b/absl/synchronization/internal/create_thread_identity.cc
@@ -150,3 +150,24 @@ ABSL_NAMESPACE_END
 }  // namespace absl
 
 #endif  // ABSL_LOW_LEVEL_ALLOC_MISSING
+
+// WASI stubs: WASI is single-threaded, use a static identity
+#if defined(__wasi__)
+
+#include "absl/base/internal/thread_identity.h"
+
+namespace absl {
+ABSL_NAMESPACE_BEGIN
+namespace synchronization_internal {
+
+static base_internal::ThreadIdentity g_wasi_thread_identity = {};
+
+base_internal::ThreadIdentity* CreateThreadIdentity() {
+  return &g_wasi_thread_identity;
+}
+
+}  // namespace synchronization_internal
+ABSL_NAMESPACE_END
+}  // namespace absl
+
+#endif  // __wasi__

--- a/absl/synchronization/internal/per_thread_sem.cc
+++ b/absl/synchronization/internal/per_thread_sem.cc
@@ -104,3 +104,29 @@ ABSL_ATTRIBUTE_WEAK bool ABSL_INTERNAL_C_SYMBOL(AbslInternalPerThreadSemWait)(
 }  // extern "C"
 
 #endif  // ABSL_LOW_LEVEL_ALLOC_MISSING
+
+// WASI stubs: WASI is single-threaded, so these are no-ops
+#if defined(__wasi__)
+
+#include "absl/base/attributes.h"
+#include "absl/synchronization/internal/per_thread_sem.h"
+
+extern "C" {
+
+void ABSL_INTERNAL_C_SYMBOL(AbslInternalPerThreadSemInit)(
+    absl::base_internal::ThreadIdentity* /*identity*/) {}
+
+void ABSL_INTERNAL_C_SYMBOL(AbslInternalPerThreadSemPost)(
+    absl::base_internal::ThreadIdentity* /*identity*/) {}
+
+void ABSL_INTERNAL_C_SYMBOL(AbslInternalPerThreadSemPoke)(
+    absl::base_internal::ThreadIdentity* /*identity*/) {}
+
+bool ABSL_INTERNAL_C_SYMBOL(AbslInternalPerThreadSemWait)(
+    absl::synchronization_internal::KernelTimeout /*t*/) {
+  return true;
+}
+
+}  // extern "C"
+
+#endif  // __wasi__


### PR DESCRIPTION
Today, WASI does not support atomics. Support for WASI in Abseil was added in #1509 and needs to be refreshed.

Note that there is a roadmap item for wasi that will give us access to atomics via the component model's [cooperative threads](https://github.com/WebAssembly/component-model/pull/557) feature. Implementations are in progress but this may take a few months and so in the mean time, we need this fix.

I created an example with the necessary stubs that are missing from upstream abseil and validated that these can be removed with the changes in this PR: https://github.com/ricochet/wasi-protobuf/blob/main/wasi-build/wasi_stubs.cpp
