### PR TITLE
cast to unsigned char before std::isspace in ParseTime

### DIFF
--- a/absl/time/format.cc
+++ b/absl/time/format.cc
@@ -101,7 +101,7 @@ bool ParseTime(absl::string_view format, absl::string_view input,
                absl::TimeZone tz, absl::Time* time, std::string* err) {
   auto strip_leading_space = [](absl::string_view* sv) {
     while (!sv->empty()) {
-      if (!std::isspace(sv->front())) return;
+      if (!std::isspace(static_cast<unsigned char>(sv->front()))) return;
       sv->remove_prefix(1);
     }
   };


### PR DESCRIPTION
std::isspace takes a value representable as unsigned char or EOF; sv->front() can yield a negative char when the input starts with a high-bit-set byte.