### PR TITLE
read float round-trip locale-independently in PrintPreciseFP

### DIFF
--- a/absl/strings/BUILD.bazel
+++ b/absl/strings/BUILD.bazel
@@ -1619,6 +1619,7 @@ cc_test(
         ":strings",
         "//absl/base:config",
         "//absl/base:core_headers",
+        "//absl/cleanup",
         "//absl/container:flat_hash_map",
         "//absl/log",
         "//absl/status",

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -1314,6 +1314,7 @@ absl_cc_test(
     ${ABSL_TEST_COPTS}
   DEPS
     absl::base
+    absl::cleanup
     absl::config
     absl::flat_hash_map
     absl::generic_printer_internal

--- a/absl/strings/internal/generic_printer.cc
+++ b/absl/strings/internal/generic_printer.cc
@@ -22,6 +22,7 @@
 #include "absl/base/config.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/escaping.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 
 namespace absl {
@@ -50,18 +51,27 @@ std::string TryShorten(T v, F strtox) {
 // ensure that values are precise, but rather that they are wide enough to
 // represent distinct values. go/c++17std/numeric.limits.members.html
 std::ostream& PrintPreciseFP(std::ostream& os, float v) {
+  // TryShorten formats with absl::StrFormat, which is locale-independent and
+  // always emits a '.' radix. The round-trip check has to read it back the same
+  // way: std::strtof honours LC_NUMERIC, so under a comma-radix locale it stops
+  // at the '.' and the shortened form is wrongly rejected. SimpleAtof is
+  // locale-independent.
   return os << TryShorten(v, [](const char* buf) {
-           char* unused;
-           return std::strtof(buf, &unused);
+           float out = 0;
+           (void)absl::SimpleAtof(buf, &out);
+           return out;
          }) << "f";
 }
 std::ostream& PrintPreciseFP(std::ostream& os, double v) {
   return os << TryShorten(v, [](const char* buf) {
-           char* unused;
-           return std::strtod(buf, &unused);
+           double out = 0;
+           (void)absl::SimpleAtod(buf, &out);
+           return out;
          });
 }
 std::ostream& PrintPreciseFP(std::ostream& os, long double v) {
+  // No locale-independent long double parser is available, so this path keeps
+  // std::strtold and remains locale-sensitive.
   return os << TryShorten(v, [](const char* buf) {
            char* unused;
            return std::strtold(buf, &unused);

--- a/absl/strings/internal/generic_printer_test.cc
+++ b/absl/strings/internal/generic_printer_test.cc
@@ -15,6 +15,7 @@
 #include "absl/strings/internal/generic_printer.h"
 
 #include <array>
+#include <clocale>
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -32,6 +33,7 @@
 #include "gtest/gtest.h"
 #include "absl/base/attributes.h"
 #include "absl/base/config.h"
+#include "absl/cleanup/cleanup.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -229,6 +231,32 @@ TEST(GenericPrinterTest, PreciseLongDouble) {
             GenericPrintToString(
                 std::nextafter(std::numeric_limits<long double>::lowest(), 1)));
   EXPECT_THAT(GenericPrintToString(0.L), EndsWith("L"));
+}
+
+TEST(GenericPrinterTest, PreciseFPUnderCommaRadixLocale) {
+  // The values are formatted with locale-independent absl::StrFormat (a '.'
+  // radix), so the round-trip shortening must not depend on LC_NUMERIC. Under a
+  // comma-radix locale a locale-sensitive reader stops at the '.', which used
+  // to defeat the shortened output.
+  const char* saved = std::setlocale(LC_NUMERIC, nullptr);
+  std::string saved_locale = saved ? saved : "C";
+  absl::Cleanup restore = [&] {
+    std::setlocale(LC_NUMERIC, saved_locale.c_str());
+  };
+
+  bool set = false;
+  for (const char* name : {"de_DE.UTF-8", "fr_FR.UTF-8", "de_DE", "fr_FR"}) {
+    if (std::setlocale(LC_NUMERIC, name) != nullptr) {
+      set = true;
+      break;
+    }
+  }
+  if (!set) {
+    GTEST_SKIP() << "No comma-radix locale available on this system.";
+  }
+
+  EXPECT_EQ("1.1f", GenericPrintToString(1.1f));
+  EXPECT_EQ("1.1", GenericPrintToString(1.1));
 }
 
 TEST(GenericPrinterTest, StreamableLvalue) {


### PR DESCRIPTION
GenericPrint shortens floating-point output in TryShorten by formatting the value with absl::StrFormat and then reading it back to confirm the shorter form still round-trips. absl::StrFormat is locale-independent and always writes a full stop as the radix, but the read-back for float and double went through std::strtof and std::strtod, which honour LC_NUMERIC. In a process that has called setlocale to a comma-radix locale such as de_DE or fr_FR those readers stop at the full stop, so the shortened candidate never compares equal and the printer quietly falls back to the long form; for instance 1.1 prints as 1.10000000000000009. I noticed it because the existing PreciseFloat and PreciseDouble cases assert the concise output and so silently depend on the C locale being active. Routing the float and double check through absl::SimpleAtof and absl::SimpleAtod, which are locale-independent, lines the parse up with the formatter and keeps the shortening working everywhere. The long double overload still uses std::strtold as there is no locale-independent long double parser to switch to. I added a regression test that pins a comma-radix locale, skips when none is installed, and restores the previous locale with absl::Cleanup.