### PR TITLE
remove ABSL_HAVE_PTHREAD_CPU_NUMBER_NP

### DIFF
--- a/absl/debugging/failure_signal_handler.cc
+++ b/absl/debugging/failure_signal_handler.cc
@@ -71,15 +71,7 @@
 // Checks whether pthread_cpu_number_np is available.
 #ifdef ABSL_HAVE_PTHREAD_CPU_NUMBER_NP
 #error ABSL_HAVE_PTHREAD_CPU_NUMBER_NP cannot be directly set
-#elif defined(__APPLE__) && defined(__has_include) &&              \
-    ((defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&    \
-      __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 110000) ||  \
-     (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) &&   \
-      __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 140200) || \
-     (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) &&    \
-      __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ >= 70100) ||   \
-     (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) &&       \
-      __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ >= 140200))
+#elif defined(__APPLE__)
 #define ABSL_HAVE_PTHREAD_CPU_NUMBER_NP 1
 #endif
 


### PR DESCRIPTION
The conditions are always satisfied based on the macOS [lower bound](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md) that has long moved past the versions being considered here.