### PR TITLE
base: fix ABSL_ATTRIBUTE_WARN_UNUSED with gcc <= 12

### DIFF
--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -1092,7 +1092,14 @@ struct AbslInternal_YouForgotToExplicitlyInitializeAField {
 // See https://clang.llvm.org/docs/AttributeReference.html#warn-unused and
 // https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html#index-warn_005funused-type-attribute
 #if ABSL_HAVE_CPP_ATTRIBUTE(gnu::warn_unused)
+// Only GCC >= 13 allows mixing standard and gnu attributes.
+// In case of gcc < 13, fallback on using __attribute__.
+// https://gcc.gnu.org/PR69585
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13
+#define ABSL_ATTRIBUTE_WARN_UNUSED __attribute__((warn_unused))
+#else
 #define ABSL_ATTRIBUTE_WARN_UNUSED [[gnu::warn_unused]]
+#endif
 #else
 #define ABSL_ATTRIBUTE_WARN_UNUSED
 #endif


### PR DESCRIPTION
Gcc <= 12 does not support mixing standard C++ attributes with GNU attributes. See [1].

This can lead to build failures such as [2] [3] and [4]. In those situations, the compilation fails with error such as:

    /usr/include/absl/base/attributes.h:1076:36: error: expected identifier before '[' token

Gcc maintainers mentioned in [1] comment 9 that this bugfix will not be backported in Gcc 12. Gcc 12 is still used in LTS distributions. For example, it is included in Debian 12 (Bookworm), which is still supported until 2028. See [5].

This commit adds a workaround for gcc <= 12 which uses __attribute__ in that case, which fixes the compilation failure.

[1] https://gcc.gnu.org/PR69585
[2] https://github.com/protocolbuffers/protobuf/issues/26383
[3] https://autobuild.buildroot.org/results/33f6cfd37cb48c15a53b3e7123d5ce8388a0f2ab/build-end.log
[4] https://gitlab.com/buildroot.org/buildroot/-/jobs/13904066346
[5] https://www.debian.org/releases/bookworm/