### PR TITLE
Revert "Skip the .exe suffix in the helpshort filter on Windows"

### DIFF
--- a/absl/flags/usage_config.cc
+++ b/absl/flags/usage_config.cc
@@ -53,15 +53,10 @@ namespace {
 bool ContainsHelpshortFlags(absl::string_view filename) {
   // By default we only want flags in binary's main. We expect the main
   // routine to reside in <program>.cc or <program>-main.cc or
-  // <program>_main.cc, where the <program> is the name of the binary
-  // (without .exe on Windows).
+  // <program>_main.cc, where the <program> is the name of the binary.
   auto suffix = flags_internal::Basename(filename);
-  auto program_name = flags_internal::ShortProgramInvocationName();
-  absl::string_view program_name_ref = program_name;
-#if defined(_WIN32)
-  absl::ConsumeSuffix(&program_name_ref, ".exe");
-#endif
-  if (!absl::ConsumePrefix(&suffix, program_name_ref))
+  if (!absl::ConsumePrefix(&suffix,
+                           flags_internal::ShortProgramInvocationName()))
     return false;
   return absl::StartsWith(suffix, ".") || absl::StartsWith(suffix, "-main.") ||
          absl::StartsWith(suffix, "_main.");

--- a/absl/flags/usage_config_test.cc
+++ b/absl/flags/usage_config_test.cc
@@ -84,11 +84,7 @@ TEST_F(FlagsUsageConfigTest, TestGetSetFlagsUsageConfig) {
 // --------------------------------------------------------------------
 
 TEST_F(FlagsUsageConfigTest, TestContainsHelpshortFlags) {
-#if defined(_WIN32)
-  flags::SetProgramInvocationName("usage_config_test.exe");
-#else
   flags::SetProgramInvocationName("usage_config_test");
-#endif
 
   auto config = flags::GetUsageConfig();
   EXPECT_TRUE(config.contains_helpshort_flags("adir/cd/usage_config_test.cc"));


### PR DESCRIPTION
Reverts abseil/abseil-cpp#62

 
Y9[]
[UNI-opensuse-leap.sh](https://github.com/user-attachments/files/24701163/UNI-opensuse-leap.sh)
(url)