### PR TITLE
disable leak sanitizer on clang/windows

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -696,7 +696,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 // Clang standalone LeakSanitizer (-fsanitize=leak)
 #elif ABSL_HAVE_FEATURE(leak_sanitizer)
 #define ABSL_HAVE_LEAK_SANITIZER 1
-#elif defined(ABSL_HAVE_ADDRESS_SANITIZER)
+#elif defined(ABSL_HAVE_ADDRESS_SANITIZER) && !defined(_WIN32)
 // GCC or Clang using the LeakSanitizer integrated into AddressSanitizer.
 #define ABSL_HAVE_LEAK_SANITIZER 1
 #endif


### PR DESCRIPTION
leak sanitizer is not supported on windows, when compiling with clang on window we get:

```
lld-link: error: undefined symbol: __lsan_do_recoverable_leak_check
>>> referenced by abseil-cpp\absl\debugging\leak_check.cc:46
```


