### PR TITLE
Remove C++11 style factory function in absl::Cleanup

### DIFF
--- a/absl/cleanup/cleanup.h
+++ b/absl/cleanup/cleanup.h
@@ -16,58 +16,81 @@
 // File: cleanup.h
 // -----------------------------------------------------------------------------
 //
-// `absl::Cleanup` implements the scope guard idiom, invoking the contained
-// callback's `operator()() &&` on scope exit.
+// `absl::Cleanup` implements the scope guard idiom. On scope exit, it invokes
+// the contained callback via `std::move(callback)();`.
 //
-// This class doesn't allocate or take any locks, and is safe to use in a signal
-// handler. Of course the callback with which it is constructed also must be
-// signal safe in order for this to be useful.
+// By design, the implementation does not allocate, take any locks or otherwise
+// acquire resources. It is safe to use `absl::Cleanup` in a signal
+// handler, assuming the underlying callback is itself signal safe.
 //
 // Example:
 //
 // ```
-//   absl::Status CopyGoodData(const char* source_path, const char* sink_path) {
-//     FILE* source_file = fopen(source_path, "r");
-//     if (source_file == nullptr) {
-//       return absl::NotFoundError("No source file");  // No cleanups execute
+//   absl::Status CopyGoodData(const std::string& src_path,
+//                             const std::string& sink_path) {
+//     std::FILE* src_file = std::fopen(src_path.c_str(), "r");
+//     if (src_file == nullptr) {
+//       absl::Status result = absl::NotFoundError("No source file");
+//       return result;  // Zero cleanups execute
 //     }
 //
-//     // C++17 style cleanup using class template argument deduction
-//     absl::Cleanup source_closer = [source_file] { fclose(source_file); };
+//     // Ensure the source file is closed on scope exit...
+//     absl::Cleanup src_closer = [src_file] { std::fclose(src_file); };
 //
-//     FILE* sink_file = fopen(sink_path, "w");
+//     std::FILE* sink_file = std::fopen(sink_path.c_str(), "w");
 //     if (sink_file == nullptr) {
-//       return absl::NotFoundError("No sink file");  // First cleanup executes
+//       absl::Status result = absl::NotFoundError("No sink file");
+//       return result;  // First cleanup executes
 //     }
 //
-//     // C++11 style cleanup using the factory function
-//     auto sink_closer = absl::MakeCleanup([sink_file] { fclose(sink_file); });
+//     // Ensure the sink file is closed on scope exit...
+//     absl::Cleanup sink_closer = [sink_file] { std::fclose(sink_file); };
 //
-//     Data data;
-//     while (ReadData(source_file, &data)) {
+//     example::Data data;
+//     while (example::ReadData(src_file, &data)) {
 //       if (!data.IsGood()) {
 //         absl::Status result = absl::FailedPreconditionError("Read bad data");
 //         return result;  // Both cleanups execute
 //       }
-//       SaveData(sink_file, &data);
+//       example::SaveData(sink_file, &data);
 //     }
 //
 //     return absl::OkStatus();  // Both cleanups execute
 //   }
 // ```
 //
-// Methods:
-//
-// `std::move(cleanup).Cancel()` will prevent the callback from executing.
-//
-// `std::move(cleanup).Invoke()` will execute the callback early, before
-// destruction, and prevent the callback from executing in the destructor.
-//
 // Usage:
 //
+// Refraining from calling any methods will...
+// - Result in the callback being called when the `absl::Cleanup` goes out of
+//   scope.
+// - Leverage compiler constant folding to remove the runtime branch that checks
+//   whether the callback is engaged. If you do not touch the cleanup object
+//   after initialization, it should provide performance on par with a control
+//   flow construct such as the `defer` found in Zig. Please file a bug if you
+//   observe otherwise.
+//
+// Calls to `std::move(cleanup).Cancel();` will...
+// - Destroy the callback immediately.
+// - Disengage the callback, meaning that when the `absl::Cleanup` goes out of
+//   scope, the callback will not be called.
+//
+// Calls to `std::move(cleanup).Invoke();` will...
+// - Invoke the callback immediately.
+// - Destroy the callback as soon as the immediate invocation completes.
+// - Disengage the callback, meaning that when the `absl::Cleanup` goes out of
+//   scope, the callback will not be called.
+//
+// Note:
+//
 // `absl::Cleanup` is not an interface type. It is only intended to be used
