### PR TITLE
Capture and emit function name in log messages

### DIFF
--- a/absl/log/die_if_null.cc
+++ b/absl/log/die_if_null.cc
@@ -24,8 +24,9 @@ ABSL_NAMESPACE_BEGIN
 namespace log_internal {
 
 void DieBecauseNull(const char* absl_nonnull file, int line,
+                    const char* absl_nonnull function,
                     const char* absl_nonnull exprtext) {
-  LOG(FATAL).AtLocation(file, line)
+  LOG(FATAL).AtLocation(file, line, function)
       << absl::StrCat("Check failed: '", exprtext, "' Must be non-null");
 }
 

--- a/absl/log/die_if_null.h
+++ b/absl/log/die_if_null.h
@@ -48,18 +48,21 @@
 // Use `CHECK(ptr)` or `CHECK(ptr != nullptr)` if the returned pointer is
 // unused.
 #define ABSL_DIE_IF_NULL(val) \
-  ::absl::log_internal::DieIfNull(__FILE__, __LINE__, #val, (val))
+  ::absl::log_internal::DieIfNull(__FILE__, __LINE__, __func__, #val, (val))
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace log_internal {
 
-// Crashes the process after logging `exprtext` annotated at the `file` and
-// `line` location. Called when `ABSL_DIE_IF_NULL` fails. Calling this function
-// generates less code than its implementation would if inlined, for a slight
-// code size reduction each time `ABSL_DIE_IF_NULL` is called.
+// Crashes the process after logging `exprtext` annotated at the `file`,
+// `line` and `function` location. Called when `ABSL_DIE_IF_NULL` fails.
+// Calling this function generates less code than its implementation would
+// if inlined, for a slight code size reduction each time `ABSL_DIE_IF_NULL`
+// is called.
 [[noreturn]] ABSL_ATTRIBUTE_NOINLINE void DieBecauseNull(
-    const char* absl_nonnull file, int line, const char* absl_nonnull exprtext);
+    const char* absl_nonnull file, int line,
+    const char* absl_nonnull function,
+    const char* absl_nonnull exprtext);
 
 // Helper for `ABSL_DIE_IF_NULL`.
 
@@ -70,10 +73,11 @@ template <typename T>
 [[nodiscard]] typename absl::base_internal::AddNonnullIfCompatible<
     std::remove_reference_t<T>>::type&
 DieIfNull(const char* absl_nonnull file, int line,
+          const char* absl_nonnull function,
           const char* absl_nonnull exprtext, T& t) {
   if (ABSL_PREDICT_FALSE(t == nullptr)) {
     // Call a non-inline helper function for a small code size improvement.
-    DieBecauseNull(file, line, exprtext);
+    DieBecauseNull(file, line, function, exprtext);
   }
   return t;
 }
@@ -82,10 +86,11 @@ template <typename T>
 [[nodiscard]] typename absl::base_internal::AddNonnullIfCompatible<
     std::remove_reference_t<T>>::type&&
 DieIfNull(const char* absl_nonnull file, int line,
+          const char* absl_nonnull function,
           const char* absl_nonnull exprtext, T&& t) {
   if (ABSL_PREDICT_FALSE(t == nullptr)) {
     // Call a non-inline helper function for a small code size improvement.
-    DieBecauseNull(file, line, exprtext);
+    DieBecauseNull(file, line, function, exprtext);
   }
   return std::forward<T>(t);
 }

--- a/absl/log/internal/log_format.cc
+++ b/absl/log/internal/log_format.cc
@@ -146,6 +146,7 @@ size_t FormatBoundedFields(absl::LogSeverity severity, absl::Time timestamp,
   return bytes_formatted;
 }
 
+// Writes `:<line>` to `buf`.
 size_t FormatLineNumber(int line, absl::Span<char>& buf) {
   constexpr size_t kLineFieldMaxLen =
       sizeof(":] ") + (1 + std::numeric_limits<int>::digits10 + 1) - sizeof("");
@@ -158,11 +159,34 @@ size_t FormatLineNumber(int line, absl::Span<char>& buf) {
   char* p = buf.data();
   *p++ = ':';
   p = absl::numbers_internal::FastIntToBuffer(line, p);
-  *p++ = ']';
-  *p++ = ' ';
   const size_t bytes_formatted = static_cast<size_t>(p - buf.data());
   buf.remove_prefix(bytes_formatted);
   return bytes_formatted;
+}
+
+// Writes ` <function>` to `buf` when `function` is non-empty (no-op otherwise).
+// The function name itself may be truncated (via `AppendTruncated`) when the
+// buffer cannot hold it.
+size_t FormatFunctionName(absl::string_view function, absl::Span<char>& buf) {
+  if (ABSL_PREDICT_FALSE(buf.empty()) || function.empty()) {
+    return 0;
+  }
+  buf.data()[0] = ' ';
+  buf.remove_prefix(1);
+  return 1 + log_internal::AppendTruncated(function, buf);
+}
+
+// Writes the trailing `] ` to `buf`. Returns 2 on success, or 0 (and drops
+// any remaining buffer capacity) if there isn't room.
+size_t FormatClosingBracket(absl::Span<char>& buf) {
+  if (ABSL_PREDICT_FALSE(buf.size() < 2)) {
+    buf.remove_suffix(buf.size());
+    return 0;
+  }
+  buf.data()[0] = ']';
+  buf.data()[1] = ' ';
+  buf.remove_prefix(2);
+  return 2;
 }
 
 }  // namespace
@@ -171,30 +195,37 @@ std::string FormatLogMessage(absl::LogSeverity severity,
                              absl::CivilSecond civil_second,
                              absl::Duration subsecond, log_internal::Tid tid,
                              absl::string_view basename, int line,
-                             PrefixFormat format, absl::string_view message) {
+                             absl::string_view function, PrefixFormat format,
+                             absl::string_view message) {
   return absl::StrFormat(
-      "%c%02d%02d %02d:%02d:%02d.%06d %7d %s:%d] %s%s",
+      "%c%02d%02d %02d:%02d:%02d.%06d %7d %s:%d%s%s] %s%s",
       absl::LogSeverityName(severity)[0], civil_second.month(),
       civil_second.day(), civil_second.hour(), civil_second.minute(),
       civil_second.second(), absl::ToInt64Microseconds(subsecond), tid,
-      basename, line, format == PrefixFormat::kRaw ? "RAW: " : "", message);
+      basename, line, function.empty() ? "" : " ", function,
+      format == PrefixFormat::kRaw ? "RAW: " : "", message);
 }
 
 // This method is fairly hot, and the library always passes a huge `buf`, so we
 // save some bounds-checking cycles by not trying to do precise truncation.
 // Truncating at a field boundary is probably a better UX anyway.
 //
-// The prefix is written in three parts, each of which does a single
+// The prefix is written in several parts, each of which does a single
 // bounds-check and truncation:
 // 1. severity, timestamp, and thread ID
 // 2. filename
-// 3. line number and bracket
+// 3. line number
+// 4. (optional) function name
+// 5. closing bracket
 size_t FormatLogPrefix(absl::LogSeverity severity, absl::Time timestamp,
                        log_internal::Tid tid, absl::string_view basename,
-                       int line, PrefixFormat format, absl::Span<char>& buf) {
+                       int line, absl::string_view function,
+                       PrefixFormat format, absl::Span<char>& buf) {
   auto prefix_size = FormatBoundedFields(severity, timestamp, tid, buf);
   prefix_size += log_internal::AppendTruncated(basename, buf);
   prefix_size += FormatLineNumber(line, buf);
+  prefix_size += FormatFunctionName(function, buf);
+  prefix_size += FormatClosingBracket(buf);
   if (format == PrefixFormat::kRaw)
     prefix_size += log_internal::AppendTruncated("RAW: ", buf);
   return prefix_size;

--- a/absl/log/internal/log_format.h
+++ b/absl/log/internal/log_format.h
@@ -48,7 +48,8 @@ std::string FormatLogMessage(absl::LogSeverity severity,
                              absl::CivilSecond civil_second,
                              absl::Duration subsecond, log_internal::Tid tid,
                              absl::string_view basename, int line,
-                             PrefixFormat format, absl::string_view message);
+                             absl::string_view function, PrefixFormat format,
+                             absl::string_view message);
 
 // Formats various entry metadata into a text string meant for use as a
 // prefix on a log message string.  Writes into `buf`, advances `buf` to point
@@ -59,7 +60,7 @@ std::string FormatLogMessage(absl::LogSeverity severity,
 // function may also do `buf->remove_suffix(buf->size())` in cases where no more
 // bytes (i.e. no message data) should be written into the buffer.  For example,
 // if the prefix ought to be:
-//   I0926 09:00:00.000000 1234567 foo.cc:123]
+//   I0926 09:00:00.000000 1234567 foo.cc:123 test]
 // `buf` is too small, the function might fill the whole buffer:
 //   I0926 09:00:00.000000 1234
 // (note the apparrently incorrect thread ID), or it might write less:
@@ -69,7 +70,8 @@ std::string FormatLogMessage(absl::LogSeverity severity,
 // see a thread ID.
 size_t FormatLogPrefix(absl::LogSeverity severity, absl::Time timestamp,
                        log_internal::Tid tid, absl::string_view basename,
-                       int line, PrefixFormat format, absl::Span<char>& buf);
+                       int line, absl::string_view function,
+                       PrefixFormat format, absl::Span<char>& buf);
 
 }  // namespace log_internal
 ABSL_NAMESPACE_END

--- a/absl/log/internal/log_message.cc
+++ b/absl/log/internal/log_message.cc
@@ -151,6 +151,7 @@ void WriteToStream(const char* data, void* os) {
 
 struct LogMessage::LogMessageData final {
   LogMessageData(absl::string_view file, int line,
+                 absl::string_view function,
                  absl::LogSeverity severity, absl::Time timestamp);
   LogMessageData(const LogMessageData&) = delete;
   LogMessageData& operator=(const LogMessageData&) = delete;
@@ -202,8 +203,9 @@ struct LogMessage::LogMessageData final {
   void FinalizeEncodingAndFormat();
 };
 
-LogMessage::LogMessageData::LogMessageData(absl::string_view file,
-                                           int line, absl::LogSeverity severity,
+LogMessage::LogMessageData::LogMessageData(absl::string_view file, int line,
+                                           absl::string_view function,
+                                           absl::LogSeverity severity,
                                            absl::Time timestamp)
     : extra_sinks_only(false), manipulated(nullptr) {
   // Legacy defaults for LOG's ostream:
@@ -211,6 +213,7 @@ LogMessage::LogMessageData::LogMessageData(absl::string_view file,
   entry.full_filename_ = file;
   entry.base_filename_ = Basename(file);
   entry.line_ = line;
+  entry.function_name_ = function;
   entry.prefix_ = absl::ShouldPrependLogPrefix();
   entry.severity_ = absl::NormalizeLogSeverity(severity);
   entry.verbose_level_ = absl::LogEntry::kNoVerbosityLevel;
@@ -250,6 +253,7 @@ void LogMessage::LogMessageData::FinalizeEncodingAndFormat() {
       entry.prefix() ? log_internal::FormatLogPrefix(
                            entry.log_severity(), entry.timestamp(), entry.tid(),
                            entry.source_basename(), entry.source_line(),
+                           entry.source_function_name(),
                            log_internal::ThreadIsLoggingToLogSink()
                                ? PrefixFormat::kRaw
                                : PrefixFormat::kNotRaw,
@@ -275,12 +279,15 @@ void LogMessage::LogMessageData::FinalizeEncodingAndFormat() {
 }
 
 LogMessage::LogMessage(const char* absl_nonnull file, int line,
+                       const char* absl_nonnull function,
                        absl::LogSeverity severity)
-  : LogMessage(absl::string_view(file), line, severity) {}
+  : LogMessage(absl::string_view(file), line,
+               absl::string_view(function), severity) {}
 LogMessage::LogMessage(absl::string_view file, int line,
+                       absl::string_view function,
                        absl::LogSeverity severity)
     : data_(
-          std::make_unique<LogMessageData>(file, line, severity, absl::Now())) {
+          std::make_unique<LogMessageData>(file, line, function, severity, absl::Now())) {
   data_->first_fatal = false;
   data_->is_perror = false;
   data_->fail_quietly = false;
@@ -291,20 +298,25 @@ LogMessage::LogMessage(absl::string_view file, int line,
   LogBacktraceIfNeeded();
 }
 
-LogMessage::LogMessage(const char* absl_nonnull file, int line, InfoTag)
-    : LogMessage(file, line, absl::LogSeverity::kInfo) {}
-LogMessage::LogMessage(const char* absl_nonnull file, int line, WarningTag)
-    : LogMessage(file, line, absl::LogSeverity::kWarning) {}
-LogMessage::LogMessage(const char* absl_nonnull file, int line, ErrorTag)
-    : LogMessage(file, line, absl::LogSeverity::kError) {}
+LogMessage::LogMessage(const char* absl_nonnull file, int line,
+                       const char* absl_nonnull function, InfoTag)
+    : LogMessage(file, line, function, absl::LogSeverity::kInfo) {}
+LogMessage::LogMessage(const char* absl_nonnull file, int line,
+                       const char* absl_nonnull function, WarningTag)
+    : LogMessage(file, line, function, absl::LogSeverity::kWarning) {}
+LogMessage::LogMessage(const char* absl_nonnull file, int line,
+                       const char* absl_nonnull function, ErrorTag)
+    : LogMessage(file, line, function, absl::LogSeverity::kError) {}
 
 // This cannot go in the header since LogMessageData is defined in this file.
 LogMessage::~LogMessage() = default;
 
-LogMessage& LogMessage::AtLocation(absl::string_view file, int line) {
+LogMessage& LogMessage::AtLocation(absl::string_view file, int line,
+                                   absl::string_view function) {
   data_->entry.full_filename_ = file;
   data_->entry.base_filename_ = Basename(file);
   data_->entry.line_ = line;
+  data_->entry.function_name_ = function;
   LogBacktraceIfNeeded();
   return *this;
 }
@@ -337,6 +349,7 @@ LogMessage& LogMessage::WithMetadataFrom(const absl::LogEntry& entry) {
   data_->entry.full_filename_ = entry.full_filename_;
   data_->entry.base_filename_ = entry.base_filename_;
   data_->entry.line_ = entry.line_;
+  data_->entry.function_name_ = entry.function_name_;
   data_->entry.prefix_ = entry.prefix_;
   data_->entry.severity_ = entry.severity_;
   data_->entry.verbose_level_ = entry.verbose_level_;
@@ -739,41 +752,45 @@ void LogMessage::CopyToEncodedBufferWithStructuredProtoField(
 #pragma warning(disable : 4722)
 #endif
 
-LogMessageFatal::LogMessageFatal(const char* absl_nonnull file, int line)
-    : LogMessage(file, line, absl::LogSeverity::kFatal) {}
+LogMessageFatal::LogMessageFatal(const char* absl_nonnull file, int line,
+                                 const char* absl_nonnull function)
+    : LogMessage(file, line, function, absl::LogSeverity::kFatal) {}
 
 LogMessageFatal::LogMessageFatal(const char* absl_nonnull file, int line,
+                                 const char* absl_nonnull function,
                                  const char* absl_nonnull failure_msg)
-    : LogMessage(file, line, absl::LogSeverity::kFatal) {
+    : LogMessage(file, line, function, absl::LogSeverity::kFatal) {
   *this << "Check failed: " << failure_msg << " ";
 }
 
 LogMessageFatal::~LogMessageFatal() { FailWithoutStackTrace(); }
 
-LogMessageDebugFatal::LogMessageDebugFatal(const char* absl_nonnull file,
-                                           int line)
-    : LogMessage(file, line, absl::LogSeverity::kFatal) {}
+LogMessageDebugFatal::LogMessageDebugFatal(const char* absl_nonnull file, int line,
+                                           const char* absl_nonnull function)
+    : LogMessage(file, line, function, absl::LogSeverity::kFatal) {}
 
 LogMessageDebugFatal::~LogMessageDebugFatal() { FailWithoutStackTrace(); }
 
 LogMessageQuietlyDebugFatal::LogMessageQuietlyDebugFatal(
-    const char* absl_nonnull file, int line)
-    : LogMessage(file, line, absl::LogSeverity::kFatal) {
+    const char* absl_nonnull file, int line,
+    const char* absl_nonnull function)
+    : LogMessage(file, line, function, absl::LogSeverity::kFatal) {
   SetFailQuietly();
 }
 
 LogMessageQuietlyDebugFatal::~LogMessageQuietlyDebugFatal() { FailQuietly(); }
 
-LogMessageQuietlyFatal::LogMessageQuietlyFatal(const char* absl_nonnull file,
-                                               int line)
-    : LogMessage(file, line, absl::LogSeverity::kFatal) {
+LogMessageQuietlyFatal::LogMessageQuietlyFatal(const char* absl_nonnull file, int line,
+                                               const char* absl_nonnull function)
+    : LogMessage(file, line, function, absl::LogSeverity::kFatal) {
   SetFailQuietly();
 }
 
 LogMessageQuietlyFatal::LogMessageQuietlyFatal(
     const char* absl_nonnull file, int line,
+    const char* absl_nonnull function,
     const char* absl_nonnull failure_msg)
-    : LogMessageQuietlyFatal(file, line) {
+    : LogMessageQuietlyFatal(file, line, function) {
   *this << "Check failed: " << failure_msg << " ";
 }
 

--- a/absl/log/internal/log_message.h
+++ b/absl/log/internal/log_message.h
@@ -69,29 +69,39 @@ class LogMessage {
   // Used for `LOG`.  Taking `const char *` instead of `string_view` keeps
   // callsites a little bit smaller at the cost of doing `strlen` at runtime.
   LogMessage(const char* absl_nonnull file, int line,
+             const char* absl_nonnull function,
              absl::LogSeverity severity) ABSL_ATTRIBUTE_COLD;
   // Used for FFI integrations that don't have a NUL-terminated string.
   LogMessage(absl::string_view file, int line,
+             absl::string_view function,
              absl::LogSeverity severity) ABSL_ATTRIBUTE_COLD;
   // These constructors are slightly smaller/faster to call; the severity is
   // curried into the function pointer.
   LogMessage(const char* absl_nonnull file, int line,
+             const char* absl_nonnull function,
              InfoTag) ABSL_ATTRIBUTE_COLD ABSL_ATTRIBUTE_NOINLINE;
   LogMessage(const char* absl_nonnull file, int line,
+             const char* absl_nonnull function,
              WarningTag) ABSL_ATTRIBUTE_COLD ABSL_ATTRIBUTE_NOINLINE;
   LogMessage(const char* absl_nonnull file, int line,
+             const char* absl_nonnull function,
              ErrorTag) ABSL_ATTRIBUTE_COLD ABSL_ATTRIBUTE_NOINLINE;
   LogMessage(const LogMessage&) = delete;
   LogMessage& operator=(const LogMessage&) = delete;
   ~LogMessage() ABSL_ATTRIBUTE_COLD;
 
-  // Overrides the location inferred from the callsite.  The string pointed to
-  // by `file` must be valid until the end of the statement.
-  LogMessage& AtLocation(absl::string_view file, int line);
+  // Overrides the location inferred from the callsite.  The strings pointed to
+  // by `file` and `function` must be valid until the end of the statement.
+  LogMessage& AtLocation(absl::string_view file, int line,
+                         absl::string_view function);
+  LogMessage& AtLocation(absl::string_view file, int line) {
+    return AtLocation(file, line, {});
+  }
   // `loc` doesn't default to `absl::SourceLocation::current()` here since the
   // callsite is already the default location for `LOG` statements.
   LogMessage& AtLocation(absl::SourceLocation loc) {
-    return AtLocation(loc.file_name(), static_cast<int>(loc.line()));
+    return AtLocation(loc.file_name(), static_cast<int>(loc.line()),
+                      loc.function_name());
   }
   // Omits the prefix from this line.  The prefix includes metadata about the
   // logged data such as source code location and timestamp.
@@ -422,8 +432,10 @@ extern template void LogMessage::CopyToEncodedBuffer<
 // message.
 class LogMessageFatal final : public LogMessage {
  public:
-  LogMessageFatal(const char* absl_nonnull file, int line) ABSL_ATTRIBUTE_COLD;
   LogMessageFatal(const char* absl_nonnull file, int line,
+                  const char* absl_nonnull function) ABSL_ATTRIBUTE_COLD;
+  LogMessageFatal(const char* absl_nonnull file, int line,
+                  const char* absl_nonnull function,
                   const char* absl_nonnull failure_msg) ABSL_ATTRIBUTE_COLD;
   [[noreturn]] ~LogMessageFatal();
 };
@@ -433,8 +445,8 @@ class LogMessageFatal final : public LogMessage {
 // for DLOG(FATAL) variants.
 class LogMessageDebugFatal final : public LogMessage {
  public:
-  LogMessageDebugFatal(const char* absl_nonnull file,
-                       int line) ABSL_ATTRIBUTE_COLD;
+  LogMessageDebugFatal(const char* absl_nonnull file, int line,
+                       const char* absl_nonnull function) ABSL_ATTRIBUTE_COLD;
   ~LogMessageDebugFatal();
 };
 
@@ -443,17 +455,19 @@ class LogMessageQuietlyDebugFatal final : public LogMessage {
   // DLOG(QFATAL) calls this instead of LogMessageQuietlyFatal to make sure the
   // destructor is not [[noreturn]] even if this is always FATAL as this is only
   // invoked when DLOG() is enabled.
-  LogMessageQuietlyDebugFatal(const char* absl_nonnull file,
-                              int line) ABSL_ATTRIBUTE_COLD;
+  LogMessageQuietlyDebugFatal(const char* absl_nonnull file, int line,
+                              const char* absl_nonnull function)
+      ABSL_ATTRIBUTE_COLD;
   ~LogMessageQuietlyDebugFatal();
 };
 
 // Used for LOG(QFATAL) to make sure it's properly understood as [[noreturn]].
 class LogMessageQuietlyFatal final : public LogMessage {
  public:
-  LogMessageQuietlyFatal(const char* absl_nonnull file,
-                         int line) ABSL_ATTRIBUTE_COLD;
   LogMessageQuietlyFatal(const char* absl_nonnull file, int line,
+                         const char* absl_nonnull function) ABSL_ATTRIBUTE_COLD;
+  LogMessageQuietlyFatal(const char* absl_nonnull file, int line,
+                         const char* absl_nonnull function,
                          const char* absl_nonnull failure_msg)
       ABSL_ATTRIBUTE_COLD;
   [[noreturn]] ~LogMessageQuietlyFatal();

--- a/absl/log/internal/strip.h
+++ b/absl/log/internal/strip.h
@@ -55,35 +55,35 @@
 
 #define ABSL_LOG_INTERNAL_LOG_INFO  \
   ::absl::log_internal::LogMessage( \
-      __FILE__, __LINE__, ::absl::log_internal::LogMessage::InfoTag{})
+      __FILE__, __LINE__, __func__, ::absl::log_internal::LogMessage::InfoTag{})
 #define ABSL_LOG_INTERNAL_LOG_WARNING \
   ::absl::log_internal::LogMessage(   \
-      __FILE__, __LINE__, ::absl::log_internal::LogMessage::WarningTag{})
+      __FILE__, __LINE__, __func__, ::absl::log_internal::LogMessage::WarningTag{})
 #define ABSL_LOG_INTERNAL_LOG_ERROR \
   ::absl::log_internal::LogMessage( \
-      __FILE__, __LINE__, ::absl::log_internal::LogMessage::ErrorTag{})
+      __FILE__, __LINE__, __func__, ::absl::log_internal::LogMessage::ErrorTag{})
 #define ABSL_LOG_INTERNAL_LOG_FATAL \
-  ::absl::log_internal::LogMessageFatal(__FILE__, __LINE__)
+  ::absl::log_internal::LogMessageFatal(__FILE__, __LINE__, __func__)
 #define ABSL_LOG_INTERNAL_LOG_QFATAL \
-  ::absl::log_internal::LogMessageQuietlyFatal(__FILE__, __LINE__)
+  ::absl::log_internal::LogMessageQuietlyFatal(__FILE__, __LINE__, __func__)
 #define ABSL_LOG_INTERNAL_LOG_DFATAL \
-  ::absl::log_internal::LogMessage(__FILE__, __LINE__, ::absl::kLogDebugFatal)
+  ::absl::log_internal::LogMessage(__FILE__, __LINE__, __func__, ::absl::kLogDebugFatal)
 #define ABSL_LOG_INTERNAL_LOG_LEVEL(severity)          \
-  ::absl::log_internal::LogMessage(__FILE__, __LINE__, \
+  ::absl::log_internal::LogMessage(__FILE__, __LINE__, __func__, \
                                    absl_log_internal_severity)
 
 // Fatal `DLOG`s expand a little differently to avoid being `[[noreturn]]`.
 #define ABSL_LOG_INTERNAL_DLOG_FATAL \
-  ::absl::log_internal::LogMessageDebugFatal(__FILE__, __LINE__)
+  ::absl::log_internal::LogMessageDebugFatal(__FILE__, __LINE__, __func__)
 #define ABSL_LOG_INTERNAL_DLOG_QFATAL \
-  ::absl::log_internal::LogMessageQuietlyDebugFatal(__FILE__, __LINE__)
+  ::absl::log_internal::LogMessageQuietlyDebugFatal(__FILE__, __LINE__, __func__)
 
 // These special cases dispatch to special-case constructors that allow us to
 // avoid an extra function call and shrink non-LTO binaries by a percent or so.
 #define ABSL_LOG_INTERNAL_CHECK(failure_message) \
-  ::absl::log_internal::LogMessageFatal(__FILE__, __LINE__, failure_message)
+  ::absl::log_internal::LogMessageFatal(__FILE__, __LINE__, __func__, failure_message)
 #define ABSL_LOG_INTERNAL_QCHECK(failure_message)                  \
-  ::absl::log_internal::LogMessageQuietlyFatal(__FILE__, __LINE__, \
+  ::absl::log_internal::LogMessageQuietlyFatal(__FILE__, __LINE__, __func__, \
                                                failure_message)
 #endif  // !defined(STRIP_LOG) || !STRIP_LOG
 

--- a/absl/log/internal/test_matchers.cc
+++ b/absl/log/internal/test_matchers.cc
@@ -117,6 +117,12 @@ Matcher<const absl::LogEntry&> SourceLine(
   return Property("source_line", &absl::LogEntry::source_line, source_line);
 }
 
+Matcher<const absl::LogEntry&> SourceFunctionName(
+    const Matcher<absl::string_view>& source_function_name) {
+  return Property("source_function_name",
+                  &absl::LogEntry::source_function_name, source_function_name);
+}
+
 Matcher<const absl::LogEntry&> Prefix(
     const Matcher<bool>& prefix) {
   return Property("prefix", &absl::LogEntry::prefix, prefix);

--- a/absl/log/internal/test_matchers.h
+++ b/absl/log/internal/test_matchers.h
@@ -54,6 +54,8 @@ namespace log_internal {
 // within the code block that's expected to die.
 ::testing::Matcher<const absl::LogEntry&> SourceLine(
     const ::testing::Matcher<int>& source_line);
+::testing::Matcher<const absl::LogEntry&> SourceFunctionName(
+    const ::testing::Matcher<absl::string_view>& source_function_name);
 ::testing::Matcher<const absl::LogEntry&> Prefix(
     const ::testing::Matcher<bool>& prefix);
 ::testing::Matcher<const absl::LogEntry&> LogSeverity(

--- a/absl/log/log_entry.h
+++ b/absl/log/log_entry.h
@@ -64,15 +64,17 @@ class LogEntry final {
   LogEntry(const LogEntry&) = delete;
   LogEntry& operator=(const LogEntry&) = delete;
 
-  // Source file and line where the log message occurred.  Taken from `__FILE__`
-  // and `__LINE__` unless overridden by `LOG(...).AtLocation(...)`.
+  // Source file, line and function name where the log message occurred.
+  // Taken from `__FILE__`, `__LINE__` and `__func__` unless overridden
+  // by `LOG(...).AtLocation(...)`.
   //
-  // Take special care not to use the values returned by `source_filename()` and
-  // `source_basename()` after the lifetime of the entry.  This is always
-  // incorrect, but it will often work in practice because they usually point
-  // into a statically allocated character array obtained from `__FILE__`.
-  // Statements like `LOG(INFO).AtLocation(std::string(...), ...)` will expose
-  // the bug.  If you need the data later, you must copy them.
+  // Take special care not to use the values returned by `source_filename()`,
+  // `source_basename()` and `source_function_name()` after the lifetime of
+  // the entry.  This is always incorrect, but it will often work in practice
+  // because they usually point into a statically allocated character array
+  // obtained from `__FILE__`. Statements like
+  // `LOG(INFO).AtLocation(std::string(...), ...)` will expose the bug.  If
+  // you need the data later, you must copy them.
   absl::string_view source_filename() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
     return full_filename_;
   }
@@ -80,6 +82,9 @@ class LogEntry final {
     return base_filename_;
   }
   int source_line() const { return line_; }
+  absl::string_view source_function_name() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return function_name_;
+  }
 
   // LogEntry::prefix()
   //
@@ -202,6 +207,7 @@ class LogEntry final {
   absl::string_view full_filename_;
   absl::string_view base_filename_;
   int line_;
+  absl::string_view function_name_;
   bool prefix_;
   absl::LogSeverity severity_;
   int verbose_level_;  // >=0 for `VLOG`, etc.; otherwise `kNoVerbosityLevel`.

--- a/absl/log/log_entry_test.cc
+++ b/absl/log/log_entry_test.cc
@@ -57,13 +57,15 @@ namespace log_internal {
 
 class LogEntryTestPeer {
  public:
-  LogEntryTestPeer(absl::string_view base_filename, int line, bool prefix,
+  LogEntryTestPeer(absl::string_view base_filename, int line,
+                   absl::string_view function_name, bool prefix,
                    absl::LogSeverity severity, absl::string_view timestamp,
                    absl::LogEntry::tid_t tid, PrefixFormat format,
                    absl::string_view text_message)
       : format_{format}, buf_(15000, '\0') {
     entry_.base_filename_ = base_filename;
     entry_.line_ = line;
+    entry_.function_name_ = function_name;
     entry_.prefix_ = prefix;
     entry_.severity_ = severity;
     std::string time_err;
@@ -89,7 +91,8 @@ class LogEntryTestPeer {
         entry_.prefix_
             ? log_internal::FormatLogPrefix(
                   entry_.log_severity(), entry_.timestamp(), entry_.tid(),
-                  entry_.source_basename(), entry_.source_line(), format_, view)
+                  entry_.source_basename(), entry_.source_line(),
+                  entry_.source_function_name(), format_, view)
             : 0;
 
     EXPECT_THAT(entry_.prefix_len_,
@@ -108,15 +111,16 @@ class LogEntryTestPeer {
   std::string FormatLogMessage() const {
     return log_internal::FormatLogMessage(
         entry_.log_severity(), ci_.cs, ci_.subsecond, entry_.tid(),
-        entry_.source_basename(), entry_.source_line(), format_,
-        entry_.text_message());
+        entry_.source_basename(), entry_.source_line(),
+        entry_.source_function_name(), format_, entry_.text_message());
   }
   std::string FormatPrefixIntoSizedBuffer(size_t sz) {
     std::string str(sz, '\0');
     absl::Span<char> buf(&str[0], str.size());
     const size_t prefix_size = log_internal::FormatLogPrefix(
         entry_.log_severity(), entry_.timestamp(), entry_.tid(),
-        entry_.source_basename(), entry_.source_line(), format_, buf);
+        entry_.source_basename(), entry_.source_line(),
+        entry_.source_function_name(), format_, buf);
     EXPECT_THAT(prefix_size, Eq(static_cast<size_t>(buf.data() - str.data())));
     str.resize(prefix_size);
     return str;
@@ -138,42 +142,49 @@ namespace {
 constexpr bool kUsePrefix = true, kNoPrefix = false;
 
 TEST(LogEntryTest, Baseline) {
-  LogEntryTestPeer entry("foo.cc", 1234, kUsePrefix, absl::LogSeverity::kInfo,
-                         "2020-01-02T03:04:05.6789", 451,
-                         absl::log_internal::PrefixFormat::kNotRaw,
+  LogEntryTestPeer entry("foo.cc", 1234, "MyFunc", kUsePrefix,
+                         absl::LogSeverity::kInfo, "2020-01-02T03:04:05.6789",
+                         451, absl::log_internal::PrefixFormat::kNotRaw,
                          "hello world");
-  EXPECT_THAT(entry.FormatLogMessage(),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] hello world"));
+  EXPECT_THAT(
+      entry.FormatLogMessage(),
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] hello world"));
   EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] "));
-  for (size_t sz = strlen("I0102 03:04:05.678900     451 foo.cc:1234] ") + 20;
+              Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] "));
+  for (size_t sz =
+           strlen("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] ") + 20;
        sz != std::numeric_limits<size_t>::max(); sz--)
-    EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:1234] ",
+    EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] ",
                 StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
-  EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline(),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] hello world\n"));
+  EXPECT_THAT(
+      entry.entry().text_message_with_prefix_and_newline(),
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] hello world\n"));
   EXPECT_THAT(
       entry.entry().text_message_with_prefix_and_newline_c_str(),
-      StrEq("I0102 03:04:05.678900     451 foo.cc:1234] hello world\n"));
-  EXPECT_THAT(entry.entry().text_message_with_prefix(),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] hello world"));
+      StrEq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] hello world\n"));
+  EXPECT_THAT(
+      entry.entry().text_message_with_prefix(),
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] hello world"));
   EXPECT_THAT(entry.entry().text_message(), Eq("hello world"));
+  EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
 }
 
 TEST(LogEntryTest, NoPrefix) {
-  LogEntryTestPeer entry("foo.cc", 1234, kNoPrefix, absl::LogSeverity::kInfo,
-                         "2020-01-02T03:04:05.6789", 451,
-                         absl::log_internal::PrefixFormat::kNotRaw,
+  LogEntryTestPeer entry("foo.cc", 1234, "MyFunc", kNoPrefix,
+                         absl::LogSeverity::kInfo, "2020-01-02T03:04:05.6789",
+                         451, absl::log_internal::PrefixFormat::kNotRaw,
                          "hello world");
-  EXPECT_THAT(entry.FormatLogMessage(),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] hello world"));
+  EXPECT_THAT(
+      entry.FormatLogMessage(),
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] hello world"));
   // These methods are not responsible for honoring `prefix()`.
   EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] "));
-  for (size_t sz = strlen("I0102 03:04:05.678900     451 foo.cc:1234] ") + 20;
+              Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] "));
+  for (size_t sz =
+           strlen("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] ") + 20;
        sz != std::numeric_limits<size_t>::max(); sz--)
-    EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:1234] ",
+    EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] ",
                 StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
   EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline(),
@@ -182,11 +193,14 @@ TEST(LogEntryTest, NoPrefix) {
               StrEq("hello world\n"));
   EXPECT_THAT(entry.entry().text_message_with_prefix(), Eq("hello world"));
   EXPECT_THAT(entry.entry().text_message(), Eq("hello world"));
+  EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
 }
 
+// Empty function name: the prefix must NOT contain a function segment (so the
+// formatted prefix should look just like it did before this feature was added).
 TEST(LogEntryTest, EmptyFields) {
-  LogEntryTestPeer entry("", 0, kUsePrefix, absl::LogSeverity::kInfo,
-                         "2020-01-02T03:04:05", 0,
+  LogEntryTestPeer entry("", 0, /*function_name=*/"", kUsePrefix,
+                         absl::LogSeverity::kInfo, "2020-01-02T03:04:05", 0,
                          absl::log_internal::PrefixFormat::kNotRaw, "");
   const std::string format_message = entry.FormatLogMessage();
   EXPECT_THAT(format_message, Eq("I0102 03:04:05.000000       0 :0] "));
@@ -203,6 +217,7 @@ TEST(LogEntryTest, EmptyFields) {
   EXPECT_THAT(entry.entry().text_message_with_prefix(),
               Eq("I0102 03:04:05.000000       0 :0] "));
   EXPECT_THAT(entry.entry().text_message(), Eq(""));
+  EXPECT_THAT(entry.entry().source_function_name(), Eq(""));
 }
 
 TEST(LogEntryTest, NegativeFields) {
@@ -210,52 +225,58 @@ TEST(LogEntryTest, NegativeFields) {
   // converted to a constexpr if and the static_cast below removed.
   if (std::is_signed_v<absl::LogEntry::tid_t>) {
     LogEntryTestPeer entry(
-        "foo.cc", -1234, kUsePrefix, absl::LogSeverity::kInfo,
+        "foo.cc", -1234, "MyFunc", kUsePrefix, absl::LogSeverity::kInfo,
         "2020-01-02T03:04:05.6789", static_cast<absl::LogEntry::tid_t>(-451),
         absl::log_internal::PrefixFormat::kNotRaw, "hello world");
-    EXPECT_THAT(entry.FormatLogMessage(),
-                Eq("I0102 03:04:05.678900    -451 foo.cc:-1234] hello world"));
+    EXPECT_THAT(
+        entry.FormatLogMessage(),
+        Eq("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] hello world"));
     EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
-                Eq("I0102 03:04:05.678900    -451 foo.cc:-1234] "));
+                Eq("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] "));
     for (size_t sz =
-             strlen("I0102 03:04:05.678900    -451 foo.cc:-1234] ") + 20;
+             strlen("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] ") + 20;
          sz != std::numeric_limits<size_t>::max(); sz--)
-      EXPECT_THAT("I0102 03:04:05.678900    -451 foo.cc:-1234] ",
+      EXPECT_THAT("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] ",
                   StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
+    EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline(),
+                Eq("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] hello "
+                   "world\n"));
+    EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline_c_str(),
+                StrEq("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] "
+                      "hello world\n"));
     EXPECT_THAT(
-        entry.entry().text_message_with_prefix_and_newline(),
-        Eq("I0102 03:04:05.678900    -451 foo.cc:-1234] hello world\n"));
-    EXPECT_THAT(
-        entry.entry().text_message_with_prefix_and_newline_c_str(),
-        StrEq("I0102 03:04:05.678900    -451 foo.cc:-1234] hello world\n"));
-    EXPECT_THAT(entry.entry().text_message_with_prefix(),
-                Eq("I0102 03:04:05.678900    -451 foo.cc:-1234] hello world"));
+        entry.entry().text_message_with_prefix(),
+        Eq("I0102 03:04:05.678900    -451 foo.cc:-1234 MyFunc] hello world"));
     EXPECT_THAT(entry.entry().text_message(), Eq("hello world"));
+    EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
   } else {
-    LogEntryTestPeer entry("foo.cc", -1234, kUsePrefix,
+    LogEntryTestPeer entry("foo.cc", -1234, "MyFunc", kUsePrefix,
                            absl::LogSeverity::kInfo, "2020-01-02T03:04:05.6789",
                            451, absl::log_internal::PrefixFormat::kNotRaw,
                            "hello world");
-    EXPECT_THAT(entry.FormatLogMessage(),
-                Eq("I0102 03:04:05.678900     451 foo.cc:-1234] hello world"));
+    EXPECT_THAT(
+        entry.FormatLogMessage(),
+        Eq("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] hello world"));
     EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
-                Eq("I0102 03:04:05.678900     451 foo.cc:-1234] "));
+                Eq("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] "));
     for (size_t sz =
-             strlen("I0102 03:04:05.678900     451 foo.cc:-1234] ") + 20;
+             strlen("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] ") + 20;
          sz != std::numeric_limits<size_t>::max(); sz--)
-      EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:-1234] ",
+      EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] ",
                   StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
+    EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline(),
+                Eq("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] hello "
+                   "world\n"));
+    EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline_c_str(),
+                StrEq("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] "
+                      "hello world\n"));
     EXPECT_THAT(
-        entry.entry().text_message_with_prefix_and_newline(),
-        Eq("I0102 03:04:05.678900     451 foo.cc:-1234] hello world\n"));
-    EXPECT_THAT(
-        entry.entry().text_message_with_prefix_and_newline_c_str(),
-        StrEq("I0102 03:04:05.678900     451 foo.cc:-1234] hello world\n"));
-    EXPECT_THAT(entry.entry().text_message_with_prefix(),
-                Eq("I0102 03:04:05.678900     451 foo.cc:-1234] hello world"));
+        entry.entry().text_message_with_prefix(),
+        Eq("I0102 03:04:05.678900     451 foo.cc:-1234 MyFunc] hello world"));
     EXPECT_THAT(entry.entry().text_message(), Eq("hello world"));
+    EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
   }
 }
 
@@ -263,7 +284,7 @@ TEST(LogEntryTest, LongFields) {
   LogEntryTestPeer entry(
       "I am the very model of a modern Major-General / "
       "I've information vegetable, animal, and mineral.",
-      2147483647, kUsePrefix, absl::LogSeverity::kInfo,
+      2147483647, "MyFunc", kUsePrefix, absl::LogSeverity::kInfo,
       "2020-01-02T03:04:05.678967896789", 2147483647,
       absl::log_internal::PrefixFormat::kNotRaw,
       "I know the kings of England, and I quote the fights historical / "
@@ -271,48 +292,49 @@ TEST(LogEntryTest, LongFields) {
   EXPECT_THAT(entry.FormatLogMessage(),
               Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
                  "modern Major-General / I've information vegetable, animal, "
-                 "and mineral.:2147483647] I know the kings of England, and I "
+                 "and mineral.:2147483647 MyFunc] I know the kings of England, and I "
                  "quote the fights historical / From Marathon to Waterloo, in "
                  "order categorical."));
   EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
               Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
                  "modern Major-General / I've information vegetable, animal, "
-                 "and mineral.:2147483647] "));
+                 "and mineral.:2147483647 MyFunc] "));
   for (size_t sz =
            strlen("I0102 03:04:05.678967 2147483647 I am the very model of a "
                   "modern Major-General / I've information vegetable, animal, "
-                  "and mineral.:2147483647] ") +
+                  "and mineral.:2147483647 MyFunc] ") +
            20;
        sz != std::numeric_limits<size_t>::max(); sz--)
     EXPECT_THAT(
         "I0102 03:04:05.678967 2147483647 I am the very model of a "
         "modern Major-General / I've information vegetable, animal, "
-        "and mineral.:2147483647] ",
+        "and mineral.:2147483647 MyFunc] ",
         StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
   EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline(),
               Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
                  "modern Major-General / I've information vegetable, animal, "
-                 "and mineral.:2147483647] I know the kings of England, and I "
+                 "and mineral.:2147483647 MyFunc] I know the kings of England, and I "
                  "quote the fights historical / From Marathon to Waterloo, in "
                  "order categorical.\n"));
   EXPECT_THAT(
       entry.entry().text_message_with_prefix_and_newline_c_str(),
       StrEq("I0102 03:04:05.678967 2147483647 I am the very model of a "
             "modern Major-General / I've information vegetable, animal, "
-            "and mineral.:2147483647] I know the kings of England, and I "
+            "and mineral.:2147483647 MyFunc] I know the kings of England, and I "
             "quote the fights historical / From Marathon to Waterloo, in "
             "order categorical.\n"));
   EXPECT_THAT(entry.entry().text_message_with_prefix(),
               Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
                  "modern Major-General / I've information vegetable, animal, "
-                 "and mineral.:2147483647] I know the kings of England, and I "
+                 "and mineral.:2147483647 MyFunc] I know the kings of England, and I "
                  "quote the fights historical / From Marathon to Waterloo, in "
                  "order categorical."));
   EXPECT_THAT(
       entry.entry().text_message(),
       Eq("I know the kings of England, and I quote the fights historical / "
          "From Marathon to Waterloo, in order categorical."));
+  EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
 }
 
 TEST(LogEntryTest, LongNegativeFields) {
@@ -322,7 +344,7 @@ TEST(LogEntryTest, LongNegativeFields) {
     LogEntryTestPeer entry(
         "I am the very model of a modern Major-General / "
         "I've information vegetable, animal, and mineral.",
-        -2147483647, kUsePrefix, absl::LogSeverity::kInfo,
+        -2147483647, "MyFunc", kUsePrefix, absl::LogSeverity::kInfo,
         "2020-01-02T03:04:05.678967896789",
         static_cast<absl::LogEntry::tid_t>(-2147483647),
         absl::log_internal::PrefixFormat::kNotRaw,
@@ -332,56 +354,57 @@ TEST(LogEntryTest, LongNegativeFields) {
         entry.FormatLogMessage(),
         Eq("I0102 03:04:05.678967 -2147483647 I am the very model of a "
            "modern Major-General / I've information vegetable, animal, "
-           "and mineral.:-2147483647] I know the kings of England, and I "
+           "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
            "quote the fights historical / From Marathon to Waterloo, in "
            "order categorical."));
     EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
                 Eq("I0102 03:04:05.678967 -2147483647 I am the very model of a "
                    "modern Major-General / I've information vegetable, animal, "
-                   "and mineral.:-2147483647] "));
+                   "and mineral.:-2147483647 MyFunc] "));
     for (size_t sz =
              strlen(
                  "I0102 03:04:05.678967 -2147483647 I am the very model of a "
                  "modern Major-General / I've information vegetable, animal, "
-                 "and mineral.:-2147483647] ") +
+                 "and mineral.:-2147483647 MyFunc] ") +
              20;
          sz != std::numeric_limits<size_t>::max(); sz--)
       EXPECT_THAT(
           "I0102 03:04:05.678967 -2147483647 I am the very model of a "
           "modern Major-General / I've information vegetable, animal, "
-          "and mineral.:-2147483647] ",
+          "and mineral.:-2147483647 MyFunc] ",
           StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
     EXPECT_THAT(
         entry.entry().text_message_with_prefix_and_newline(),
         Eq("I0102 03:04:05.678967 -2147483647 I am the very model of a "
            "modern Major-General / I've information vegetable, animal, "
-           "and mineral.:-2147483647] I know the kings of England, and I "
+           "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
            "quote the fights historical / From Marathon to Waterloo, in "
            "order categorical.\n"));
     EXPECT_THAT(
         entry.entry().text_message_with_prefix_and_newline_c_str(),
         StrEq("I0102 03:04:05.678967 -2147483647 I am the very model of a "
               "modern Major-General / I've information vegetable, animal, "
-              "and mineral.:-2147483647] I know the kings of England, and I "
+              "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
               "quote the fights historical / From Marathon to Waterloo, in "
               "order categorical.\n"));
     EXPECT_THAT(
         entry.entry().text_message_with_prefix(),
         Eq("I0102 03:04:05.678967 -2147483647 I am the very model of a "
            "modern Major-General / I've information vegetable, animal, "
-           "and mineral.:-2147483647] I know the kings of England, and I "
+           "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
            "quote the fights historical / From Marathon to Waterloo, in "
            "order categorical."));
     EXPECT_THAT(
         entry.entry().text_message(),
         Eq("I know the kings of England, and I quote the fights historical / "
            "From Marathon to Waterloo, in order categorical."));
+    EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
   } else {
     LogEntryTestPeer entry(
         "I am the very model of a modern Major-General / "
         "I've information vegetable, animal, and mineral.",
-        -2147483647, kUsePrefix, absl::LogSeverity::kInfo,
+        -2147483647, "MyFunc", kUsePrefix, absl::LogSeverity::kInfo,
         "2020-01-02T03:04:05.678967896789", 2147483647,
         absl::log_internal::PrefixFormat::kNotRaw,
         "I know the kings of England, and I quote the fights historical / "
@@ -390,79 +413,84 @@ TEST(LogEntryTest, LongNegativeFields) {
         entry.FormatLogMessage(),
         Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
            "modern Major-General / I've information vegetable, animal, "
-           "and mineral.:-2147483647] I know the kings of England, and I "
+           "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
            "quote the fights historical / From Marathon to Waterloo, in "
            "order categorical."));
     EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
                 Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
                    "modern Major-General / I've information vegetable, animal, "
-                   "and mineral.:-2147483647] "));
+                   "and mineral.:-2147483647 MyFunc] "));
     for (size_t sz =
              strlen(
                  "I0102 03:04:05.678967 2147483647 I am the very model of a "
                  "modern Major-General / I've information vegetable, animal, "
-                 "and mineral.:-2147483647] ") +
+                 "and mineral.:-2147483647 MyFunc] ") +
              20;
          sz != std::numeric_limits<size_t>::max(); sz--)
       EXPECT_THAT(
           "I0102 03:04:05.678967 2147483647 I am the very model of a "
           "modern Major-General / I've information vegetable, animal, "
-          "and mineral.:-2147483647] ",
+          "and mineral.:-2147483647 MyFunc] ",
           StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
     EXPECT_THAT(
         entry.entry().text_message_with_prefix_and_newline(),
         Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
            "modern Major-General / I've information vegetable, animal, "
-           "and mineral.:-2147483647] I know the kings of England, and I "
+           "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
            "quote the fights historical / From Marathon to Waterloo, in "
            "order categorical.\n"));
     EXPECT_THAT(
         entry.entry().text_message_with_prefix_and_newline_c_str(),
         StrEq("I0102 03:04:05.678967 2147483647 I am the very model of a "
               "modern Major-General / I've information vegetable, animal, "
-              "and mineral.:-2147483647] I know the kings of England, and I "
+              "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
               "quote the fights historical / From Marathon to Waterloo, in "
               "order categorical.\n"));
     EXPECT_THAT(
         entry.entry().text_message_with_prefix(),
         Eq("I0102 03:04:05.678967 2147483647 I am the very model of a "
            "modern Major-General / I've information vegetable, animal, "
-           "and mineral.:-2147483647] I know the kings of England, and I "
+           "and mineral.:-2147483647 MyFunc] I know the kings of England, and I "
            "quote the fights historical / From Marathon to Waterloo, in "
            "order categorical."));
     EXPECT_THAT(
         entry.entry().text_message(),
         Eq("I know the kings of England, and I quote the fights historical / "
            "From Marathon to Waterloo, in order categorical."));
+    EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
   }
 }
 
 TEST(LogEntryTest, Raw) {
-  LogEntryTestPeer entry("foo.cc", 1234, kUsePrefix, absl::LogSeverity::kInfo,
-                         "2020-01-02T03:04:05.6789", 451,
-                         absl::log_internal::PrefixFormat::kRaw, "hello world");
+  LogEntryTestPeer entry("foo.cc", 1234, "MyFunc", kUsePrefix,
+                         absl::LogSeverity::kInfo, "2020-01-02T03:04:05.6789",
+                         451, absl::log_internal::PrefixFormat::kRaw,
+                         "hello world");
   EXPECT_THAT(
       entry.FormatLogMessage(),
-      Eq("I0102 03:04:05.678900     451 foo.cc:1234] RAW: hello world"));
-  EXPECT_THAT(entry.FormatPrefixIntoSizedBuffer(1000),
-              Eq("I0102 03:04:05.678900     451 foo.cc:1234] RAW: "));
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: hello world"));
+  EXPECT_THAT(
+      entry.FormatPrefixIntoSizedBuffer(1000),
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: "));
   for (size_t sz =
-           strlen("I0102 03:04:05.678900     451 foo.cc:1234] RAW: ") + 20;
+           strlen("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: ") +
+           20;
        sz != std::numeric_limits<size_t>::max(); sz--)
-    EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:1234] RAW: ",
+    EXPECT_THAT("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: ",
                 StartsWith(entry.FormatPrefixIntoSizedBuffer(sz)));
 
-  EXPECT_THAT(
-      entry.entry().text_message_with_prefix_and_newline(),
-      Eq("I0102 03:04:05.678900     451 foo.cc:1234] RAW: hello world\n"));
-  EXPECT_THAT(
-      entry.entry().text_message_with_prefix_and_newline_c_str(),
-      StrEq("I0102 03:04:05.678900     451 foo.cc:1234] RAW: hello world\n"));
+  EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline(),
+              Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: hello "
+                 "world\n"));
+  EXPECT_THAT(entry.entry().text_message_with_prefix_and_newline_c_str(),
+              StrEq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: "
+                    "hello world\n"));
   EXPECT_THAT(
       entry.entry().text_message_with_prefix(),
-      Eq("I0102 03:04:05.678900     451 foo.cc:1234] RAW: hello world"));
+      Eq("I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: hello world"));
   EXPECT_THAT(entry.entry().text_message(), Eq("hello world"));
