### PR TITLE
simplify condition for ABSL_INTERNAL_STD_FILESYSTEM_PATH_HASH_AVAILABLE

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -683,10 +683,6 @@ H AbslHashValue(H hash_state, std::basic_string_view<Char> str) {
 }
 
 #if defined(__cpp_lib_filesystem) && __cpp_lib_filesystem >= 201703L && \
-    (!defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) ||        \
-     __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 130000) &&       \
-    (!defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) ||         \
-     __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 101500) &&        \
     (!defined(__XTENSA__))
 
 #define ABSL_INTERNAL_STD_FILESYSTEM_PATH_HASH_AVAILABLE 1


### PR DESCRIPTION
The conditions for `ABSL_INTERNAL_STD_FILESYSTEM_PATH_HASH_AVAILABLE` are basically always true, since abseil now requires C++17 (and all compilers have implemented `__cpp_lib_filesystem` for a long time), plus the macOS [lower bound](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md) has long moved past the versions being considered here.

It could be deleted entirely depending on what's the status resp. support for XTENSA. I've left it in for now because I don't know the details there.