### PR TITLE
Fix absl_stacktrace_test on s390x

### DIFF
--- a/absl/debugging/internal/stacktrace_generic-inl.inc
+++ b/absl/debugging/internal/stacktrace_generic-inl.inc
@@ -71,13 +71,20 @@ static int UnwindImpl(void** result, uintptr_t* frames, int* sizes,
 
   size = backtrace(stack, kStackLength);
   skip_count++;  // we want to skip the current frame as well
-  int result_count = size - skip_count;
-  if (result_count < 0)
-    result_count = 0;
-  if (result_count > max_depth)
-    result_count = max_depth;
-  for (int i = 0; i < result_count; i++)
-    result[i] = stack[i + skip_count];
+
+  int num_frames = size - skip_count;
+  if (num_frames < 0) num_frames = 0;
+  if (num_frames > max_depth) num_frames = max_depth;
+
+  int result_count = 0;
+  for (int i = 0; i < num_frames; i++) {
+    int stack_index = i + skip_count;
+    // Follow x86 and stop if the return address is null (end of stack).
+    if (stack[stack_index] == nullptr) {
+      break;
+    }
+    result[result_count++] = stack[stack_index];
+  }
 
   if (IS_STACK_FRAMES) {
     // No implementation for finding out the stack frames yet.


### PR DESCRIPTION
Commit 33bbc26 made changes to stacktrace_emscripten-inl.inc but did not change the stacktrace_generic-inl.inc file. This caused `absl_stacktrace_test` to fail on s390x.
```
Expected: (results[i]) != (nullptr), actual: NULL vs (nullptr)
Unexpected nullptr found at index 14

[  FAILED  ] StackTrace.NoNullptrInPopulatedRange (0 ms)
```
This patch applies the same logic to stacktrace_generic-inl.inc.