+  EXPECT_THAT(entry.entry().source_function_name(), Eq("MyFunc"));
 }
 
 }  // namespace

--- a/absl/log/log_format_test.cc
+++ b/absl/log/log_format_test.cc
@@ -47,6 +47,7 @@ namespace {
 using ::absl::log_internal::AsString;
 using ::absl::log_internal::MatchesOstream;
 using ::absl::log_internal::RawEncodedMessage;
+using ::absl::log_internal::SourceFunctionName;
 using ::absl::log_internal::TextMessage;
 using ::absl::log_internal::TextPrefix;
 using ::testing::_;
@@ -80,12 +81,14 @@ TEST(LogFormatTest, NoMessage) {
   const int log_line = __LINE__ + 1;
   auto do_log = [] { LOG(INFO); };
 
-  EXPECT_CALL(test_sink,
-              Send(AllOf(TextMessage(MatchesOstream(ComparisonStream())),
-                         TextPrefix(AsString(EndsWith(absl::StrCat(
-                             " log_format_test.cc:", log_line, "] ")))),
-                         TextMessage(IsEmpty()),
-                         ENCODED_MESSAGE(HasValues(IsEmpty())))));
+  EXPECT_CALL(
+      test_sink,
+      Send(AllOf(TextMessage(MatchesOstream(ComparisonStream())),
+                 SourceFunctionName(Eq("operator()")),
+                 TextPrefix(AsString(EndsWith(absl::StrCat(
+                     " log_format_test.cc:", log_line, " operator()] ")))),
+                 TextMessage(IsEmpty()),
+                 ENCODED_MESSAGE(HasValues(IsEmpty())))));
 
   test_sink.StartCapturingLogs();
   do_log();

--- a/absl/log/log_modifier_methods_test.cc
+++ b/absl/log/log_modifier_methods_test.cc
@@ -41,6 +41,7 @@ using ::absl::log_internal::LogSeverity;
 using ::absl::log_internal::Prefix;
 using ::absl::log_internal::SourceBasename;
 using ::absl::log_internal::SourceFilename;
+using ::absl::log_internal::SourceFunctionName;
 using ::absl::log_internal::SourceLine;
 using ::absl::log_internal::Stacktrace;
 using ::absl::log_internal::TextMessage;
@@ -69,15 +70,18 @@ TEST(TailCallsModifiesTest, AtLocationFileLine) {
           // The metadata should change:
           SourceFilename(Eq("/my/very/very/very_long_source_file.cc")),
           SourceBasename(Eq("very_long_source_file.cc")), SourceLine(Eq(777)),
+          SourceFunctionName(Eq("AtLocationFileLine")),
           // The logged line should change too, even though the prefix must
           // grow to fit the new metadata.
           TextMessageWithPrefix(Truly([](absl::string_view msg) {
-            return absl::EndsWith(msg,
-                                  " very_long_source_file.cc:777] hello world");
+            return absl::EndsWith(
+                msg,
+                " very_long_source_file.cc:777 AtLocationFileLine] hello world");
           })))));
 
   test_sink.StartCapturingLogs();
