### PR TITLE
Construct {flat,node}_hash_{set,map} w/ from_range

### DIFF
--- a/absl/container/flat_hash_map.h
+++ b/absl/container/flat_hash_map.h
@@ -181,6 +181,11 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_map
   //
   //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
   //   absl::flat_hash_map<int, std::string> map7(v.begin(), v.end());
+  //
+  // * from_range constructor (C++23)
+  //
+  //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
+  //   absl::flat_hash_map<int, std::string> map8(std::from_range, v);
   flat_hash_map() {}
   using Base::Base;
 

--- a/absl/container/flat_hash_map_test.cc
+++ b/absl/container/flat_hash_map_test.cc
@@ -21,6 +21,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(__cplusplus) && __cplusplus >= 202302L
+#include <ranges>
+#endif
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/base/config.h"
@@ -444,6 +448,14 @@ TEST(Iterator, InconsistentHashEqFunctorsValidation) {
 #endif
   EXPECT_DEATH_IF_SUPPORTED(insert_conflicting_elems(), crash_message);
 }
+
+#if defined(__cplusplus) && __cplusplus >= 202302L
+TEST(FlatHashMap, FromRange) {
+  std::vector<std::pair<int, int>> v = {{1, 2}, {3, 4}, {5, 6}};
+  absl::flat_hash_map<int, int> m(std::from_range, v);
+  EXPECT_THAT(m, UnorderedElementsAre(Pair(1, 2), Pair(3, 4), Pair(5, 6)));
+}
+#endif
 
 }  // namespace
 }  // namespace container_internal

--- a/absl/container/flat_hash_set.h
+++ b/absl/container/flat_hash_set.h
@@ -177,6 +177,11 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_set
   //
   //   std::vector<std::string> v = {"a", "b"};
   //   absl::flat_hash_set<std::string> set7(v.begin(), v.end());
+  //
+  // * from_range constructor (C++23)
+  //
+  //   std::vector<std::string> v = {"a", "b"};
+  //   absl::flat_hash_set<std::string> set8(std::from_range, v);
   flat_hash_set() {}
   using Base::Base;
 

--- a/absl/container/flat_hash_set_test.cc
+++ b/absl/container/flat_hash_set_test.cc
@@ -22,6 +22,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(__cplusplus) && __cplusplus >= 202302L
+#include <ranges>
+#endif
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/base/config.h"
@@ -394,6 +398,14 @@ TEST(FlatHashSet, IsDefaultHash) {
   EXPECT_EQ((HashtableDebugAccess<flat_hash_set<size_t, Hash>>::kIsDefaultHash),
             false);
 }
+
+#if defined(__cplusplus) && __cplusplus >= 202302L
+TEST(FlatHashSet, FromRange) {
+  std::vector<int> v = {1, 2, 3, 4, 5};
+  absl::flat_hash_set<int> s(std::from_range, v);
+  EXPECT_THAT(s, UnorderedElementsAre(1, 2, 3, 4, 5));
+}
+#endif
 
 }  // namespace
 }  // namespace container_internal

--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -2149,6 +2149,15 @@ class raw_hash_set {
                const allocator_type& alloc)
       : raw_hash_set(first, last, bucket_count, hasher(), key_equal(), alloc) {}
 
+#if defined(__cplusplus) && __cplusplus >= 202302L
+  template <typename R>
+  raw_hash_set(std::from_range_t, R&& rg, size_type bucket_count = 0,
+               const hasher& hash = hasher(), const key_equal& eq = key_equal(),
+               const allocator_type& alloc = allocator_type())
+      : raw_hash_set(std::begin(rg), std::end(rg), bucket_count, hash, eq,
+                     alloc) {}
+#endif
+
   template <class InputIter>
   raw_hash_set(InputIter first, InputIter last, const allocator_type& alloc)
       : raw_hash_set(first, last, 0, hasher(), key_equal(), alloc) {}

--- a/absl/container/node_hash_map.h
+++ b/absl/container/node_hash_map.h
@@ -177,6 +177,11 @@ class ABSL_ATTRIBUTE_OWNER node_hash_map
   //
   //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
   //   absl::node_hash_map<int, std::string> map7(v.begin(), v.end());
+  //
+  // * from_range constructor (C++23)
+  //
+  //   std::vector<std::pair<int, std::string>> v = {{1, "a"}, {2, "b"}};
+  //   absl::node_hash_map<int, std::string> map8(std::from_range, v);
   node_hash_map() {}
   using Base::Base;
 

--- a/absl/container/node_hash_map_test.cc
+++ b/absl/container/node_hash_map_test.cc
@@ -22,6 +22,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(__cplusplus) && __cplusplus >= 202302L
+#include <ranges>
+#endif
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/base/config.h"
@@ -341,6 +345,14 @@ TEST(NodeHashMap, RecursiveTypeCompiles) {
   RecursiveType t;
   t.m[0] = RecursiveType{};
 }
+
+#if defined(__cplusplus) && __cplusplus >= 202302L
+TEST(NodeHashMap, FromRange) {
+  std::vector<std::pair<int, int>> v = {{1, 2}, {3, 4}, {5, 6}};
+  absl::node_hash_map<int, int> m(std::from_range, v);
+  EXPECT_THAT(m, UnorderedElementsAre(Pair(1, 2), Pair(3, 4), Pair(5, 6)));
+}
+#endif
 
 }  // namespace
 }  // namespace container_internal

--- a/absl/container/node_hash_set.h
+++ b/absl/container/node_hash_set.h
@@ -171,6 +171,11 @@ class ABSL_ATTRIBUTE_OWNER node_hash_set
   //
   //   std::vector<std::string> v = {"a", "b"};
   //   absl::node_hash_set<std::string> set7(v.begin(), v.end());
+  //
+  // * from_range constructor (C++23)
+  //
+  //   std::vector<std::string> v = {"a", "b"};
+  //   absl::node_hash_set<std::string> set8(std::from_range, v);
   node_hash_set() {}
   using Base::Base;
 

--- a/absl/container/node_hash_set_test.cc
+++ b/absl/container/node_hash_set_test.cc
@@ -20,6 +20,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(__cplusplus) && __cplusplus >= 202302L
+#include <ranges>
+#endif
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/base/config.h"
@@ -181,6 +185,14 @@ TEST(NodeHashSet, CForEach) {
     expected.emplace_back(i, i);
   }
 }
+
+#if defined(__cplusplus) && __cplusplus >= 202302L
+TEST(NodeHashSet, FromRange) {
+  std::vector<int> v = {1, 2, 3, 4, 5};
+  absl::node_hash_set<int> s(std::from_range, v);
+  EXPECT_THAT(s, UnorderedElementsAre(1, 2, 3, 4, 5));
+}
+#endif
 
 }  // namespace
 }  // namespace container_internal


### PR DESCRIPTION
Adds constructors accepting std::from_range if building with C++23. See https://en.cppreference.com/w/cpp/ranges/from_range.html for context.