### PR TITLE
validate TZif header limits before parsing

### DIFF
--- a/absl/time/internal/cctz/src/time_zone_info.cc
+++ b/absl/time/internal/cctz/src/time_zone_info.cc
@@ -41,6 +41,7 @@
 #include <cstring>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -144,8 +145,18 @@ struct Header {            // counts of:
   std::size_t ttisutcnt;   // standard/wall indicators (unused)
 
   bool Build(const tzhead& tzh);
-  std::size_t DataLength(std::size_t time_len) const;
+  bool DataLength(std::size_t time_len, std::size_t* len) const;
 };
+
+bool AddFieldLength(std::size_t count, std::size_t item_size,
+                    std::size_t* len) {
+  const std::size_t max = (std::numeric_limits<std::size_t>::max)();
+  if (count != 0 && item_size > max / count) return false;
+  const std::size_t field_len = count * item_size;
+  if (*len > max - field_len) return false;
+  *len += field_len;
+  return true;
+}
 
 // Builds the in-memory header using the raw bytes from the file.
 bool Header::Build(const tzhead& tzh) {
@@ -162,20 +173,31 @@ bool Header::Build(const tzhead& tzh) {
   ttisstdcnt = static_cast<std::size_t>(v);
   if ((v = Decode32(tzh.tzh_ttisutcnt)) < 0) return false;
   ttisutcnt = static_cast<std::size_t>(v);
+  // Enforce tzfile.h implementation limits. These are structural invariants:
+  // TZif stores several indexes as unsigned bytes, and cctz represents
+  // transition type and abbreviation indexes with 8-bit fields.
+  if (timecnt > TZ_MAX_TIMES) return false;
+  if (typecnt > TZ_MAX_TYPES) return false;
+  if (charcnt > TZ_MAX_CHARS) return false;
+  if (leapcnt > TZ_MAX_LEAPS) return false;
+  if (ttisstdcnt > typecnt) return false;
+  if (ttisutcnt > typecnt) return false;
   return true;
 }
 
 // How many bytes of data are associated with this header. The result
 // depends upon whether this is a section with 4-byte or 8-byte times.
-std::size_t Header::DataLength(std::size_t time_len) const {
-  std::size_t len = 0;
-  len += (time_len + 1) * timecnt;  // unix_time + type_index
-  len += (4 + 1 + 1) * typecnt;     // utc_offset + is_dst + abbr_index
-  len += 1 * charcnt;               // abbreviations
-  len += (time_len + 4) * leapcnt;  // leap-time + TAI-UTC
-  len += 1 * ttisstdcnt;            // UTC/local indicators
-  len += 1 * ttisutcnt;             // standard/wall indicators
-  return len;
+bool Header::DataLength(std::size_t time_len, std::size_t* len) const {
+  std::size_t total = 0;
+  // Keep this layout in sync with tzfile.h.
+  if (!AddFieldLength(timecnt, time_len + 1, &total)) return false;
+  if (!AddFieldLength(typecnt, 4 + 1 + 1, &total)) return false;
+  if (!AddFieldLength(charcnt, 1, &total)) return false;
+  if (!AddFieldLength(leapcnt, time_len + 4, &total)) return false;
+  if (!AddFieldLength(ttisstdcnt, 1, &total)) return false;
+  if (!AddFieldLength(ttisutcnt, 1, &total)) return false;
+  *len = total;
+  return true;
 }
 
 // Does the rule for future transitions call for year-round daylight time?
@@ -642,7 +664,10 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   std::size_t time_len = 4;
   if (tzh.tzh_version[0] != '\0') {
     // Skip the 4-byte data.
-    if (zip->Skip(hdr.DataLength(time_len)) != 0) return false;
+    std::size_t skip_len;
+    if (!hdr.DataLength(time_len, &skip_len) || zip->Skip(skip_len) != 0) {
+      return false;
+    }
     // Read and validate the header for the 8-byte data.
     if (zip->Read(&tzh, sizeof(tzh)) != sizeof(tzh)) return false;
     if (strncmp(tzh.tzh_magic, TZ_MAGIC, sizeof(tzh.tzh_magic)) != 0)
@@ -663,7 +688,8 @@ bool TimeZoneInfo::Load(ZoneInfoSource* zip) {
   if (hdr.ttisutcnt != 0 && hdr.ttisutcnt != hdr.typecnt) return false;
 
   // Read the data into a local buffer.
-  std::size_t len = hdr.DataLength(time_len);
+  std::size_t len;
+  if (!hdr.DataLength(time_len, &len)) return false;
   std::vector<char> tbuf(len);
   if (zip->Read(tbuf.data(), len) != len) return false;
   const char* bp = tbuf.data();

--- a/absl/time/internal/cctz/src/time_zone_lookup_test.cc
+++ b/absl/time/internal/cctz/src/time_zone_lookup_test.cc
@@ -12,17 +12,25 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <functional>
 #include <future>
 #include <limits>
+#include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "absl/base/config.h"
 #include "absl/time/internal/cctz/include/cctz/time_zone.h"
+#include "absl/time/internal/cctz/include/cctz/zone_info_source.h"
+#include "absl/time/internal/cctz/src/tzfile.h"
 #if defined(__linux__)
 #include <features.h>
 #endif
@@ -73,6 +81,138 @@ int VersionCmp(time_zone tz, const std::string& target) {
   if (version.empty() && !target.empty()) return 1;  // unknown > known
   return version.compare(target);
 }
+
+void AppendTzifCount(std::vector<char>* out, std::uint32_t value) {
+  out->push_back(static_cast<char>((value >> 24) & 0xff));
+  out->push_back(static_cast<char>((value >> 16) & 0xff));
+  out->push_back(static_cast<char>((value >> 8) & 0xff));
+  out->push_back(static_cast<char>(value & 0xff));
+}
+
+std::vector<char> TzifWithCounts(char version, std::uint32_t ttisutcnt,
+                                 std::uint32_t ttisstdcnt,
+                                 std::uint32_t leapcnt, std::uint32_t timecnt,
+                                 std::uint32_t typecnt,
+                                 std::uint32_t charcnt) {
+  std::vector<char> tzif;
+  tzif.push_back('T');
+  tzif.push_back('Z');
+  tzif.push_back('i');
+  tzif.push_back('f');
+  tzif.push_back(version);  // '\0', '2', '3', ...
+  for (int i = 0; i != 15; ++i) tzif.push_back('\0');  // Reserved.
+  AppendTzifCount(&tzif, ttisutcnt);
+  AppendTzifCount(&tzif, ttisstdcnt);
+  AppendTzifCount(&tzif, leapcnt);
+  AppendTzifCount(&tzif, timecnt);
+  AppendTzifCount(&tzif, typecnt);
+  AppendTzifCount(&tzif, charcnt);
+
+  for (std::uint32_t i = 0; i != timecnt; ++i) AppendTzifCount(&tzif, i);
+  for (std::uint32_t i = 0; i != timecnt; ++i) {
+    tzif.push_back('\0');  // transition type index
+  }
+  for (std::uint32_t i = 0; i != typecnt; ++i) {
+    AppendTzifCount(&tzif, 0);  // UTC offset
+    tzif.push_back(0);          // is_dst
+    tzif.push_back(0);          // abbreviation index
+  }
+  const char kAbbr[] = "UTC";
+  for (std::uint32_t i = 0; i != charcnt; ++i) {
+    tzif.push_back(i < sizeof(kAbbr) ? kAbbr[i] : '\0');
+  }
+  for (std::uint32_t i = 0; i != leapcnt; ++i) {
+    AppendTzifCount(&tzif, 0);  // leap-time (v1)
+    AppendTzifCount(&tzif, 0);  // TAI-UTC
+  }
+  for (std::uint32_t i = 0; i != ttisstdcnt; ++i) tzif.push_back('\0');
+  for (std::uint32_t i = 0; i != ttisutcnt; ++i) tzif.push_back('\0');
+  return tzif;
+}
+
+struct TransportConfig {
+  std::size_t max_bytes_per_read = (std::numeric_limits<std::size_t>::max)();
+  bool return_zero_after_bytes = false;
+  std::size_t zero_after_bytes = 0;
+  bool fail_skip = false;
+  std::size_t fail_skip_after_calls = (std::numeric_limits<std::size_t>::max)();
+  bool short_skip = false;  // Advances less than requested but returns success.
+  std::size_t short_skip_max_bytes = 0;
+};
+
+class TestZoneInfoSource : public ZoneInfoSource {
+ public:
+  TestZoneInfoSource(std::vector<char> data, TransportConfig config)
+      : data_(std::move(data)), config_(config) {}
+
+  std::size_t Read(void* ptr, std::size_t size) override {
+    if (pos_ > data_.size()) return 0;
+    if (config_.return_zero_after_bytes && pos_ >= config_.zero_after_bytes) {
+      return 0;
+    }
+    size = std::min(size, data_.size() - pos_);
+    size = std::min(size, config_.max_bytes_per_read);
+    std::memcpy(ptr, data_.data() + pos_, size);
+    pos_ += size;
+    return size;
+  }
+
+  int Skip(std::size_t offset) override {
+    ++skip_calls_;
+    if (config_.fail_skip && skip_calls_ > config_.fail_skip_after_calls) {
+      return -1;
+    }
+    if (pos_ > data_.size()) return -1;
+    std::size_t to_advance = offset;
+    if (config_.short_skip) {
+      to_advance = std::min(to_advance, config_.short_skip_max_bytes);
+    }
+    pos_ += std::min(to_advance, data_.size() - pos_);
+    return 0;
+  }
+
+ private:
+  std::vector<char> data_;
+  std::size_t pos_ = 0;
+  std::size_t skip_calls_ = 0;
+  TransportConfig config_;
+};
+
+struct TestZone {
+  std::string name;
+  std::vector<char> data;
+  TransportConfig transport;
+};
+
+TestZone* test_zone = nullptr;
+
+std::unique_ptr<ZoneInfoSource> TestZoneInfoSourceFactory(
+    const std::string& name,
+    const std::function<std::unique_ptr<ZoneInfoSource>(const std::string&)>&
+        fallback_factory) {
+  if (test_zone != nullptr && name == test_zone->name) {
+    return std::unique_ptr<ZoneInfoSource>(
+        new TestZoneInfoSource(test_zone->data, test_zone->transport));
+  }
+  return fallback_factory(name);
+}
+
+class ScopedTestZoneInfoSourceFactory {
+ public:
+  explicit ScopedTestZoneInfoSourceFactory(TestZone* zone)
+      : old_factory_(cctz_extension::zone_info_source_factory) {
+    test_zone = zone;
+    cctz_extension::zone_info_source_factory = TestZoneInfoSourceFactory;
+  }
+
+  ~ScopedTestZoneInfoSourceFactory() {
+    cctz_extension::zone_info_source_factory = old_factory_;
+    test_zone = nullptr;
+  }
+
+ private:
+  cctz_extension::ZoneInfoSourceFactory old_factory_;
+};
 
 }  // namespace
 
@@ -180,6 +320,243 @@ TEST(TimeZone, Failures) {
   EXPECT_FALSE(load_time_zone("", &tz));
   EXPECT_EQ(chrono::system_clock::from_time_t(0),
             convert(civil_second(1970, 1, 1, 0, 0, 0), tz));  // UTC
+}
+
+TEST(TimeZone, RejectsTzifWithTooManyTransitionTypes) {
+  TestZone zone;
+  zone.name = "Test/TooManyTransitionTypes";
+  zone.data = TzifWithCounts('\0', 0, 0, 0, 0, TZ_MAX_TYPES + 1, sizeof("UTC"));
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTzifWithTooManyTransitions) {
+  TestZone zone;
+  zone.name = "Test/TooManyTransitions";
+  zone.data = TzifWithCounts('\0', 0, 0, 0, TZ_MAX_TIMES + 1, 1, sizeof("UTC"));
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTzifWithTooManyAbbreviationChars) {
+  TestZone zone;
+  zone.name = "Test/TooManyAbbreviationChars";
+  zone.data = TzifWithCounts('\0', 0, 0, 0, 0, 1, TZ_MAX_CHARS + 1);
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTzifWithLeapSeconds) {
+  // cctz explicitly rejects leap-second encoded zoneinfo.
+  TestZone zone;
+  zone.name = "Test/LeapSeconds";
+  zone.data = TzifWithCounts('\0', 0, 0, 1, 0, 1, sizeof("UTC"));
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTzifWithTooManyLeapSeconds) {
+  TestZone zone;
+  zone.name = "Test/TooManyLeaps";
+  zone.data = TzifWithCounts('\0', 0, 0, TZ_MAX_LEAPS + 1, 0, 1, sizeof("UTC"));
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTzifWithTtisstdcntGreaterThanTypecnt) {
+  TestZone zone;
+  zone.name = "Test/BadTtisstdcnt";
+  zone.data = TzifWithCounts('\0', 0, 2, 0, 0, 1, sizeof("UTC"));
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTzifWithTtisutcntGreaterThanTypecnt) {
+  TestZone zone;
+  zone.name = "Test/BadTtisutcnt";
+  zone.data = TzifWithCounts('\0', 2, 0, 0, 0, 1, sizeof("UTC"));
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTruncatedHeader) {
+  TestZone zone;
+  zone.name = "Test/TruncatedHeader";
+  zone.data.assign(10, '\0');  // shorter than tzhead
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsShortReadDuringHeader) {
+  TestZone zone;
+  zone.name = "Test/ShortReadHeader";
+  zone.data = TzifWithCounts('\0', 0, 0, 0, 0, 1, sizeof("UTC"));
+  zone.transport.max_bytes_per_read = 8;  // can't read tzhead in one go
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsShortReadDuringDataBlock) {
+  TestZone zone;
+  zone.name = "Test/ShortReadData";
+  // Ensure the data block is larger than tzhead so we can short-read the data
+  // block without also short-reading the header.
+  zone.data = TzifWithCounts('\0', 0, 0, 0, 100, 1, sizeof("UTC"));
+  zone.transport.max_bytes_per_read = sizeof(tzhead);  // header ok, data block short
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsSkipFailureForVersionedFile) {
+  TestZone zone;
+  zone.name = "Test/SkipFailure";
+  // Versioned file triggers the skip of the 4-byte section.
+  zone.data = TzifWithCounts('2', 0, 0, 0, 0, 1, sizeof("UTC"));
+  zone.transport.fail_skip = true;
+  zone.transport.fail_skip_after_calls = 0;  // fail first Skip()
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsShortSkipForVersionedFile) {
+  TestZone zone;
+  zone.name = "Test/ShortSkip";
+  // Versioned file triggers a Skip() of the v1 data section.
+  zone.data = TzifWithCounts('2', 0, 0, 0, 0, 1, sizeof("UTC"));
+  zone.transport.short_skip = true;
+  zone.transport.short_skip_max_bytes = 0;  // claims success but skips nothing
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTruncatedDataBlock) {
+  TestZone zone;
+  zone.name = "Test/TruncatedDataBlock";
+  zone.data = TzifWithCounts('\0', 0, 0, 0, 1, 1, sizeof("UTC"));
+  zone.data.resize(sizeof(tzhead) + 1);  // far too short for the data block
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+TEST(TimeZone, RejectsTypecntZero) {
+  TestZone zone;
+  zone.name = "Test/TypecntZero";
+  zone.data = TzifWithCounts('\0', 0, 0, 0, 0, 0, 0);
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_FALSE(load_time_zone(zone.name, &tz));
+}
+
+std::vector<char> MinimalValidTzifV1() {
+  // A minimal TZif v1 file with one time type and "UTC" abbreviation.
+  // timecnt=0 implies no stored transitions; cctz will synthesize sentinel
+  // transitions after loading.
+  return TzifWithCounts('\0', 0, 0, 0, 0, 1, sizeof("UTC"));
+}
+
+std::vector<char> MinimalValidTzifV2OrV3(char version) {
+  // Versioned TZif includes:
+  // 1) a v1 header+data block (4-byte times)
+  // 2) a second header+data block (8-byte times)
+  // 3) a footer: '\n' + TZ string + '\n'
+  // First section: header.version = '2'/'3', but data block uses 4-byte times.
+  std::vector<char> tzif = TzifWithCounts(version, 0, 0, 0, 0, 1, sizeof("UTC"));
+  // Second section: header.version = '2'/'3', data block uses 8-byte times.
+  // Our minimal fixture uses timecnt=0 and leapcnt=0, so the 4-byte and 8-byte
+  // data blocks are identical in size.
+  std::vector<char> v2 = TzifWithCounts(version, 0, 0, 0, 0, 1, sizeof("UTC"));
+  tzif.insert(tzif.end(), v2.begin(), v2.end());
+  tzif.push_back('\n');
+  tzif.push_back('U');
+  tzif.push_back('T');
+  tzif.push_back('C');
+  tzif.push_back('0');
+  tzif.push_back('\n');
+  return tzif;
+}
+
+TEST(TimeZone, LoadsMinimalValidTzifV1) {
+  TestZone zone;
+  zone.name = "Test/ValidV1";
+  zone.data = MinimalValidTzifV1();
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_TRUE(load_time_zone(zone.name, &tz));
+  EXPECT_EQ(zone.name, tz.name());
+  const auto al =
+      tz.lookup(chrono::system_clock::from_time_t(0));  // 1970-01-01T00:00:00Z
+  EXPECT_EQ(0, al.offset);
+  EXPECT_FALSE(al.is_dst);
+}
+
+TEST(TimeZone, LoadsMinimalValidTzifV2) {
+  TestZone zone;
+  zone.name = "Test/ValidV2";
+  zone.data = MinimalValidTzifV2OrV3('2');
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_TRUE(load_time_zone(zone.name, &tz));
+  EXPECT_EQ(zone.name, tz.name());
+  const auto al = tz.lookup(chrono::system_clock::from_time_t(0));
+  EXPECT_EQ(0, al.offset);
+  EXPECT_FALSE(al.is_dst);
+}
+
+TEST(TimeZone, LoadsMinimalValidTzifV3) {
+  TestZone zone;
+  zone.name = "Test/ValidV3";
+  zone.data = MinimalValidTzifV2OrV3('3');
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_TRUE(load_time_zone(zone.name, &tz));
+  EXPECT_EQ(zone.name, tz.name());
+  const auto al = tz.lookup(chrono::system_clock::from_time_t(0));
+  EXPECT_EQ(0, al.offset);
+  EXPECT_FALSE(al.is_dst);
+}
+
+TEST(TimeZone, LoadsBoundaryCountsWithinLimits) {
+  TestZone zone;
+  zone.name = "Test/BoundaryCounts";
+  zone.data = TzifWithCounts('\0', TZ_MAX_TYPES, TZ_MAX_TYPES, 0, TZ_MAX_TIMES,
+                             TZ_MAX_TYPES, TZ_MAX_CHARS);
+  ScopedTestZoneInfoSourceFactory scoped_factory(&zone);
+
+  time_zone tz;
+  EXPECT_TRUE(load_time_zone(zone.name, &tz));
+  const auto al = tz.lookup(chrono::system_clock::from_time_t(0));
+  EXPECT_EQ(0, al.offset);
+  EXPECT_FALSE(al.is_dst);
 }
 
 TEST(TimeZone, Equality) {


### PR DESCRIPTION
## Summary

Validate TZif header limits before parsing and make TZif section-length computation overflow-checked.

The loader previously accepted TZif files whose decoded counts exceeded the implementation limits documented in `tzfile.h`, and used those counts directly in section-length computation and parsing.

This change:
- validates decoded TZif counts against existing implementation limits before parsing,
- validates `ttisstdcnt` / `ttisutcnt` relationships before use,
- makes TZif data-length accumulation overflow-checked before `Skip()` and allocation,
- and adds deterministic in-memory regression tests for malformed TZif inputs and transport failures.

## Details

### Parser validation
Reject TZif headers when:
- `timecnt > TZ_MAX_TIMES`
- `typecnt > TZ_MAX_TYPES`
- `charcnt > TZ_MAX_CHARS`
- `leapcnt > TZ_MAX_LEAPS`
- `ttisstdcnt > typecnt`
- `ttisutcnt > typecnt`

These limits already exist in `tzfile.h`, and cctz internally represents TZif type/abbreviation indexes using 8-bit fields.

### Checked length computation
Replace unchecked TZif section-length accumulation with overflow-checked accumulation before:
- `Skip()`
- buffer allocation
- data reads

## Tests

Added deterministic in-memory tests covering:
- oversized transition/type/character/leap counts,
- invalid `ttisstdcnt` / `ttisutcnt` relationships,
- truncated reads,
- failing/short `Skip()` behavior,
- and valid minimal TZif v1/v2/v3 parsing.

The malformed-input tests fail on the unpatched tree because the loader accepts out-of-spec TZif inputs, and pass with this change.