-  LOG(INFO).AtLocation("/my/very/very/very_long_source_file.cc", 777)
+  LOG(INFO).AtLocation("/my/very/very/very_long_source_file.cc",
+                       777, "AtLocationFileLine")
       << "hello world";
 }
 
@@ -85,7 +89,7 @@ TEST(TailCallsModifiesTest, AtLocationFileLineLifetime) {
   // The macro takes care to not use this temporary after its lifetime.
   // The only salient expectation is "no sanitizer diagnostics".
   LOG(INFO).AtLocation(std::string("/my/very/very/very_long_source_file.cc"),
-                       777)
+                       777, "AtLocationFileLineLifetime")
       << "hello world";
 }
 
@@ -186,21 +190,23 @@ TEST(TailCallsModifiesTest, WithMetadataFrom) {
 
   EXPECT_CALL(
       test_sink,
-      Send(AllOf(SourceFilename(Eq("fake/file")), SourceBasename(Eq("file")),
-                 SourceLine(Eq(123)), Prefix(IsFalse()),
-                 LogSeverity(Eq(absl::LogSeverity::kWarning)),
-                 Timestamp(Eq(absl::UnixEpoch())),
-                 ThreadID(Eq(absl::LogEntry::tid_t{456})),
-                 TextMessage(Eq("forwarded: hello world")), Verbosity(Eq(7)),
-                 ENCODED_MESSAGE(MatchesEvent(
-                     Eq("fake/file"), Eq(123), Eq(absl::UnixEpoch()),
-                     Eq(logging::proto::WARNING), Eq(456),
-                     ElementsAre(ValueWithLiteral(Eq("forwarded: ")),
-                                 ValueWithStr(Eq("hello world"))))))));
+      Send(AllOf(
+           SourceFilename(Eq("fake/file")), SourceBasename(Eq("file")),
+           SourceLine(Eq(123)),
+           SourceFunctionName(Eq("WithMetadataFrom")), Prefix(IsFalse()),
+           LogSeverity(Eq(absl::LogSeverity::kWarning)),
+           Timestamp(Eq(absl::UnixEpoch())),
+           ThreadID(Eq(absl::LogEntry::tid_t{456})),
+           TextMessage(Eq("forwarded: hello world")), Verbosity(Eq(7)),
+                       ENCODED_MESSAGE(MatchesEvent(
+                           Eq("fake/file"), Eq(123), Eq(absl::UnixEpoch()),
+                           Eq(logging::proto::WARNING), Eq(456),
+                           ElementsAre(ValueWithLiteral(Eq("forwarded: ")),
+                               ValueWithStr(Eq("hello world"))))))));
 
   test_sink.StartCapturingLogs();
   LOG(WARNING)