-// within the body of a function. It is not a value type and instead models a
-// control flow construct. Check out `defer` in Golang for something similar.
+// within the body of a function. Please refrain from using it as a continuation
+// passing mechanism.
+//
+// The use of `std::move(cleanup).MyMethod()` as ceremony to invoke the methods
+// is intended to leverage existing best-effort tools that detect normal
+// use-after-move. The implementation is not equipped to handle multiple method
+// calls and thus has the same semantics the tools already diagnose.
 
 #ifndef ABSL_CLEANUP_CLEANUP_H_
 #define ABSL_CLEANUP_CLEANUP_H_
@@ -90,25 +113,41 @@ class [[nodiscard]] Cleanup final {
                 "Callbacks that return values are not supported.");
 
  public:
-  Cleanup(Callback callback) : storage_(std::move(callback)) {}  // NOLINT
+  // NOLINTBEGIN(google-explicit-constructor)
+  Cleanup(Callback callback) {  // NOLINT(runtime/explicit)
+    storage_.EmplaceCallback(std::move(callback));
+    storage_.EngageCallback();
+  }
+  // NOLINTEND(google-explicit-constructor)
 
-  Cleanup(Cleanup&& other) = default;
+  Cleanup(Cleanup&& other) {
+    ABSL_HARDENING_ASSERT(other.storage_.IsCallbackEngaged());
+    cleanup_internal::Defer last_step = [&] {
+      other.storage_.DestroyCallback();
+    };
+    other.storage_.DisengageCallback();
+    storage_.EmplaceCallback(std::move(other.storage_.GetCallback()));
+    storage_.EngageCallback();
+  }
 
   void Cancel() && {
     ABSL_HARDENING_ASSERT(storage_.IsCallbackEngaged());
-    storage_.DestroyCallback();
+    cleanup_internal::Defer last_step = [&] { storage_.DestroyCallback(); };
+    storage_.DisengageCallback();
   }
 
   void Invoke() && {
     ABSL_HARDENING_ASSERT(storage_.IsCallbackEngaged());
+    cleanup_internal::Defer last_step = [&] { storage_.DestroyCallback(); };
+    storage_.DisengageCallback();
     storage_.InvokeCallback();
-    storage_.DestroyCallback();
   }
 
   ~Cleanup() {
     if (storage_.IsCallbackEngaged()) {
+      cleanup_internal::Defer last_step = [&] { storage_.DestroyCallback(); };
+      storage_.DisengageCallback();
       storage_.InvokeCallback();
-      storage_.DestroyCallback();
     }
   }
 
@@ -118,23 +157,10 @@ class [[nodiscard]] Cleanup final {
 
 // `absl::Cleanup c = /* callback */;`
 //
-// C++17 type deduction API for creating an instance of `absl::Cleanup`
+// Explicit deduction guides signal to tooling that this type actively and
+// intentionally supports Class Template Argument Deduction.
 template <typename Callback>
 Cleanup(Callback callback) -> Cleanup<cleanup_internal::Tag, Callback>;
-
-// `auto c = absl::MakeCleanup(/* callback */);`
-//
-// C++11 type deduction API for creating an instance of `absl::Cleanup`
-template <typename... Args, typename Callback>
-absl::Cleanup<cleanup_internal::Tag, Callback> MakeCleanup(Callback callback) {
-  static_assert(cleanup_internal::WasDeduced<cleanup_internal::Tag, Args...>(),
-                "Explicit template parameters are not supported.");
-
-  static_assert(cleanup_internal::ReturnsVoid<Callback>(),
-                "Callbacks that return values are not supported.");
-
-  return {std::move(callback)};
-}
 
 ABSL_NAMESPACE_END
 }  // namespace absl

