### PR TITLE
docs: warn against using &v[0] on empty vectors in MakeSpan

### DIFF
--- a/absl/types/span.h
+++ b/absl/types/span.h
@@ -719,16 +719,8 @@ constexpr bool operator>=(Span<T> a, const U& b) {
 //     return absl::MakeSpan(&array[0], num_elements_);
 //   }
 //
-// NOTE: Do not use `&v[0]` or `&v[v.size()]` to construct spans from an empty
-// or potentially empty std::vector (or other dynamic container), as
-// dereferencing at those boundaries is undefined behavior. Use `.data()`
-// instead:
-//
-//   absl::MakeSpan(my_vector.data(), my_vector.size());
-//
-// Or simply pass the container directly:
-//
-//   absl::MakeSpan(my_vector);
+// NOTE: To avoid undefined behavior if the container is empty, use `.data()`
+// or pass the container directly instead of using `&v[0]` or `&v[v.size()]`.
 //
 template <int&... ExplicitArgumentBarrier, typename T>
 constexpr Span<T> MakeSpan(T* absl_nullable ptr ABSL_ATTRIBUTE_LIFETIME_BOUND,

--- a/absl/types/span.h
+++ b/absl/types/span.h
@@ -719,6 +719,17 @@ constexpr bool operator>=(Span<T> a, const U& b) {
 //     return absl::MakeSpan(&array[0], num_elements_);
 //   }
 //
+// NOTE: Do not use `&v[0]` or `&v[v.size()]` to construct spans from an empty
+// or potentially empty std::vector (or other dynamic container), as
+// dereferencing at those boundaries is undefined behavior. Use `.data()`
+// instead:
+//
+//   absl::MakeSpan(my_vector.data(), my_vector.size());
+//
+// Or simply pass the container directly:
+//
+//   absl::MakeSpan(my_vector);
+//
 template <int&... ExplicitArgumentBarrier, typename T>
 constexpr Span<T> MakeSpan(T* absl_nullable ptr ABSL_ATTRIBUTE_LIFETIME_BOUND,
                            size_t size) noexcept {


### PR DESCRIPTION
This PR adds a warning note to the documentation of  absl::MakeSpan  and  absl::MakeConstSpan  in  absl/types/span.h  regarding a common undefined
  behavior (UB) pitfall when constructing spans from  std::vector  (or other dynamic containers).

  #### The Problem

  Developers frequently try to initialize spans using array-like pointer boundaries:

    absl::MakeSpan(&v[0], v.size());

  However, if  v  is empty, dereferencing  v[0]  to obtain its address is undefined behavior in C++. Similarly, attempting to use  &v[v.size()]  to obtain a range-end pointer also triggers UB.

  #### The Fix

  This documentation update advises developers to use  .data()  instead:

    absl::MakeSpan(v.data(), v.size());

  Or simply pass the container directly to the container overload of  MakeSpan :

    absl::MakeSpan(v);

  This addresses the common pitfall discussed in Issue #1334.

  ### Related Issues:

  Closes #1334