### PR TITLE
fix: add HaikuOS support for GetTID() in sysinfo.cc

### DIFF
--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -50,6 +50,10 @@
 #include <zircon/process.h>
 #endif
 
+#if defined(__HAIKU__)
+#include <OS.h>
+#endif
+
 #include <string.h>
 
 #include <cassert>
@@ -465,6 +469,10 @@ pid_t GetTID() {
   // pid_t type without loss of precision, but a zx_koid_t (64-bits) cannot.
   return static_cast<pid_t>(zx_thread_self());
 }
+
+#elif defined(__HAIKU__)
+
+pid_t GetTID() { return find_thread(NULL); }
 
 #else
 


### PR DESCRIPTION
Add a platform-specific GetTID() implementation for HaikuOS using Haiku's native find_thread(NULL) API, which returns the current thread's ID. Without this, HaikuOS falls through to the generic pthread_self() fallback which causes a compilation failure due to type incompatibility.

Fixes #1981

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