--- a/absl/cleanup/cleanup_test.cc
+++ b/absl/cleanup/cleanup_test.cc
@@ -26,9 +26,9 @@ namespace {
 
 using Tag = absl::cleanup_internal::Tag;
 
-template <typename Type1, typename Type2>
-constexpr bool IsSame() {
-  return (std::is_same<Type1, Type2>::value);
+template <typename ExpectedType, typename ActualType>
+constexpr bool IsSameType(const ActualType&) {
+  return (std::is_same<ExpectedType, ActualType>::value);
 }
 
 struct IdentityFactory {
@@ -91,98 +91,28 @@ TYPED_TEST_SUITE(CleanupTest, CleanupTestParams);
 bool fn_ptr_called = false;
 void FnPtrFunction() { fn_ptr_called = true; }
 
-TYPED_TEST(CleanupTest, FactoryProducesCorrectType) {
-  {
-    auto callback = TypeParam::AsCallback([] {});
-    auto cleanup = absl::MakeCleanup(std::move(callback));
-
-    static_assert(
-        IsSame<absl::Cleanup<Tag, decltype(callback)>, decltype(cleanup)>(),
-        "");
-  }
-
-  {
-    auto cleanup = absl::MakeCleanup(&FnPtrFunction);
-
-    static_assert(IsSame<absl::Cleanup<Tag, void (*)()>, decltype(cleanup)>(),
-                  "");
-  }
-
-  {
-    auto cleanup = absl::MakeCleanup(FnPtrFunction);
-
-    static_assert(IsSame<absl::Cleanup<Tag, void (*)()>, decltype(cleanup)>(),
-                  "");
-  }
-}
-
 TYPED_TEST(CleanupTest, CTADProducesCorrectType) {
   {
     auto callback = TypeParam::AsCallback([] {});
-    absl::Cleanup cleanup = std::move(callback);
 
-    static_assert(
-        IsSame<absl::Cleanup<Tag, decltype(callback)>, decltype(cleanup)>(),
-        "");
+    using Expected = absl::Cleanup<Tag, decltype(callback)>;
+    absl::Cleanup actual = std::move(callback);
+
+    static_assert(IsSameType<Expected>(actual));
   }
 
   {
-    absl::Cleanup cleanup = &FnPtrFunction;
+    using Expected = absl::Cleanup<Tag, void (*)()>;
+    absl::Cleanup actual = &FnPtrFunction;
 
-    static_assert(IsSame<absl::Cleanup<Tag, void (*)()>, decltype(cleanup)>(),
-                  "");
+    static_assert(IsSameType<Expected>(actual));
   }
 
   {
-    absl::Cleanup cleanup = FnPtrFunction;
+    using Expected = absl::Cleanup<Tag, void (*)()>;
+    absl::Cleanup actual = FnPtrFunction;
 
-    static_assert(IsSame<absl::Cleanup<Tag, void (*)()>, decltype(cleanup)>(),
-                  "");
-  }
-}
-
-TYPED_TEST(CleanupTest, FactoryAndCTADProduceSameType) {
-  {
-    auto callback = IdentityFactory::AsCallback([] {});
-    auto factory_cleanup = absl::MakeCleanup(callback);
-    absl::Cleanup deduction_cleanup = callback;
-
-    static_assert(
-        IsSame<decltype(factory_cleanup), decltype(deduction_cleanup)>(), "");
-  }
-
-  {
-    auto factory_cleanup =
-        absl::MakeCleanup(FunctorClassFactory::AsCallback([] {}));
-    absl::Cleanup deduction_cleanup = FunctorClassFactory::AsCallback([] {});
-
-    static_assert(
-        IsSame<decltype(factory_cleanup), decltype(deduction_cleanup)>(), "");
-  }
-
-  {
-    auto factory_cleanup =
-        absl::MakeCleanup(StdFunctionFactory::AsCallback([] {}));
-    absl::Cleanup deduction_cleanup = StdFunctionFactory::AsCallback([] {});
-
-    static_assert(
-        IsSame<decltype(factory_cleanup), decltype(deduction_cleanup)>(), "");
-  }
-
-  {
-    auto factory_cleanup = absl::MakeCleanup(&FnPtrFunction);
-    absl::Cleanup deduction_cleanup = &FnPtrFunction;
-
-    static_assert(
-        IsSame<decltype(factory_cleanup), decltype(deduction_cleanup)>(), "");
-  }
-
-  {
-    auto factory_cleanup = absl::MakeCleanup(FnPtrFunction);
-    absl::Cleanup deduction_cleanup = FnPtrFunction;
-
-    static_assert(
-        IsSame<decltype(factory_cleanup), decltype(deduction_cleanup)>(), "");
+    static_assert(IsSameType<Expected>(actual));
   }
 }
 
@@ -190,8 +120,7 @@ TYPED_TEST(CleanupTest, BasicUsage) {
   bool called = false;
 
   {
-    auto cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback([&called] { called = true; }));
+    absl::Cleanup cleanup = TypeParam::AsCallback([&called] { called = true; });
     EXPECT_FALSE(called);  // Constructor shouldn't invoke the callback
   }
 
@@ -202,7 +131,7 @@ TYPED_TEST(CleanupTest, BasicUsageWithFunctionPointer) {
   fn_ptr_called = false;
 
   {
-    auto cleanup = absl::MakeCleanup(TypeParam::AsCallback(&FnPtrFunction));
+    absl::Cleanup cleanup = TypeParam::AsCallback(&FnPtrFunction);
     EXPECT_FALSE(fn_ptr_called);  // Constructor shouldn't invoke the callback
   }
 
@@ -213,8 +142,7 @@ TYPED_TEST(CleanupTest, Cancel) {
   bool called = false;
 
   {
-    auto cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback([&called] { called = true; }));
+    absl::Cleanup cleanup = TypeParam::AsCallback([&called] { called = true; });
     EXPECT_FALSE(called);  // Constructor shouldn't invoke the callback
 
     std::move(cleanup).Cancel();
@@ -228,8 +156,7 @@ TYPED_TEST(CleanupTest, Invoke) {
   bool called = false;
 
   {
-    auto cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback([&called] { called = true; }));
+    absl::Cleanup cleanup = TypeParam::AsCallback([&called] { called = true; });
     EXPECT_FALSE(called);  // Constructor shouldn't invoke the callback
 
     std::move(cleanup).Invoke();
@@ -245,12 +172,12 @@ TYPED_TEST(CleanupTest, Move) {
   bool called = false;
 
   {
-    auto moved_from_cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback([&called] { called = true; }));
+    absl::Cleanup moved_from_cleanup =
+      TypeParam::AsCallback([&called] { called = true; });
     EXPECT_FALSE(called);  // Constructor shouldn't invoke the callback
 
     {
-      auto moved_to_cleanup = std::move(moved_from_cleanup);
+      absl::Cleanup moved_to_cleanup = std::move(moved_from_cleanup);
       EXPECT_FALSE(called);  // Move shouldn't invoke the callback
     }
 
@@ -262,48 +189,45 @@ TYPED_TEST(CleanupTest, Move) {
   EXPECT_FALSE(called);  // Destructor shouldn't invoke the callback
 }
 
-int DestructionCount = 0;
+int destruction_count = 0;
 
 struct DestructionCounter {
   void operator()() {}
 
-  ~DestructionCounter() { ++DestructionCount; }
+  ~DestructionCounter() { ++destruction_count; }
 };
 
 TYPED_TEST(CleanupTest, DestructorDestroys) {
   {
-    auto cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback(DestructionCounter()));
-    DestructionCount = 0;
+    absl::Cleanup cleanup = TypeParam::AsCallback(DestructionCounter());
+    destruction_count = 0;
   }
 
-  EXPECT_EQ(DestructionCount, 1);  // Engaged cleanup destroys
+  EXPECT_EQ(destruction_count, 1);  // Engaged cleanup destroys
 }
 
 TYPED_TEST(CleanupTest, CancelDestroys) {
   {
-    auto cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback(DestructionCounter()));
-    DestructionCount = 0;
+    absl::Cleanup cleanup = TypeParam::AsCallback(DestructionCounter());
+    destruction_count = 0;
 
     std::move(cleanup).Cancel();
-    EXPECT_EQ(DestructionCount, 1);  // Cancel destroys
+    EXPECT_EQ(destruction_count, 1);  // Cancel destroys
   }
 
-  EXPECT_EQ(DestructionCount, 1);  // Canceled cleanup does not double destroy
+  EXPECT_EQ(destruction_count, 1);  // Canceled cleanup does not double destroy
 }
 
 TYPED_TEST(CleanupTest, InvokeDestroys) {
   {
-    auto cleanup =
-        absl::MakeCleanup(TypeParam::AsCallback(DestructionCounter()));
-    DestructionCount = 0;
+    absl::Cleanup cleanup = TypeParam::AsCallback(DestructionCounter());
+    destruction_count = 0;
 
     std::move(cleanup).Invoke();
-    EXPECT_EQ(DestructionCount, 1);  // Invoke destroys
+    EXPECT_EQ(destruction_count, 1);  // Invoke destroys
   }
 
-  EXPECT_EQ(DestructionCount, 1);  // Invoked cleanup does not double destroy
+  EXPECT_EQ(destruction_count, 1);  // Invoked cleanup does not double destroy
 }
 
 }  // namespace

--- a/absl/cleanup/internal/cleanup.h
+++ b/absl/cleanup/internal/cleanup.h
@@ -15,6 +15,7 @@
 #ifndef ABSL_CLEANUP_INTERNAL_CLEANUP_H_
 #define ABSL_CLEANUP_INTERNAL_CLEANUP_H_
 
+#include <cstddef>
 #include <new>
 #include <type_traits>
 #include <utility>
@@ -27,6 +28,25 @@ namespace absl {
 ABSL_NAMESPACE_BEGIN
 
 namespace cleanup_internal {
+
+template <typename Callback>
+class Defer {
+ public:
+  // NOLINTBEGIN(google-explicit-constructor)
+  Defer(Callback callback)  // NOLINT(runtime/explicit)
+    : callback_(std::move(callback)) {}
+  // NOLINTEND(google-explicit-constructor)
+
+  ~Defer() {
+    std::move(callback_)();
+  }
+
+ private:
+  Callback callback_;
+};
+
+template <typename Callback>
+Defer(Callback callback) -> Defer<Callback>;
 
 struct Tag {};
 
@@ -44,23 +64,19 @@ constexpr bool ReturnsVoid() {
 template <typename Callback>
 class Storage {
  public:
-  Storage() = delete;
+  Storage() = default;  // Trivial default initialization is expected
 
-  explicit Storage(Callback callback) {
-    // Placement-new into a character buffer is used for eager destruction when
-    // the cleanup is invoked or cancelled. To ensure this optimizes well, the
-    // behavior is implemented locally instead of using a std::optional.
+  // NOTE: Is invoked on uninitialized instances of `Storage`
+  void EmplaceCallback(Callback callback) {
+    // The callback is stored in a character buffer to decouple its storage
+    // duration from its object lifetime. We need to be able to eagerly destroy
+    // the callback when a method on `absl::Cleanup` is invoked.
     ::new (GetCallbackBuffer()) Callback(std::move(callback));
-    is_callback_engaged_ = true;
   }
 
-  Storage(Storage&& other) {
-    ABSL_HARDENING_ASSERT(other.IsCallbackEngaged());
-
-    ::new (GetCallbackBuffer()) Callback(std::move(other.GetCallback()));
-    is_callback_engaged_ = true;
-
-    other.DestroyCallback();
+  // NOTE: Is invoked on uninitialized instances of `Storage`
+  void EngageCallback() {
+    fields_.is_callback_engaged_ = true;
   }
 
   Storage(const Storage& other) = delete;
@@ -69,16 +85,19 @@ class Storage {
 
   Storage& operator=(const Storage& other) = delete;
 
-  void* GetCallbackBuffer() { return static_cast<void*>(callback_buffer_); }
+  void* GetCallbackBuffer() {
+    return static_cast<void*>(fields_.callback_buffer_);
+  }
 
   Callback& GetCallback() {
     return *reinterpret_cast<Callback*>(GetCallbackBuffer());
   }
 
-  bool IsCallbackEngaged() const { return is_callback_engaged_; }
+  bool IsCallbackEngaged() const { return fields_.is_callback_engaged_; }
+
+  void DisengageCallback() { fields_.is_callback_engaged_ = false; }
 
   void DestroyCallback() {
-    is_callback_engaged_ = false;
     GetCallback().~Callback();
   }
 
@@ -87,8 +106,13 @@ class Storage {
   }
 
  private:
-  bool is_callback_engaged_;
-  alignas(Callback) unsigned char callback_buffer_[sizeof(Callback)];
+  struct Fields {
+    alignas(Callback) std::byte callback_buffer_[sizeof(Callback)];
+    bool is_callback_engaged_;
+  };
+  static_assert(std::is_trivially_default_constructible<Fields>::value);
+
+  Fields fields_;
 };
 
 }  // namespace cleanup_internal

--- a/absl/debugging/stacktrace_benchmark.cc
+++ b/absl/debugging/stacktrace_benchmark.cc
@@ -57,8 +57,9 @@ ABSL_ATTRIBUTE_NOINLINE void func(benchmark::State& state, int x, int depth) {
 
 template <bool EnableFixup>
 void BM_GetStackTrace(benchmark::State& state) {
-  const Cleanup restore_state(
-      [prev = g_enable_fixup]() { g_enable_fixup = prev; });
+  const absl::Cleanup restore_state = [prev = g_enable_fixup] {
+    g_enable_fixup = prev;
+  };
   g_enable_fixup = EnableFixup;
   int depth = state.range(0);
   for (auto s : state) {

--- a/absl/debugging/stacktrace_test.cc
+++ b/absl/debugging/stacktrace_test.cc
@@ -28,6 +28,7 @@
 #include "absl/base/config.h"
 #include "absl/base/internal/errno_saver.h"
 #include "absl/base/optimization.h"
+#include "absl/cleanup/cleanup.h"
 #include "absl/types/span.h"
 
 static int g_should_fixup_calls = 0;
@@ -56,7 +57,6 @@ namespace {
 
 using ::testing::ContainerEq;
 using ::testing::Contains;
-using ::testing::internal::Cleanup;
 
 struct StackTrace {
   static constexpr int kStackCount = 64;
@@ -116,13 +116,13 @@ ABSL_ATTRIBUTE_NOINLINE static void FixupNoFixupEquivalenceNoInline() {
 
   // This test is known not to pass on MSVC (due to weak symbols)
 
-  const Cleanup restore_state([enable_fixup = g_enable_fixup,
+  const absl::Cleanup restore_state = [enable_fixup = g_enable_fixup,
                                fixup_calls = g_fixup_calls,
-                               should_fixup_calls = g_should_fixup_calls]() {
+                               should_fixup_calls = g_should_fixup_calls] {
     g_enable_fixup = enable_fixup;
     g_fixup_calls = fixup_calls;
     g_should_fixup_calls = should_fixup_calls;
-  });
+  };
 
   constexpr int kSkip = 1;  // Skip our own frame, whose return PCs won't match
   constexpr auto kStackCount = 1;
@@ -211,13 +211,13 @@ TEST(StackTrace, FixupLowStackUsage) {
     GTEST_SKIP() << kSkipReason;
   }
 
-  const Cleanup restore_state([enable_fixup = g_enable_fixup,
+  const absl::Cleanup restore_state = [enable_fixup = g_enable_fixup,
                                fixup_calls = g_fixup_calls,
-                               should_fixup_calls = g_should_fixup_calls]() {
+                               should_fixup_calls = g_should_fixup_calls] {
     g_enable_fixup = enable_fixup;
     g_fixup_calls = fixup_calls;
     g_should_fixup_calls = should_fixup_calls;
-  });
+  };
 
   g_enable_fixup = true;
 
@@ -265,14 +265,14 @@ TEST(StackTrace, CustomUnwinderPerformsFixup) {
   constexpr auto kStackCount = 1;
 
   absl::SetStackUnwinder(absl::DefaultStackUnwinder);
-  const Cleanup restore_state([enable_fixup = g_enable_fixup,
+  const absl::Cleanup restore_state = [enable_fixup = g_enable_fixup,
                                fixup_calls = g_fixup_calls,
-                               should_fixup_calls = g_should_fixup_calls]() {
+                               should_fixup_calls = g_should_fixup_calls] {
     absl::SetStackUnwinder(nullptr);
     g_enable_fixup = enable_fixup;
     g_fixup_calls = fixup_calls;
     g_should_fixup_calls = should_fixup_calls;
-  });
+  };
 
   StackTrace trace;
 

--- a/absl/log/internal/log_sink_set.cc
+++ b/absl/log/internal/log_sink_set.cc
@@ -196,8 +196,7 @@ class GlobalLogSinkSet final {
         ThreadIsLoggingStatus() = true;
         // Ensure the "thread is logging" status is reverted upon leaving the
         // scope even in case of exceptions.
-        auto status_cleanup =
-            absl::MakeCleanup([] { ThreadIsLoggingStatus() = false; });
+        absl::Cleanup status_cleanup = [] { ThreadIsLoggingStatus() = false; };
         SendToSinks(entry, absl::MakeSpan(sinks_));
       }
     }
@@ -240,8 +239,7 @@ class GlobalLogSinkSet final {
       ThreadIsLoggingStatus() = true;
       // Ensure the "thread is logging" status is reverted upon leaving the
       // scope even in case of exceptions.
-      auto status_cleanup =
-          absl::MakeCleanup([] { ThreadIsLoggingStatus() = false; });
+      absl::Cleanup status_cleanup = [] { ThreadIsLoggingStatus() = false; };
       FlushLogSinksLocked();
     }
   }

--- a/absl/strings/internal/cord_rep_btree_test.cc
+++ b/absl/strings/internal/cord_rep_btree_test.cc
@@ -1356,9 +1356,9 @@ TEST(CordRepBtreeTest, AssertValid) {
 TEST(CordRepBtreeTest, CheckAssertValidShallowVsDeep) {
   // Restore exhaustive validation on any exit.
   const bool exhaustive_validation = IsCordBtreeExhaustiveValidationEnabled();
-  auto cleanup = absl::MakeCleanup([exhaustive_validation] {
+  absl::Cleanup cleanup = [exhaustive_validation] {
     SetCordBtreeExhaustiveValidation(exhaustive_validation);
-  });
+  };
 
   // Create a tree of at least 2 levels, and mess with the original flat, which
   // should go undetected in shallow mode as the flat is too far away, but


### PR DESCRIPTION
Since the release of `absl::Cleanup`, an upgrade tool has been available:
- Documentation: https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/docs/clang-tidy/checks/abseil/cleanup-ctad.rst
- Implementation: https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clang-tidy/abseil/CleanupCtadCheck.cpp
- Tests: https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/test/clang-tidy/checkers/abseil/cleanup-ctad.cpp

Now that Abseil requires C++17 or newer, this PR removes the old spelling, `absl::MakeCleanup`.

This PR might not be accepted, per the "API Freeze Consequences" mentioned at https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md

I wanted to propose it to see if there was any interest in removal. And while here, I made some additional changes.