### PR TITLE
Reapply "PR #2067: Simplify the condition for ABSL_HAVE_PTHREAD_CPU_NUMBER_NP"

### DIFF
--- a/absl/debugging/failure_signal_handler.cc
+++ b/absl/debugging/failure_signal_handler.cc
@@ -71,15 +71,7 @@
 // Checks whether pthread_cpu_number_np is available.
 #ifdef ABSL_HAVE_PTHREAD_CPU_NUMBER_NP
 #error ABSL_HAVE_PTHREAD_CPU_NUMBER_NP cannot be directly set
-#elif defined(__APPLE__) && defined(__has_include) &&              \
-    ((defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&    \
-      __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 110000) ||  \
-     (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) &&   \
-      __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 140200) || \
-     (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) &&    \
-      __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ >= 70100) ||   \
-     (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) &&       \
-      __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ >= 140200))
+#elif defined(__APPLE__)
 #define ABSL_HAVE_PTHREAD_CPU_NUMBER_NP 1
 #endif
 


### PR DESCRIPTION
This reverts commit 39519d75c2958969686eba78a7707d37af41960f (which was a revert of bbca5fe5b0155b14f27ef962965417d787e5102a, but mistakenly copied the exact same commit message).

More details in #2067: 
> Yeah, so the story here is that now there is a bot running on our internal codebase that reverts changes that break tests. And of course there were people testing unsupported OS versions. Unfortunately the bot did not understand how to edit the part of the commit message that actually makes it to GitHub, so it just copied the original message. We will have to get that fixed.

