### PR TITLE
Include  <signal.h> for SIG* constants

### DIFF
--- a/absl/log/internal/test_helpers.cc
+++ b/absl/log/internal/test_helpers.cc
@@ -25,6 +25,10 @@
 #include "absl/log/initialize.h"
 #include "absl/log/internal/globals.h"
 
+#if defined(ABSL_HAVE_ALARM)
+#include <signal.h>
+#endif
+
 namespace absl {
 ABSL_NAMESPACE_BEGIN
 namespace log_internal {


### PR DESCRIPTION
The test uses `SIGABRT` on most of the systems, so explicitly include `<signal.h>` to ensure it is available, and not rely on it being implicitly pulled in by other includes.