### PR TITLE
strings: fix data corruption in Base64Escape due to aliasing

### DIFF
--- a/absl/strings/escaping.cc
+++ b/absl/strings/escaping.cc
@@ -954,17 +954,14 @@ bool WebSafeBase64Unescape(absl::string_view src,
   return Base64UnescapeInternal(src.data(), src.size(), dest, kUnWebSafeBase64);
 }
 
+
 void Base64Escape(absl::string_view src, std::string* absl_nonnull dest) {
-  strings_internal::Base64EscapeInternal(
-      reinterpret_cast<const unsigned char*>(src.data()), src.size(), dest,
-      true, strings_internal::kBase64Chars);
+    *dest = Base64Escape(src);
 }
 
 void WebSafeBase64Escape(absl::string_view src,
                          std::string* absl_nonnull dest) {
-  strings_internal::Base64EscapeInternal(
-      reinterpret_cast<const unsigned char*>(src.data()), src.size(), dest,
-      false, strings_internal::kWebSafeBase64Chars);
+    *dest = WebSafeBase64Escape(src);
 }
 
 std::string Base64Escape(absl::string_view src) {

--- a/absl/strings/escaping_test.cc
+++ b/absl/strings/escaping_test.cc
@@ -762,4 +762,12 @@ TEST(HexAndBack, HexStringToBytes_and_BytesToHexString) {
   EXPECT_EQ(hex_only_lower, hex_result);
 }
 
+TEST(Base64Escape, AliasingSafety){
+    std::string s = "Abseil";
+    absl::Base64Escape(s, &s);
+    // would corrupt or crash before fix
+    // after fix: s should be "QWJzZWls"
+    EXPECT_EQ(s, "QWJzZWls");
+}
+
 }  // namespace


### PR DESCRIPTION
Description:
Addressed a data corruption bug in the pointer-based overloads of Base64Escape and WebSafeBase64Escape.
For a full description (as well as comments that led me to the solution), see: https://github.com/abseil/abseil-cpp/issues/2015

The Problem:
When the input string_view aliases the destination std::string, the internal implementation can _potentially_ overwrite the source data before the encoding is complete, leading to corrupted output / undefined behavior.

The Fix:
Modified the implementation to route these calls through the string-returning overloads.

Testing:
Added a regression test Base64Escape.AliasingSafety in absl/strings/escaping_test.cc. Verified passing with bazel test //absl/strings:escaping_test.

