### PR TITLE
Fix MSVC warning C4819 in nullability.h

### DIFF
--- a/absl/base/nullability.h
+++ b/absl/base/nullability.h
@@ -95,7 +95,7 @@
 // // describes is preferred, unless inconsistent with surrounding code.
 // absl_nonnull std::unique_ptr<Employee> employee;
 //
-// // Invalid annotation usage – this attempts to declare a pointer to a
+// // Invalid annotation usage - this attempts to declare a pointer to a
 // // nullable `Employee`, which is meaningless.
 // absl_nullable Employee* e;
 //
@@ -204,7 +204,7 @@
 //     T* absl_nullable GetNullablePtr();           // explicitly nullable
 //     T* absl_nullability_unknown GetUnknownPtr();  // explicitly unknown
 //
-// The macro can be safely used in header files – it will not affect any files
+// The macro can be safely used in header files - it will not affect any files
 // that include it.
 //
 // In files with the macro, plain `T*` syntax means `T* absl_nonnull`, and the


### PR DESCRIPTION
Changed EN DASH "–"(U+2013) to hyphen (U+002D) in comment, because warning C4819 occurred in Japanese language environment MSVC 2026.