### PR TITLE
Initial support for GNU/Hurd

### DIFF
--- a/absl/base/config.h
+++ b/absl/base/config.h
@@ -231,11 +231,11 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #endif
 
 // ABSL_HAVE_TLS is defined to 1 when __thread should be supported.
-// We assume __thread is supported on Linux when compiled with Clang or
+// We assume __thread is supported on Linux or Hurd when compiled with Clang or
 // compiled against libstdc++ with _GLIBCXX_HAVE_TLS defined.
 #ifdef ABSL_HAVE_TLS
 #error ABSL_HAVE_TLS cannot be directly set
-#elif (defined(__linux__)) && (defined(__clang__) || defined(_GLIBCXX_HAVE_TLS))
+#elif (defined(__linux__) || defined(__GNU__)) && (defined(__clang__) || defined(_GLIBCXX_HAVE_TLS))
 #define ABSL_HAVE_TLS 1
 #elif defined(__INTEL_LLVM_COMPILER)
 #define ABSL_HAVE_TLS 1
@@ -364,6 +364,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 //   WebAssembly (Emscripten)          __EMSCRIPTEN__
 //   Fuchsia                           __Fuchsia__
 //   WebAssembly (WASI)                _WASI_EMULATED_MMAN (implies __wasi__)
+//   GNU/Hurd                          __GNU__
 //
 // Note that since Android defines both __ANDROID__ and __linux__, one
 // may probe for either Linux or Android by simply testing for __linux__.
@@ -379,7 +380,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
     defined(__EMSCRIPTEN__) || defined(__Fuchsia__) || defined(__sun) ||  \
     defined(__myriad2__) || defined(__HAIKU__) || defined(__OpenBSD__) || \
     defined(__NetBSD__) || defined(__QNX__) || defined(__VXWORKS__) ||    \
-    defined(__hexagon__) || defined(__XTENSA__) ||                        \
+    defined(__hexagon__) || defined(__XTENSA__) || defined(__GNU__) ||    \
     defined(_WASI_EMULATED_MMAN)
 #define ABSL_HAVE_MMAP 1
 #endif
@@ -427,7 +428,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 // platforms.
 #ifdef ABSL_HAVE_SEMAPHORE_H
 #error ABSL_HAVE_SEMAPHORE_H cannot be directly set
-#elif defined(__linux__) || defined(__ros__) || defined(__VXWORKS__)
+#elif defined(__linux__) || defined(__ros__) || defined(__VXWORKS__) || defined(__GNU__)
 #define ABSL_HAVE_SEMAPHORE_H 1
 #endif
 

--- a/absl/base/internal/raw_logging.cc
+++ b/absl/base/internal/raw_logging.cc
@@ -43,7 +43,7 @@
 // this, consider moving both to config.h instead.
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||     \
     defined(__hexagon__) || defined(__Fuchsia__) || defined(__OpenBSD__) || \
-    defined(__EMSCRIPTEN__) || defined(__ASYLO__)
+    defined(__EMSCRIPTEN__) || defined(__ASYLO__) || defined(__GNU__)
 
 #include <unistd.h>
 

--- a/absl/base/internal/strerror_test.cc
+++ b/absl/base/internal/strerror_test.cc
@@ -40,7 +40,8 @@ TEST(StrErrorTest, InvalidErrorCode) {
   errno = ERANGE;
   EXPECT_THAT(absl::base_internal::StrError(-1),
               AnyOf(Eq("No error information"), Eq("Unknown error -1"),
-                    Eq("Unknown error")));
+                    Eq("Unknown error"),
+                    Eq("Error in unknown error system: FFFFFFFF")));
   EXPECT_THAT(errno, Eq(ERANGE));
 }
 

--- a/absl/debugging/internal/symbolize.h
+++ b/absl/debugging/internal/symbolize.h
@@ -30,7 +30,7 @@
 #ifdef ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE
 #error ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE cannot be directly set
 #elif defined(__ELF__) && defined(__GLIBC__) && !defined(__asmjs__) \
-      && !defined(__wasm__)
+      && !defined(__wasm__) && !defined(__GNU__)
 #define ABSL_INTERNAL_HAVE_ELF_SYMBOLIZE 1
 
 #include <elf.h>

--- a/absl/log/log_modifier_methods_test.cc
+++ b/absl/log/log_modifier_methods_test.cc
@@ -218,13 +218,14 @@ TEST(TailCallsModifiesTest, WithPerror) {
       Send(AllOf(
           TextMessage(AnyOf(Eq("hello world: Bad file number [9]"),
                             Eq("hello world: Bad file descriptor [9]"),
-                            Eq("hello world: Bad file descriptor [8]"))),
+                            Eq("hello world: Bad file descriptor [8]"),
+                            Eq("hello world: Bad file descriptor [1073741833]"))),
           ENCODED_MESSAGE(HasValues(ElementsAre(
               ValueWithLiteral(Eq("hello world")), ValueWithLiteral(Eq(": ")),
               AnyOf(ValueWithStr(Eq("Bad file number")),
                     ValueWithStr(Eq("Bad file descriptor"))),
               ValueWithLiteral(Eq(" [")),
-              AnyOf(ValueWithStr(Eq("8")), ValueWithStr(Eq("9"))),
+              AnyOf(ValueWithStr(Eq("8")), ValueWithStr(Eq("9")), ValueWithStr(Eq("1073741833"))),
               ValueWithLiteral(Eq("]"))))))));
 
   test_sink.StartCapturingLogs();

--- a/absl/log/stripping_test.cc
+++ b/absl/log/stripping_test.cc
@@ -170,7 +170,7 @@ class StrippingTest : public ::testing::Test {
   // Opens this program's executable file.  Returns `nullptr` and writes to
   // `stderr` on failure.
   std::unique_ptr<FILE, std::function<void(FILE*)>> OpenTestExecutable() {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
     std::unique_ptr<FILE, std::function<void(FILE*)>> fp(
         fopen("/proc/self/exe", "rb"), [](FILE* fp) { fclose(fp); });
     if (!fp) {


### PR DESCRIPTION
Tweak configuration & tests so that most of abseil works on the Hurd:
- enable available TLS (`__thread`, in practice)
- enable available mmap
- enable available POSIX semaphores
- enable available POSIX `write()`
- disable the ELF symbolizer: while the object format is ELF, the symbolizer uses bits (i.e. `mmap` files in `/proc`) not currently available
- use the available `/proc/self/exe`
- tweak a log test for the different value of `EBADF`
- tweak the strerror test for the GNU libc Hurd string representation of `-1`