### PR TITLE
doc: clarify moved-from state for hash containers

### DIFF
--- a/absl/container/flat_hash_map.h
+++ b/absl/container/flat_hash_map.h
@@ -174,8 +174,7 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_map
   //   // After the move, map4 is in a valid but unspecified state. The only
   //   // operations guaranteed to be safe on a moved-from map are destruction,
   //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
-  //   // iteration) results in undefined behavior. Sanitizer builds will
-  //   // actively catch such misuse.
+  //   // iteration) results in undefined behavior.
   //
   // * Move assignment operator
   //

--- a/absl/container/flat_hash_map.h
+++ b/absl/container/flat_hash_map.h
@@ -171,11 +171,19 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_map
   //   // Move is guaranteed efficient
   //   absl::flat_hash_map<int, std::string> map5(std::move(map4));
   //
+  //   // After the move, map4 is in a valid but unspecified state. The only
+  //   // operations guaranteed to be safe on a moved-from map are destruction,
+  //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
+  //   // iteration) results in undefined behavior. Sanitizer builds will
+  //   // actively catch such misuse.
+  //
   // * Move assignment operator
   //
   //   // May be efficient if allocators are compatible
   //   absl::flat_hash_map<int, std::string> map6;
   //   map6 = std::move(map5);
+  //
+  //   // Same moved-from guarantees apply to map5 after this operation.
   //
   // * Range constructor
   //

--- a/absl/container/flat_hash_set.h
+++ b/absl/container/flat_hash_set.h
@@ -170,8 +170,7 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_set
   //   // After the move, set4 is in a valid but unspecified state. The only
   //   // operations guaranteed to be safe on a moved-from set are destruction,
   //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
-  //   // iteration) results in undefined behavior. Sanitizer builds will
-  //   // actively catch such misuse.
+  //   // iteration) results in undefined behavior.
   //
   // * Move assignment operator
   //

--- a/absl/container/flat_hash_set.h
+++ b/absl/container/flat_hash_set.h
@@ -167,11 +167,19 @@ class ABSL_ATTRIBUTE_OWNER flat_hash_set
   //   // Move is guaranteed efficient
   //   absl::flat_hash_set<std::string> set5(std::move(set4));
   //
+  //   // After the move, set4 is in a valid but unspecified state. The only
+  //   // operations guaranteed to be safe on a moved-from set are destruction,
+  //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
+  //   // iteration) results in undefined behavior. Sanitizer builds will
+  //   // actively catch such misuse.
+  //
   // * Move assignment operator
   //
   //   // May be efficient if allocators are compatible
   //   absl::flat_hash_set<std::string> set6;
   //   set6 = std::move(set5);
+  //
+  //   // Same moved-from guarantees apply to set5 after this operation.
   //
   // * Range constructor
   //

--- a/absl/container/node_hash_map.h
+++ b/absl/container/node_hash_map.h
@@ -170,8 +170,7 @@ class ABSL_ATTRIBUTE_OWNER node_hash_map
   //   // After the move, map4 is in a valid but unspecified state. The only
   //   // operations guaranteed to be safe on a moved-from map are destruction,
   //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
-  //   // iteration) results in undefined behavior. Sanitizer builds will
-  //   // actively catch such misuse.
+  //   // iteration) results in undefined behavior.
   //
   // * Move assignment operator
   //

--- a/absl/container/node_hash_map.h
+++ b/absl/container/node_hash_map.h
@@ -167,11 +167,19 @@ class ABSL_ATTRIBUTE_OWNER node_hash_map
   //   // Move is guaranteed efficient
   //   absl::node_hash_map<int, std::string> map5(std::move(map4));
   //
+  //   // After the move, map4 is in a valid but unspecified state. The only
+  //   // operations guaranteed to be safe on a moved-from map are destruction,
+  //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
+  //   // iteration) results in undefined behavior. Sanitizer builds will
+  //   // actively catch such misuse.
+  //
   // * Move assignment operator
   //
   //   // May be efficient if allocators are compatible
   //   absl::node_hash_map<int, std::string> map6;
   //   map6 = std::move(map5);
+  //
+  //   // Same moved-from guarantees apply to map5 after this operation.
   //
   // * Range constructor
   //

--- a/absl/container/node_hash_set.h
+++ b/absl/container/node_hash_set.h
@@ -164,8 +164,7 @@ class ABSL_ATTRIBUTE_OWNER node_hash_set
   //   // After the move, set4 is in a valid but unspecified state. The only
   //   // operations guaranteed to be safe on a moved-from set are destruction,
   //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
-  //   // iteration) results in undefined behavior. Sanitizer builds will
-  //   // actively catch such misuse.
+  //   // iteration) results in undefined behavior.
   //
   // * Move assignment operator
   //

--- a/absl/container/node_hash_set.h
+++ b/absl/container/node_hash_set.h
@@ -161,11 +161,19 @@ class ABSL_ATTRIBUTE_OWNER node_hash_set
   //   // Move is guaranteed efficient
   //   absl::node_hash_set<std::string> set5(std::move(set4));
   //
+  //   // After the move, set4 is in a valid but unspecified state. The only
+  //   // operations guaranteed to be safe on a moved-from set are destruction,
+  //   // assignment, and clear(). Any other operation (e.g. size(), empty(),
+  //   // iteration) results in undefined behavior. Sanitizer builds will
+  //   // actively catch such misuse.
+  //
   // * Move assignment operator
   //
   //   // May be efficient if allocators are compatible
   //   absl::node_hash_set<std::string> set6;
   //   set6 = std::move(set5);
+  //
+  //   // Same moved-from guarantees apply to set5 after this operation.
   //
   // * Range constructor
   //


### PR DESCRIPTION
Adds documentation to flat_hash_map, flat_hash_set, node_hash_map, and 
node_hash_set clarifying the moved-from contract for Swiss table containers.

After a move, only destruction, assignment, and clear() are guaranteed 
safe. Any other operation (e.g. size(), empty(), iteration) results in 
undefined behavior. Sanitizer builds actively catch such misuse via 
sentinel capacity values (kMovedFrom/kSelfMovedFrom).

This was confirmed by a maintainer in the linked issue.

Fixes #1928