-          .AtLocation("fake/file", 123)
+          .AtLocation("fake/file", 123, "WithMetadataFrom")
           .NoPrefix()
           .WithTimestamp(absl::UnixEpoch())
           .WithThreadID(456)

--- a/absl/log/log_streamer.h
+++ b/absl/log/log_streamer.h
@@ -61,12 +61,13 @@ ABSL_NAMESPACE_BEGIN
 // Examples:
 //
 //   ShaveYakAndWriteToStream(
-//       yak, absl::LogInfoStreamer(__FILE__, __LINE__).stream());
+//     yak, absl::LogInfoStreamer(__FILE__, __LINE__, __func__).stream());
 //
 //   {
 //     // This logs a single line containing data streamed by all three function
 //     // calls.
-//     absl::LogStreamer streamer(absl::LogSeverity::kInfo, __FILE__, __LINE__);
+//     absl::LogStreamer streamer(
+//         absl::LogSeverity::kInfo, __FILE__, __LINE__, __func__);
 //     ShaveYakAndWriteToStream(yak1, streamer.stream());
 //     streamer.stream() << " ";
 //     ShaveYakAndWriteToStream(yak2, streamer.stream());
@@ -78,20 +79,26 @@ class LogStreamer final {
   // LogStreamer::LogStreamer()
   //
   // Creates a LogStreamer with a given `severity` that will log a message
-  // attributed to the given `file` and `line`.
+  // attributed to the given `file`, `line` and (optionally) `function`.
   explicit LogStreamer(absl::LogSeverity severity, absl::string_view file,
-                       int line)
+                       int line, absl::string_view function)
       : severity_(severity),
         line_(line),
         file_(file),
