### PR TITLE
Include x86gprintrin.h instead of bmi2intrin.h

### DIFF
--- a/absl/container/internal/raw_hash_set.h
+++ b/absl/container/internal/raw_hash_set.h
@@ -231,7 +231,7 @@
 #endif
 
 #ifdef __BMI2__
-#include <bmi2intrin.h>
+#include <x86gprintrin.h>
 #endif  // __BMI2__
 
 namespace absl {


### PR DESCRIPTION
GCC 16 produces an error when including `bmi2intrin.h` directly:

```
Never use <bmi2intrin.h> directly; include <x86gprintrin.h> instead.
```

See https://github.com/gcc-mirror/gcc/blob/cd33e5ad1945f19b5b1b2429ee62d1b3c8919914/gcc/config/i386/bmi2intrin.h#L24-L26.

This PR fixes failure to build with GCC 16 when the BMI2 extensions are enabled, e.g., when targeting `x86_64-v3`, by following the compiler’s advice.