### PR TITLE
docs: document MSVC compile-time format checking limitation in str_format.h

### DIFF
--- a/absl/strings/str_format.h
+++ b/absl/strings/str_format.h
@@ -68,6 +68,13 @@
 //
 // In addition, the `str_format` library provides extension points for
 // augmenting formatting to new types.  See "StrFormat Extensions" below.
+//
+// Compiler Support Note:
+// Compile-time format string checking (e.g. detecting `absl::StrFormat("%s",
+// 1)` as an error at compile time) is supported on GCC and Clang only. MSVC
+// does not support the compiler extension required for this feature. When
+// compiling with MSVC, format string errors will only be caught at runtime,
+// not at compile time.
 
 #ifndef ABSL_STRINGS_STR_FORMAT_H_
 #define ABSL_STRINGS_STR_FORMAT_H_

--- a/absl/strings/str_format.h
+++ b/absl/strings/str_format.h
@@ -49,7 +49,8 @@
 //   * A `FormatSpec` class template fully encapsulates a format string and its
 //     type arguments and is usually provided to `str_format` functions as a
 //     variadic argument of type `FormatSpec<Arg...>`. The `FormatSpec<Args...>`
-//     template is evaluated at compile-time, providing type safety.
+//     template is evaluated at compile-time, providing type safety (supported
+//     on GCC and Clang; on MSVC, these checks are deferred to runtime).
 //   * A `ParsedFormat` instance, which encapsulates a specific, pre-compiled
 //     format string for a specific set of type(s), and which can be passed
 //     between API boundaries. (The `FormatSpec` type should not be used
@@ -68,13 +69,7 @@
 //
 // In addition, the `str_format` library provides extension points for
 // augmenting formatting to new types.  See "StrFormat Extensions" below.
-//
-// Compiler Support Note:
-// Compile-time format string checking (e.g. detecting `absl::StrFormat("%s",
-// 1)` as an error at compile time) is supported on GCC and Clang only. MSVC
-// does not support the compiler extension required for this feature. When
-// compiling with MSVC, format string errors will only be caught at runtime,
-// not at compile time.
+
 
 #ifndef ABSL_STRINGS_STR_FORMAT_H_
 #define ABSL_STRINGS_STR_FORMAT_H_
@@ -282,7 +277,9 @@ class FormatCountCapture {
 // any string-like argument, so `std::string`, `std::wstring`,
 // `absl::string_view`, `const char*`, and `const wchar_t*` are all accepted.
 // Likewise, `%d` accepts any integer-like argument, etc.
-
+//
+// Note: Compile-time format string checking is supported on GCC and
+// Clang. On MSVC, these checks are performed at runtime instead.
 template <typename... Args>
 using FormatSpec = str_format_internal::FormatSpecTemplate<
     str_format_internal::ArgumentToConv<Args>()...>;


### PR DESCRIPTION
Fixes #1478

absl::StrFormat compile-time format string checking relies on
__attribute__((format(...))), a GCC/Clang-specific compiler extension
that MSVC does not support. This adds a note to the file-level
documentation so MSVC users are aware that format string errors will
only be caught at runtime, not at compile time.