### PR TITLE
Remove an obsolete //visibility:private tag

### DIFF
--- a/absl/strings/BUILD.bazel
+++ b/absl/strings/BUILD.bazel
@@ -435,7 +435,6 @@ cc_library(
     visibility = [
         "//absl:friends",
         "//absl/status:__pkg__",
-        "//visibility:private",
     ],
     deps = [
         ":string_view",


### PR DESCRIPTION
[Cherry-pick] Remove an obsolete //visibility:private tag

PiperOrigin-RevId: 924755156
Change-Id: I60faad5644dbcf53e1ca4a502f1eb4bf4dfd1b87
