### PR TITLE
Restrict in memory mmap arguments to glibc on s390x

### DIFF
--- a/absl/base/internal/direct_mmap.h
+++ b/absl/base/internal/direct_mmap.h
@@ -104,7 +104,7 @@ inline void* DirectMmap(void* start, size_t length, int prot, int flags, int fd,
       syscall(SYS_mmap2, start, length, prot, flags, fd,
               static_cast<unsigned long>(offset / pagesize)));  // NOLINT
 #endif
-#elif defined(__s390x__)
+#elif defined(__s390x__) && defined(__GLIBC__)
   // On s390x, mmap() arguments are passed in memory.
   unsigned long buf[6] = {reinterpret_cast<unsigned long>(start),  // NOLINT
                           static_cast<unsigned long>(length),      // NOLINT


### PR DESCRIPTION
DirectMmap fails for musl, because passing mmap arguments in memory is glibc specific.
