### PR TITLE
Allow WASM targets to pre-define ABSL_HAVE_MMAP

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -372,7 +372,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 //
 // Checks whether the platform has an mmap(2) implementation as defined in
 // POSIX.1-2001.
-#ifdef ABSL_HAVE_MMAP
+#if defined(ABSL_HAVE_MMAP) && !defined(__wasm__)
 #error ABSL_HAVE_MMAP cannot be directly set
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
     defined(_AIX) || defined(__ros__) || defined(__asmjs__) ||            \

--- a/ci/linux_wasi_cmake.sh
+++ b/ci/linux_wasi_cmake.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2025 The Abseil Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify that abseil-cpp builds for WASI using wasi-sdk.
+
+set -euox pipefail
+
+if [[ -z ${ABSEIL_ROOT:-} ]]; then
+  ABSEIL_ROOT="$(realpath $(dirname ${0})/..)"
+fi
+
+WASI_SDK_VERSION="25.0"
+WASI_SDK_DIR="/opt/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux"
+
+if [[ ! -d "${WASI_SDK_DIR}" ]]; then
+  curl -fL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-${WASI_SDK_VERSION}-x86_64-linux.tar.gz" \
+    | tar xz -C /opt
+fi
+
+cmake -B /tmp/abseil-wasi-build -S "${ABSEIL_ROOT}" \
+  -DCMAKE_TOOLCHAIN_FILE="${WASI_SDK_DIR}/share/cmake/wasi-sdk-pthread.cmake" \
+  -DCMAKE_C_FLAGS="-D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -DABSL_HAVE_MMAP" \
+  -DCMAKE_CXX_FLAGS="-D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -DABSL_HAVE_MMAP -fno-exceptions" \
+  -DCMAKE_EXE_LINKER_FLAGS="-lwasi-emulated-mman -lwasi-emulated-signal" \
+  -DABSL_BUILD_TESTING=OFF
+
+cmake --build /tmp/abseil-wasi-build -j"$(nproc)"
+
+echo "PASS: abseil-cpp builds for WASI with wasi-sdk"


### PR DESCRIPTION
Hi :wave: !
Thank you so much for maintaining Abseil, it's an amazing library and we really appreciate all the work that goes into it!

This is a tiny follow-up to #1976 . When building Abseil for WASM/WASI with wasi-sdk, build systems need to pass `-DABSL_HAVE_MMAP` alongside `-D_WASI_EMULATED_MMAN`. The #error guard on `ABSL_HAVE_MMAP` prevents this.

This PR exempts `__wasm__` targets from that guard (1 line changed), while keeping it intact for all other platforms. It also adds a CI script that builds Abseil with `wasi-sdk` to prevent regressions, I can remove it and leave the single line change when requested.

This patch (or equivalent) is already working in the wild across several projects, for example:

- [roastedroot/protobuf4j](https://github.com/roastedroot/protobuf4j/blob/main/buildtools-v3/patch-absl.txt)
- [wasilibs/go-protoc-gen-grpc-java](https://github.com/wasilibs/go-protoc-gen-grpc-java/blob/main/buildtools/wasm/patch-absl.txt)
- [wasilibs/go-protoc-gen-builtins](https://github.com/wasilibs/go-protoc-gen-builtins/blob/main/buildtools-descriptors/wasm/patch-absl.txt)

Having this upstream would let all these projects drop their local patches. Thank you for considering it!