+        function_(function),
         stream_(std::in_place, &buf_) {
     // To match `LOG`'s defaults:
     stream_->setf(std::ios_base::showbase | std::ios_base::boolalpha);
   }
+  explicit LogStreamer(absl::LogSeverity severity, absl::string_view file,
+                       int line)
+      : LogStreamer(severity, file, line, {}) {}
   explicit LogStreamer(
       absl::LogSeverity severity,
       absl::SourceLocation loc = absl::SourceLocation::current())
-      : LogStreamer(severity, loc.file_name(), static_cast<int>(loc.line())) {}
+      : LogStreamer(severity, loc.file_name(),
+                    static_cast<int>(loc.line()),
+                    loc.function_name()) {}
 
   // A moved-from `absl::LogStreamer` does not `LOG` when destroyed,
   // and a program that streams into one has undefined behavior.
@@ -99,16 +106,19 @@ class LogStreamer final {
       : severity_(that.severity_),
         line_(that.line_),
         file_(std::move(that.file_)),
+        function_(std::move(that.function_)),
         buf_(std::move(that.buf_)),
         stream_(std::move(that.stream_)) {
     if (stream_.has_value()) stream_->str(&buf_);
     that.stream_.reset();
   }
   LogStreamer& operator=(LogStreamer&& that) {
-    ABSL_LOG_IF(LEVEL(severity_), stream_).AtLocation(file_, line_) << buf_;
+    ABSL_LOG_IF(LEVEL(severity_), stream_).AtLocation(
+      file_, line_, function_) << buf_;
     severity_ = that.severity_;
     file_ = std::move(that.file_);
     line_ = that.line_;
+    function_ = std::move(that.function_);
     buf_ = std::move(that.buf_);
     stream_ = std::move(that.stream_);
     if (stream_.has_value()) stream_->str(&buf_);
@@ -120,8 +130,8 @@ class LogStreamer final {
   //
   // Logs this LogStreamer's buffered content as if by LOG.
   ~LogStreamer() {
-    ABSL_LOG_IF(LEVEL(severity_), stream_.has_value()).AtLocation(file_, line_)
-        << buf_;
+    ABSL_LOG_IF(LEVEL(severity_), stream_.has_value())
+        .AtLocation(file_, line_, function_) << buf_;
   }
 
   // LogStreamer::stream()
@@ -134,6 +144,7 @@ class LogStreamer final {
   absl::LogSeverity severity_;
   int line_;
   std::string file_;
+  std::string function_;
   std::string buf_;
   // A disengaged `stream_` indicates a moved-from `LogStreamer` that should not
   // `LOG` upon destruction.
@@ -143,6 +154,10 @@ class LogStreamer final {
 // LogInfoStreamer()
 //
 // Returns a LogStreamer that writes at level LogSeverity::kInfo.
+inline LogStreamer LogInfoStreamer(absl::string_view file, int line,
+                                   absl::string_view function) {
+  return absl::LogStreamer(absl::LogSeverity::kInfo, file, line, function);
+}
 inline LogStreamer LogInfoStreamer(absl::string_view file, int line) {
   return absl::LogStreamer(absl::LogSeverity::kInfo, file, line);
 }
@@ -150,6 +165,10 @@ inline LogStreamer LogInfoStreamer(absl::string_view file, int line) {
 // LogWarningStreamer()
 //
 // Returns a LogStreamer that writes at level LogSeverity::kWarning.
+inline LogStreamer LogWarningStreamer(absl::string_view file, int line,
+                                      absl::string_view function) {
+  return absl::LogStreamer(absl::LogSeverity::kWarning, file, line, function);
+}
 inline LogStreamer LogWarningStreamer(absl::string_view file, int line) {
   return absl::LogStreamer(absl::LogSeverity::kWarning, file, line);
 }
@@ -157,6 +176,10 @@ inline LogStreamer LogWarningStreamer(absl::string_view file, int line) {
 // LogErrorStreamer()
 //
 // Returns a LogStreamer that writes at level LogSeverity::kError.
+inline LogStreamer LogErrorStreamer(absl::string_view file, int line,
+                                    absl::string_view function) {
+  return absl::LogStreamer(absl::LogSeverity::kError, file, line, function);
+}
 inline LogStreamer LogErrorStreamer(absl::string_view file, int line) {
   return absl::LogStreamer(absl::LogSeverity::kError, file, line);
 }
@@ -167,6 +190,10 @@ inline LogStreamer LogErrorStreamer(absl::string_view file, int line) {
 //
 // The program will be terminated when this `LogStreamer` is destroyed,
 // regardless of whether any data were streamed in.
+inline LogStreamer LogFatalStreamer(absl::string_view file, int line,
+                                    absl::string_view function) {
+  return absl::LogStreamer(absl::LogSeverity::kFatal, file, line, function);
+}
 inline LogStreamer LogFatalStreamer(absl::string_view file, int line) {
   return absl::LogStreamer(absl::LogSeverity::kFatal, file, line);
 }
@@ -177,6 +204,10 @@ inline LogStreamer LogFatalStreamer(absl::string_view file, int line) {
 //
 // In debug mode, the program will be terminated when this `LogStreamer` is
 // destroyed, regardless of whether any data were streamed in.
+inline LogStreamer LogDebugFatalStreamer(absl::string_view file, int line,
+                                         absl::string_view function) {
+  return absl::LogStreamer(absl::kLogDebugFatal, file, line, function);
+}
 inline LogStreamer LogDebugFatalStreamer(absl::string_view file, int line) {
   return absl::LogStreamer(absl::kLogDebugFatal, file, line);
 }

--- a/absl/log/log_streamer_test.cc
+++ b/absl/log/log_streamer_test.cc
@@ -43,6 +43,7 @@ using ::absl::log_internal::InMatchWindow;
 using ::absl::log_internal::LogSeverity;
 using ::absl::log_internal::Prefix;
 using ::absl::log_internal::SourceFilename;
+using ::absl::log_internal::SourceFunctionName;
 using ::absl::log_internal::SourceLine;
 using ::absl::log_internal::Stacktrace;
 using ::absl::log_internal::TextMessage;
@@ -71,20 +72,23 @@ TEST(LogStreamerTest, LogInfoStreamer) {
 
   EXPECT_CALL(
       test_sink,
-      Send(
-          AllOf(SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
-                Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kInfo)),
-                Timestamp(InMatchWindow()),
-                ThreadID(Eq(absl::base_internal::GetTID())),
-                TextMessage(Eq("WriteToStream: foo")),
-                ENCODED_MESSAGE(MatchesEvent(
-                    Eq("path/file.cc"), Eq(1234), InMatchWindow(),
-                    Eq(logging::proto::INFO), Eq(absl::base_internal::GetTID()),
-                    ElementsAre(ValueWithStr(Eq("WriteToStream: foo"))))),
-                Stacktrace(IsEmpty()))));
+      Send(AllOf(
+           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+           SourceFunctionName(Eq("LogInfoStreamer")),
+           Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kInfo)),
+           Timestamp(InMatchWindow()),
+           ThreadID(Eq(absl::base_internal::GetTID())),
+           TextMessage(Eq("WriteToStream: foo")),
+           ENCODED_MESSAGE(MatchesEvent(
+              Eq("path/file.cc"), Eq(1234), InMatchWindow(),
+              Eq(logging::proto::INFO), Eq(absl::base_internal::GetTID()),
+              ElementsAre(ValueWithStr(Eq("WriteToStream: foo"))))),
+              Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  WriteToStream("foo", &absl::LogInfoStreamer("path/file.cc", 1234).stream());
+  WriteToStream("foo",
+                &absl::LogInfoStreamer(
+                    "path/file.cc", 1234, "LogInfoStreamer").stream());
 }
 
 TEST(LogStreamerTest, LogWarningStreamer) {
@@ -95,6 +99,7 @@ TEST(LogStreamerTest, LogWarningStreamer) {
       test_sink,
       Send(AllOf(
           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+          SourceFunctionName(Eq("LogWarningStreamer")),
           Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kWarning)),
           Timestamp(InMatchWindow()),
           ThreadID(Eq(absl::base_internal::GetTID())),
@@ -107,7 +112,8 @@ TEST(LogStreamerTest, LogWarningStreamer) {
 
   test_sink.StartCapturingLogs();
   WriteToStream("foo",
-                &absl::LogWarningStreamer("path/file.cc", 1234).stream());
+                &absl::LogWarningStreamer(
+                    "path/file.cc", 1234, "LogWarningStreamer").stream());
 }
 
 TEST(LogStreamerTest, LogErrorStreamer) {
@@ -118,6 +124,7 @@ TEST(LogStreamerTest, LogErrorStreamer) {
       test_sink,
       Send(AllOf(
           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+          SourceFunctionName(Eq("LogErrorStreamer")),
           Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kError)),
           Timestamp(InMatchWindow()),
           ThreadID(Eq(absl::base_internal::GetTID())),
@@ -129,7 +136,9 @@ TEST(LogStreamerTest, LogErrorStreamer) {
           Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  WriteToStream("foo", &absl::LogErrorStreamer("path/file.cc", 1234).stream());
+  WriteToStream("foo",
+                &absl::LogErrorStreamer(
+                    "path/file.cc", 1234, "LogErrorStreamer").stream());
 }
 
 #if GTEST_HAS_DEATH_TEST
@@ -147,6 +156,7 @@ TEST(LogStreamerDeathTest, LogFatalStreamer) {
             test_sink,
             Send(AllOf(
                 SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+                SourceFunctionName(Eq("LogFatalStreamer")),
                 Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kFatal)),
                 Timestamp(InMatchWindow()),
                 ThreadID(Eq(absl::base_internal::GetTID())),
@@ -160,7 +170,8 @@ TEST(LogStreamerDeathTest, LogFatalStreamer) {
 
         test_sink.StartCapturingLogs();
         WriteToStream("foo",
-                      &absl::LogFatalStreamer("path/file.cc", 1234).stream());
+                      &absl::LogFatalStreamer(
+                          "path/file.cc", 1234, "LogFatalStreamer").stream());
       },
       DiedOfFatal, DeathTestValidateExpectations());
 }
@@ -175,6 +186,7 @@ TEST(LogStreamerTest, LogDebugFatalStreamer) {
       test_sink,
       Send(AllOf(
           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+          SourceFunctionName(Eq("LogDebugFatalStreamer")),
           Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kError)),
           Timestamp(InMatchWindow()),
           ThreadID(Eq(absl::base_internal::GetTID())),
@@ -187,7 +199,8 @@ TEST(LogStreamerTest, LogDebugFatalStreamer) {
 
   test_sink.StartCapturingLogs();
   WriteToStream("foo",
-                &absl::LogDebugFatalStreamer("path/file.cc", 1234).stream());
+                &absl::LogDebugFatalStreamer(
+                    "path/file.cc", 1234, "LogDebugFatalStreamer").stream());
 }
 #elif GTEST_HAS_DEATH_TEST
 TEST(LogStreamerDeathTest, LogDebugFatalStreamer) {
@@ -204,6 +217,7 @@ TEST(LogStreamerDeathTest, LogDebugFatalStreamer) {
             test_sink,
             Send(AllOf(
                 SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+                SourceFunctionName(Eq("LogDebugFatalStreamer")),
                 Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kFatal)),
                 Timestamp(InMatchWindow()),
                 ThreadID(Eq(absl::base_internal::GetTID())),
@@ -216,8 +230,9 @@ TEST(LogStreamerDeathTest, LogDebugFatalStreamer) {
             .WillOnce(DeathTestExpectedLogging());
 
         test_sink.StartCapturingLogs();
-        WriteToStream(
-            "foo", &absl::LogDebugFatalStreamer("path/file.cc", 1234).stream());
+        WriteToStream("foo",
+                      &absl::LogDebugFatalStreamer(
+                          "path/file.cc", 1234, "LogDebugFatalStreamer").stream());
       },
       DiedOfFatal, DeathTestValidateExpectations());
 }
@@ -231,6 +246,7 @@ TEST(LogStreamerTest, LogStreamer) {
       test_sink,
       Send(AllOf(
           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+          SourceFunctionName(Eq("LogStreamer")),
           Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kError)),
           Timestamp(InMatchWindow()),
           ThreadID(Eq(absl::base_internal::GetTID())),
@@ -242,9 +258,9 @@ TEST(LogStreamerTest, LogStreamer) {
           Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  WriteToStream(
-      "foo", &absl::LogStreamer(absl::LogSeverity::kError, "path/file.cc", 1234)
-                  .stream());
+  WriteToStream("foo", &absl::LogStreamer(absl::LogSeverity::kError,
+                            "path/file.cc", 1234, "LogStreamer")
+                        .stream());
 }
 
 #if GTEST_HAS_DEATH_TEST
@@ -262,6 +278,7 @@ TEST(LogStreamerDeathTest, LogStreamer) {
             test_sink,
             Send(AllOf(
                 SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+                SourceFunctionName(Eq("LogStreamer")),
                 Prefix(IsTrue()), LogSeverity(Eq(absl::LogSeverity::kFatal)),
                 Timestamp(InMatchWindow()),
                 ThreadID(Eq(absl::base_internal::GetTID())),
@@ -275,8 +292,9 @@ TEST(LogStreamerDeathTest, LogStreamer) {
 
         test_sink.StartCapturingLogs();
         WriteToStream("foo", &absl::LogStreamer(absl::LogSeverity::kFatal,
-                                                "path/file.cc", 1234)
-                                  .stream());
+                                                "path/file.cc", 1234,
+                                                "LogStreamer")
+                                                    .stream());
       },
       DiedOfFatal, DeathTestValidateExpectations());
 }
@@ -288,22 +306,26 @@ TEST(LogStreamerTest, PassedByReference) {
 
   EXPECT_CALL(
       test_sink,
-      Send(AllOf(SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
-                 TextMessage(Eq("WriteToStreamRef: foo")),
-                 ENCODED_MESSAGE(MatchesEvent(
-                     Eq("path/file.cc"), Eq(1234), _, _, _,
-                     ElementsAre(ValueWithStr(Eq("WriteToStreamRef: foo"))))),
-                 Stacktrace(IsEmpty()))));
+      Send(AllOf(
+           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+           SourceFunctionName(Eq("PassedByReference")),
+           TextMessage(Eq("WriteToStreamRef: foo")),
+           ENCODED_MESSAGE(MatchesEvent(
+               Eq("path/file.cc"), Eq(1234), _, _, _,
+               ElementsAre(ValueWithStr(Eq("WriteToStreamRef: foo"))))),
+               Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  WriteToStreamRef("foo", absl::LogInfoStreamer("path/file.cc", 1234).stream());
+  WriteToStreamRef("foo",
+                   absl::LogInfoStreamer("path/file.cc", 1234, "PassedByReference")
+                       .stream());
 }
 
 TEST(LogStreamerTest, StoredAsLocal) {
   absl::ScopedMockLog test_sink(absl::MockLogDefault::kDisallowUnexpected);
   EXPECT_CALL(test_sink, Send).Times(0);
 
-  auto streamer = absl::LogInfoStreamer("path/file.cc", 1234);
+  auto streamer = absl::LogInfoStreamer("path/file.cc", 1234, "StoredAsLocal");
   WriteToStream("foo", &streamer.stream());
   streamer.stream() << " ";
   WriteToStreamRef("bar", streamer.stream());
@@ -313,13 +335,15 @@ TEST(LogStreamerTest, StoredAsLocal) {
   // test would fail.
   EXPECT_CALL(
       test_sink,
-      Send(AllOf(SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
-                 TextMessage(Eq("WriteToStream: foo WriteToStreamRef: bar")),
-                 ENCODED_MESSAGE(MatchesEvent(
-                     Eq("path/file.cc"), Eq(1234), _, _, _,
-                     ElementsAre(ValueWithStr(
-                         Eq("WriteToStream: foo WriteToStreamRef: bar"))))),
-                 Stacktrace(IsEmpty()))));
+      Send(AllOf(
+           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+           SourceFunctionName(Eq("StoredAsLocal")),
+           TextMessage(Eq("WriteToStream: foo WriteToStreamRef: bar")),
+           ENCODED_MESSAGE(MatchesEvent(
+               Eq("path/file.cc"), Eq(1234), _, _, _,
+               ElementsAre(ValueWithStr(
+                 Eq("WriteToStream: foo WriteToStreamRef: bar"))))),
+               Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
 }
@@ -329,7 +353,7 @@ TEST(LogStreamerDeathTest, StoredAsLocal) {
   EXPECT_EXIT(
       {
         // This is fatal when it goes out of scope, but not until then:
-        auto streamer = absl::LogFatalStreamer("path/file.cc", 1234);
+        auto streamer = absl::LogFatalStreamer("path/file.cc", 1234, "StoredAsLocal");
         std::cerr << "I'm still alive" << std::endl;
         WriteToStream("foo", &streamer.stream());
       },
@@ -341,15 +365,19 @@ TEST(LogStreamerTest, LogsEmptyLine) {
   absl::ScopedMockLog test_sink(absl::MockLogDefault::kDisallowUnexpected);
   EXPECT_CALL(test_sink, Send).Times(0);
 
-  EXPECT_CALL(test_sink, Send(AllOf(SourceFilename(Eq("path/file.cc")),
-                                    SourceLine(Eq(1234)), TextMessage(Eq("")),
-                                    ENCODED_MESSAGE(MatchesEvent(
-                                        Eq("path/file.cc"), Eq(1234), _, _, _,
-                                        ElementsAre(ValueWithStr(Eq(""))))),
-                                    Stacktrace(IsEmpty()))));
+  EXPECT_CALL(test_sink,
+              Send(AllOf(
+                   SourceFilename(Eq("path/file.cc")),
+                   SourceLine(Eq(1234)),
+                   SourceFunctionName(Eq("LogsEmptyLine")),
+                   TextMessage(Eq("")),
+                   ENCODED_MESSAGE(MatchesEvent(
+                       Eq("path/file.cc"), Eq(1234), _, _, _,
+                       ElementsAre(ValueWithStr(Eq(""))))),
+                       Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  absl::LogInfoStreamer("path/file.cc", 1234);
+  absl::LogInfoStreamer("path/file.cc", 1234, "LogsEmptyLine");
 }
 
 #if GTEST_HAS_DEATH_TEST
@@ -363,15 +391,18 @@ TEST(LogStreamerDeathTest, LogsEmptyLine) {
 
         EXPECT_CALL(
             test_sink,
-            Send(AllOf(SourceFilename(Eq("path/file.cc")), TextMessage(Eq("")),
-                       ENCODED_MESSAGE(
-                           MatchesEvent(Eq("path/file.cc"), _, _, _, _,
-                                        ElementsAre(ValueWithStr(Eq(""))))))))
+            Send(AllOf(
+                 SourceFilename(Eq("path/file.cc")),
+                 SourceFunctionName(Eq("LogsEmptyLine")),
+                 TextMessage(Eq("")),
+                 ENCODED_MESSAGE(MatchesEvent(
+                     Eq("path/file.cc"), _, _, _, _,
+                     ElementsAre(ValueWithStr(Eq(""))))))))
             .WillOnce(DeathTestExpectedLogging());
 
         test_sink.StartCapturingLogs();
         // This is fatal even though it's never used:
-        auto streamer = absl::LogFatalStreamer("path/file.cc", 1234);
+        auto streamer = absl::LogFatalStreamer("path/file.cc", 1234, "LogsEmptyLine");
       },
       DiedOfFatal, DeathTestValidateExpectations());
 }
@@ -383,17 +414,18 @@ TEST(LogStreamerTest, MoveConstruction) {
 
   EXPECT_CALL(
       test_sink,
-      Send(
-          AllOf(SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
-                LogSeverity(Eq(absl::LogSeverity::kInfo)),
-                TextMessage(Eq("hello 0x10 world 0x10")),
-                ENCODED_MESSAGE(MatchesEvent(
-                    Eq("path/file.cc"), Eq(1234), _, Eq(logging::proto::INFO),
-                    _, ElementsAre(ValueWithStr(Eq("hello 0x10 world 0x10"))))),
-                Stacktrace(IsEmpty()))));
+      Send(AllOf(
+           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+           SourceFunctionName(Eq("MoveConstruction")),
+           LogSeverity(Eq(absl::LogSeverity::kInfo)),
+           TextMessage(Eq("hello 0x10 world 0x10")),
+           ENCODED_MESSAGE(MatchesEvent(
+               Eq("path/file.cc"), Eq(1234), _, Eq(logging::proto::INFO),
+               _, ElementsAre(ValueWithStr(Eq("hello 0x10 world 0x10"))))),
+               Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  auto streamer1 = absl::LogInfoStreamer("path/file.cc", 1234);
+  auto streamer1 = absl::LogInfoStreamer("path/file.cc", 1234, "MoveConstruction");
   streamer1.stream() << "hello " << std::hex << 16;
   absl::LogStreamer streamer2(std::move(streamer1));
   streamer2.stream() << " world " << 16;
@@ -408,6 +440,7 @@ TEST(LogStreamerTest, MoveAssignment) {
       test_sink,
       Send(AllOf(
           SourceFilename(Eq("path/file2.cc")), SourceLine(Eq(5678)),
+          SourceFunctionName(Eq("MoveAssignment")),
           LogSeverity(Eq(absl::LogSeverity::kWarning)),
           TextMessage(Eq("something else")),
           ENCODED_MESSAGE(MatchesEvent(
@@ -416,19 +449,20 @@ TEST(LogStreamerTest, MoveAssignment) {
           Stacktrace(IsEmpty()))));
   EXPECT_CALL(
       test_sink,
-      Send(
-          AllOf(SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
-                LogSeverity(Eq(absl::LogSeverity::kInfo)),
-                TextMessage(Eq("hello 0x10 world 0x10")),
-                ENCODED_MESSAGE(MatchesEvent(
-                    Eq("path/file.cc"), Eq(1234), _, Eq(logging::proto::INFO),
-                    _, ElementsAre(ValueWithStr(Eq("hello 0x10 world 0x10"))))),
-                Stacktrace(IsEmpty()))));
+      Send(AllOf(
+           SourceFilename(Eq("path/file.cc")), SourceLine(Eq(1234)),
+           SourceFunctionName(Eq("MoveAssignment")),
+           LogSeverity(Eq(absl::LogSeverity::kInfo)),
+           TextMessage(Eq("hello 0x10 world 0x10")),
+           ENCODED_MESSAGE(MatchesEvent(
+               Eq("path/file.cc"), Eq(1234), _, Eq(logging::proto::INFO),
+               _, ElementsAre(ValueWithStr(Eq("hello 0x10 world 0x10"))))),
+               Stacktrace(IsEmpty()))));
 
   test_sink.StartCapturingLogs();
-  auto streamer1 = absl::LogInfoStreamer("path/file.cc", 1234);
+  auto streamer1 = absl::LogInfoStreamer("path/file.cc", 1234, "MoveAssignment");
   streamer1.stream() << "hello " << std::hex << 16;
-  auto streamer2 = absl::LogWarningStreamer("path/file2.cc", 5678);
+  auto streamer2 = absl::LogWarningStreamer("path/file2.cc", 5678, "MoveAssignment");
   streamer2.stream() << "something else";
   streamer2 = std::move(streamer1);
   streamer2.stream() << " world " << 16;
@@ -444,7 +478,7 @@ TEST(LogStreamerTest, CorrectDefaultFlags) {
       .Times(2);
 
   test_sink.StartCapturingLogs();
-  absl::LogInfoStreamer("path/file.cc", 1234).stream()
+  absl::LogInfoStreamer("path/file.cc", 1234, "CorrectDefaultFlags").stream()
       << false << std::hex << 0xdeadbeef;
   LOG(INFO) << false << std::hex << 0xdeadbeef;
 }

--- a/absl/log/scoped_mock_log_test.cc
+++ b/absl/log/scoped_mock_log_test.cc
@@ -106,12 +106,13 @@ TEST(ScopedMockLogTest, LogMockCatchAndMatchSendExpectations) {
                  SourceLine(Eq(777)), ThreadID(Eq(absl::LogEntry::tid_t{1234})),
                  TextMessageWithPrefix(Truly([](absl::string_view msg) {
                    return absl::EndsWith(
-                       msg, " very_long_source_file.cc:777] Info message");
+                       msg,
+                       " very_long_source_file.cc:777 TestBody] Info message");
                  })))));
 
   log.StartCapturingLogs();
   LOG(INFO)
-          .AtLocation("/my/very/very/very_long_source_file.cc", 777)
+          .AtLocation("/my/very/very/very_long_source_file.cc", 777, "TestBody")
           .WithThreadID(1234)
       << "Info message";
 }
@@ -130,35 +131,35 @@ TEST(ScopedMockLogTest, ScopedMockLogCanBeNice) {
   // Any number of these are OK.
   LOG(INFO) << "Info message.";
   // Any number of these are OK.
-  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100) << "Danger ";
+  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100, "ScopedMockLogCanBeNice") << "Danger ";
 
   LOG(WARNING) << "Danger.";
 
   // Any number of these are OK.
   LOG(INFO) << "Info message.";
   // Any number of these are OK.
-  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100) << "Danger ";
+  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100, "ScopedMockLogCanBeNice") << "Danger ";
 
   LOG(INFO) << "Working...";
 
   // Any number of these are OK.
   LOG(INFO) << "Info message.";
   // Any number of these are OK.
-  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100) << "Danger ";
+  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100, "ScopedMockLogCanBeNice") << "Danger ";
 
   LOG(INFO) << "Working...";
 
   // Any number of these are OK.
   LOG(INFO) << "Info message.";
   // Any number of these are OK.
-  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100) << "Danger ";
+  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100, "ScopedMockLogCanBeNice") << "Danger ";
 
   LOG(ERROR) << "Bad!!";
 
   // Any number of these are OK.
   LOG(INFO) << "Info message.";
   // Any number of these are OK.
-  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100) << "Danger ";
+  LOG(WARNING).AtLocation("SomeOtherFile.cc", 100, "ScopedMockLogCanBeNice") << "Danger ";
 }
 
 // Tests that ScopedMockLog generates a test failure if a message is logged


### PR DESCRIPTION
This PR adds the function name (`__func__`) to absl log messages, making it appear in the log prefix right after the line number, which gives a more precise callsite identifier.

```
# before
I0102 03:04:05.678900     451 foo.cc:1234] RAW: hello world

# after
I0102 03:04:05.678900     451 foo.cc:1234 MyFunc] RAW: hello world
```