### PR TITLE
Fix MSVC warning C4819 in discrete_distribution.h

### DIFF
--- a/absl/random/discrete_distribution.h
+++ b/absl/random/discrete_distribution.h
@@ -38,7 +38,7 @@ ABSL_NAMESPACE_BEGIN
 // A discrete distribution produces random integers i, where 0 <= i < n
 // distributed according to the discrete probability function:
 //
-//     P(i|p0,...,pn−1)=pi
+//     P(i|p0,...,pn-1)=pi
 //
 // This class is an implementation of discrete_distribution (see
 // [rand.dist.samp.discrete]).


### PR DESCRIPTION
Changed MINUS SIGN "−"(U+2212) to hyphen (U+002D) in comment, because warning C4819 occurred in Japanese language environment MSVC 2026.