### PR TITLE
docs: clarify rehash guarantees for reserve() in Swiss Tables

### DIFF
--- a/absl/container/flat_hash_map.h
+++ b/absl/container/flat_hash_map.h
@@ -472,8 +472,13 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_map
   // Sets the number of slots in the `flat_hash_map` to the number needed to
   // accommodate at least `count` total elements without exceeding the current
   // maximum load factor, and may rehash the container if needed. After this
-  // returns, it is guaranteed that `count - size()` elements can be inserted
-  // into the `flat_hash_map` without another rehash.
+  // returns, it is guaranteed that `count - size()` consecutive elements can
+  // be inserted into the `flat_hash_map` without another rehash.
+  //
+  // NOTE: This guarantee only applies to consecutive insertions. Because of
+  // probing requirements, erased slots may still occupy capacity from the
+  // perspective of needing a rehash. Therefore, interleaving insertions and
+  // erasures may trigger a compacting rehash.
   using Base::reserve;
 
   // flat_hash_map::at()

--- a/absl/container/flat_hash_set.h
+++ b/absl/container/flat_hash_set.h
@@ -406,8 +406,13 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_set
   // Sets the number of slots in the `flat_hash_set` to the number needed to
   // accommodate at least `count` total elements without exceeding the current
   // maximum load factor, and may rehash the container if needed. After this
-  // returns, it is guaranteed that `count - size()` elements can be inserted
-  // into the `flat_hash_set` without another rehash.
+  // returns, it is guaranteed that `count - size()` consecutive elements can
+  // be inserted into the `flat_hash_set` without another rehash.
+  //
+  // NOTE: This guarantee only applies to consecutive insertions. Because of
+  // probing requirements, erased slots may still occupy capacity from the
+  // perspective of needing a rehash. Therefore, interleaving insertions and
+  // erasures may trigger a compacting rehash.
   using Base::reserve;
 
   // flat_hash_set::contains()


### PR DESCRIPTION
Updates the documentation for flat_hash_set and flat_hash_map reserve() functions to explicitly state that erased elements may still occupy capacity due to probing requirements, and that interleaving insertions and erasures may trigger a compacting rehash.

Fixes #906
