### PR TITLE
Recognize `clang` targeting Windows as "MinGW like"

### DIFF
--- a/absl/BUILD.bazel
+++ b/absl/BUILD.bazel
@@ -52,11 +52,23 @@ config_setting(
     visibility = [":__subpackages__"],
 )
 
+config_setting(
+    name = "windows-clang",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "clang",
+    },
+    visibility = [":__subpackages__"],
+)
+
 selects.config_setting_group(
     name = "mingw_compiler",
     match_any = [
         ":mingw_unspecified_compiler",
         ":mingw-gcc_compiler",
+        ":windows-clang",
     ],
     visibility = [":__subpackages__"],
 )


### PR DESCRIPTION
This is necessary to get abseil to build with https://github.com/cerisier/toolchains_llvm_bootstrapped. The old mappings for MinGW are arguably not semantically correct as MinGW is the runtime/sysroot, not the compiler, but are left in place for backwards compatibility.

