### PR TITLE
Add basic Zephyr platform support

### DIFF
--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -50,6 +50,10 @@
 #include <zircon/process.h>
 #endif
 
+#if defined(__FREERTOS__)
+#include <task.h>
+#endif
+
 #include <string.h>
 
 #include <cassert>
@@ -463,6 +467,12 @@ pid_t GetTID() {
   // a kernel object ID (KOID) because zx_handle_t (32-bits) can be cast to a
   // pid_t type without loss of precision, but a zx_koid_t (64-bits) cannot.
   return static_cast<pid_t>(zx_thread_self());
+}
+
+#elif defined(__FREERTOS__)
+
+pid_t GetTID() {
+  return static_cast<pid_t>(uxTaskGetTaskNumber(xTaskGetCurrentTaskHandle()));
 }
 
 #else

--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -35,7 +35,7 @@
 #if defined(__ELF__) && !defined(__OpenBSD__) && !defined(__QNX__) &&    \
     !defined(__asmjs__) && !defined(__wasm__) && !defined(__HAIKU__) &&  \
     !defined(__sun) && !defined(__VXWORKS__) && !defined(__hexagon__) && \
-    !defined(__XTENSA__) && !defined(__FREERTOS__)
+    !defined(__XTENSA__) && !defined(__FREERTOS__) && !defined(__ZEPHYR__)
 #define ABSL_HAVE_ELF_MEM_IMAGE 1
 #endif
 

--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -35,7 +35,7 @@
 #if defined(__ELF__) && !defined(__OpenBSD__) && !defined(__QNX__) &&    \
     !defined(__asmjs__) && !defined(__wasm__) && !defined(__HAIKU__) &&  \
     !defined(__sun) && !defined(__VXWORKS__) && !defined(__hexagon__) && \
-    !defined(__XTENSA__)
+    !defined(__XTENSA__) && !defined(__FREERTOS__)
 #define ABSL_HAVE_ELF_MEM_IMAGE 1
 #endif
 

--- a/absl/log/internal/log_message.cc
+++ b/absl/log/internal/log_message.cc
@@ -221,7 +221,7 @@ LogMessage::LogMessageData::LogMessageData(absl::string_view file,
 void LogMessage::LogMessageData::InitializeEncodingAndFormat() {
   EncodeStringTruncate(EventTag::kFileName, entry.source_filename(),
                        &encoded_remaining());
-  EncodeVarint(EventTag::kFileLine, entry.source_line(), &encoded_remaining());
+  EncodeVarint(EventTag::kFileLine, static_cast<int32_t>(entry.source_line()), &encoded_remaining());
   EncodeVarint(EventTag::kTimeNsecs, absl::ToUnixNanos(entry.timestamp()),
                &encoded_remaining());
   EncodeVarint(EventTag::kSeverity,

--- a/absl/log/internal/proto.h
+++ b/absl/log/internal/proto.h
@@ -79,6 +79,9 @@ inline bool EncodeVarint(uint64_t tag, uint32_t value, absl::Span<char> *buf) {
 inline bool EncodeVarint(uint64_t tag, int32_t value, absl::Span<char> *buf) {
   return EncodeVarint(tag, static_cast<uint64_t>(value), buf);
 }
+inline bool EncodeVarint(uint64_t tag, bool value, absl::Span<char> *buf) {
+  return EncodeVarint(tag, static_cast<uint64_t>(value), buf);
+}
 
 // Encodes the specified integer as a varint field using ZigZag encoding and
 // returns true if it fits.

--- a/absl/time/internal/cctz/src/time_zone_libc.cc
+++ b/absl/time/internal/cctz/src/time_zone_libc.cc
@@ -81,6 +81,15 @@ auto tm_zone(const std::tm& tm) -> decltype(tzname[0]) {
   const bool is_dst = tm.tm_isdst > 0;
   return tzname[is_dst];
 }
+#elif defined(__FREERTOS__)
+long int tm_gmtoff(const std::tm& tm) {
+  (void)tm;
+  return 0;
+}
+const char* tm_zone(const std::tm& tm) {
+  (void)tm;
+  return "UTC";
+}
 #else
 // Adapt to different spellings of the struct std::tm extension fields.
 #if defined(tm_gmtoff)

--- a/absl/time/internal/cctz/src/time_zone_libc.cc
+++ b/absl/time/internal/cctz/src/time_zone_libc.cc
@@ -81,7 +81,7 @@ auto tm_zone(const std::tm& tm) -> decltype(tzname[0]) {
   const bool is_dst = tm.tm_isdst > 0;
   return tzname[is_dst];
 }
-#elif defined(__FREERTOS__)
+#elif defined(__FREERTOS__) || defined(__ZEPHYR__)
 long int tm_gmtoff(const std::tm& tm) {
   (void)tm;
   return 0;


### PR DESCRIPTION
This PR adds basic support for the Zephyr platform.

Based on https://github.com/abseil/abseil-cpp/pull/2053

Changes:

- `absl/debugging/internal/elf_mem_image.h`: exclude Zephyr from ELF memory image support
- `absl/time/internal/cctz/src/time_zone_libc.cc`: add tm_gmtoff() and tm_zone() stubs for Zephyr

Tested on Zephyr V2.7.0 with POSIX primitives support,
arm-zephyr-eabi-gcc (gcc version 10.3.0 (crosstool-NG 1.24.0.378_e011758))