### PR TITLE
Allow string_view as default value for string flags

### DIFF
--- a/absl/flags/flag_test.cc
+++ b/absl/flags/flag_test.cc
@@ -294,6 +294,10 @@ ABSL_FLAG(uint64_t, test_flag_08, 9876543, "test flag 08");
 ABSL_FLAG(double, test_flag_09, -9.876e-50, "test flag 09");
 ABSL_FLAG(float, test_flag_10, 1.234e12f, "test flag 10");
 ABSL_FLAG(std::string, test_flag_11, "", "test flag 11");
+
+constexpr absl::string_view kStringViewDefault = "asdf";
+ABSL_FLAG(std::string, test_flag_sv_default, kStringViewDefault, "test flag with string_view default");
+
 ABSL_FLAG(absl::Duration, test_flag_12, absl::Minutes(10), "test flag 12");
 ABSL_FLAG(absl::int128, test_flag_13, absl::MakeInt128(-1, 0), "test flag 13");
 ABSL_FLAG(absl::uint128, test_flag_14, absl::MakeUint128(0, 0xFFFAAABBBCCCDDD),
@@ -435,6 +439,10 @@ TEST_F(FlagTest, TestFlagDefinition) {
 }
 
 // --------------------------------------------------------------------
+
+TEST_F(FlagTest, TestStringViewDefault) {
+  EXPECT_EQ(absl::GetFlag(FLAGS_test_flag_sv_default), "asdf");
+}
 
 TEST_F(FlagTest, TestDefault) {
   EXPECT_EQ(absl::GetFlagReflectionHandle(FLAGS_test_flag_01).DefaultValue(),

--- a/absl/flags/internal/flag.h
+++ b/absl/flags/internal/flag.h
@@ -272,14 +272,20 @@ struct FlagDefaultArg {
 // TODO(rogeeff): Fix handling types with explicit constructors.
 struct EmptyBraces {};
 
-template <typename T>
-constexpr T InitDefaultValue(T t) {
-  return t;
+template <typename T, typename U = T>
+constexpr T InitDefaultValue(U t) {
+  return T(t);
 }
 
 template <typename T>
 constexpr T InitDefaultValue(EmptyBraces) {
   return T{};
+}
+
+
+// Allow std::string_view to be used as default value for std::string flags
+inline std::string InitDefaultValue(absl::string_view sv) {
+  return std::string(sv);
 }
 
 template <typename ValueT, typename GenT,


### PR DESCRIPTION
Fixes #1540

Allow std::string_view to be used as default value for ABSL_FLAG(std::string, ...).

Changed InitDefaultValue template to accept any convertible type U,
so that string_view is implicitly converted to string when used as
a default value.