### PR TITLE
Make absl::InitializeLog() safe to call more than once (#1656)

### DIFF
--- a/absl/log/BUILD.bazel
+++ b/absl/log/BUILD.bazel
@@ -137,6 +137,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":globals",
+        "//absl/base",
         "//absl/base:config",
         "//absl/log/internal:globals",
         "//absl/time",
@@ -425,6 +426,20 @@ cc_test(
         "//absl/base:log_severity",
         "//absl/log/internal:globals",
         "//absl/log/internal:test_helpers",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "initialize_test",
+    size = "small",
+    srcs = ["initialize_test.cc"],
+    copts = ABSL_TEST_COPTS,
+    linkopts = ABSL_DEFAULT_LINKOPTS,
+    deps = [
+        ":initialize",
+        "//absl/log/internal:globals",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/absl/log/CMakeLists.txt
+++ b/absl/log/CMakeLists.txt
@@ -537,6 +537,7 @@ absl_cc_library(
   LINKOPTS
     ${ABSL_DEFAULT_LINKOPTS}
   DEPS
+    absl::base
     absl::config
     absl::log_globals
     absl::log_internal_globals
@@ -999,6 +1000,21 @@ absl_cc_test(
     absl::log_internal_test_helpers
     absl::log_severity
     absl::scoped_mock_log
+    GTest::gmock_main
+)
+
+absl_cc_test(
+  NAME
+    log_initialize_test
+  SRCS
+    "initialize_test.cc"
+  COPTS
+    ${ABSL_TEST_COPTS}
+  LINKOPTS
+    ${ABSL_DEFAULT_LINKOPTS}
+  DEPS
+    absl::log_initialize
+    absl::log_internal_globals
     GTest::gmock_main
 )
 

--- a/absl/log/initialize.cc
+++ b/absl/log/initialize.cc
@@ -14,6 +14,7 @@
 
 #include "absl/log/initialize.h"
 
+#include "absl/base/call_once.h"
 #include "absl/base/config.h"
 #include "absl/log/internal/globals.h"
 #include "absl/time/time.h"
@@ -22,6 +23,9 @@ namespace absl {
 ABSL_NAMESPACE_BEGIN
 
 namespace {
+
+absl::once_flag init_log_once;
+
 void InitializeLogImpl(absl::TimeZone time_zone) {
   // This comes first since it is used by RAW_LOG.
   absl::log_internal::SetTimeZone(time_zone);
@@ -32,7 +36,13 @@ void InitializeLogImpl(absl::TimeZone time_zone) {
 }
 }  // namespace
 
-void InitializeLog() { InitializeLogImpl(absl::LocalTimeZone()); }
+void InitializeLog() {
+  // Repeated calls are intentionally safe: only the first call has effect, and
+  // subsequent calls are no-ops. This lets independent libraries that each
+  // want to bring up the logging library coexist without coordination.
+  absl::call_once(init_log_once,
+                  []() { InitializeLogImpl(absl::LocalTimeZone()); });
+}
 
 ABSL_NAMESPACE_END
 }  // namespace absl

--- a/absl/log/initialize.h
+++ b/absl/log/initialize.h
@@ -34,7 +34,12 @@ ABSL_NAMESPACE_BEGIN
 // After initialization is finished, log messages are directed to all registered
 // `LogSink`s.
 //
-// It is an error to call this function twice.
+// Calling this function more than once is safe: only the first call has effect
+// and subsequent calls are no-ops. This is intended to support situations
+// where multiple independent libraries each want to bring up the logging
+// library and have no way to coordinate among themselves. Concurrent calls
+// from multiple threads are likewise safe; later callers block until the
+// first call has completed.
 //
 // There is no corresponding function to shut down the logging library.
 void InitializeLog();

--- a/absl/log/initialize_test.cc
+++ b/absl/log/initialize_test.cc
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/log/initialize.h"
+
+#include <thread>  // NOLINT(build/c++11)
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "absl/log/internal/globals.h"
+
+namespace {
+
+TEST(InitializeLogTest, FirstCallInitializes) {
+  absl::InitializeLog();
+  EXPECT_TRUE(absl::log_internal::IsInitialized());
+}
+
+TEST(InitializeLogTest, SecondCallIsNoOp) {
+  // The first call may have happened in a previous test in the same binary;
+  // either way, calling again must not fail and must leave the library in the
+  // initialized state.
+  absl::InitializeLog();
+  absl::InitializeLog();
+  EXPECT_TRUE(absl::log_internal::IsInitialized());
+}
+
+TEST(InitializeLogTest, ConcurrentCallsAreSafe) {
+  // Spawn several threads that race to initialize the logging library. Without
+  // the call_once guard inside InitializeLog(), this would either crash via
+  // ABSL_RAW_LOG(FATAL) inside SetTimeZone() or expose a data race on the
+  // initialization globals. With the guard, exactly one underlying
+  // initialization runs and the rest become no-ops.
+  constexpr int kNumThreads = 8;
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([] { absl::InitializeLog(); });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+  EXPECT_TRUE(absl::log_internal::IsInitialized());
+}
+
+}  // namespace


### PR DESCRIPTION
Fixes #1656.

Previously, calling `absl::InitializeLog()` more than once aborted the program: the underlying `absl::log_internal::SetTimeZone()` fires `ABSL_RAW_LOG(FATAL, "...has already been called")` on its second invocation. The header documented this as "an error to call this function twice", but in real-world systems multiple independent libraries each want to bring up the logging library and have no way to coordinate among themselves — Google's XLA project being the example cited in #1656.

## Change

Wrap the body of `InitializeLog()` in `absl::call_once`. Exactly the first invocation runs the underlying initialization; all subsequent calls (including concurrent ones from other threads) become no-ops. The first caller's `absl::LocalTimeZone()` value wins, matching the documented "only the first call has effect" intent — just made safe instead of UB.

Net diff: +106 / −2 across 5 files.

- `absl/log/initialize.cc` — `absl::call_once` guard around `InitializeLogImpl(absl::LocalTimeZone())`.
- `absl/log/initialize.h` — docstring updated to document the new contract (safe to call repeatedly; concurrent callers block until the first call completes).
- `absl/log/initialize_test.cc` — new gtest covering: first call initializes, second call is a no-op, concurrent calls from N threads are safe.
- `absl/log/BUILD.bazel`, `absl/log/CMakeLists.txt` — wire the new test target and add the `//absl/base` (CMake: `absl::base`) dep to the `log_initialize` library for `call_once`.

## Testing

Built and ran the new test locally with CMake/Ninja + MSVC 19.36 on Windows:

```
[==========] 3 tests from InitializeLogTest
[ RUN      ] InitializeLogTest.FirstCallInitializes      OK (0 ms)
[ RUN      ] InitializeLogTest.SecondCallIsNoOp          OK (0 ms)
[ RUN      ] InitializeLogTest.ConcurrentCallsAreSafe    OK (1 ms)
[==========] 3 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 3 tests.
```

Sibling regression check: `absl_log_globals_test` also passes after the BUILD/CMake edits.

Without the `call_once` guard, `ConcurrentCallsAreSafe` either races on the initialization globals or aborts via the FATAL raw log inside `SetTimeZone()`, so it doubles as a regression marker.

## Notes

- No public API surface change — same function name, same signature.
- The cost on every `InitializeLog()` call is one `absl::call_once` flag check, which after the first call is a single relaxed atomic load on the fast path.
- Out of scope: adding a `ShutdownLog()` / re-init capability (the issue does not request it)