### PR TITLE
Fix AbslInternalGetFileMappingHint to obey ABSL_OPTION_USE_INLINE_NAMESPACE

### DIFF
--- a/absl/debugging/internal/symbolize.h
+++ b/absl/debugging/internal/symbolize.h
@@ -156,8 +156,8 @@ ABSL_NAMESPACE_END
 extern "C"
 #endif  // __cplusplus
 
-    bool
-    AbslInternalGetFileMappingHint(const void** start, const void** end,
-                                   uint64_t* offset, const char** filename);
+    bool ABSL_INTERNAL_C_SYMBOL(AbslInternalGetFileMappingHint)(
+        const void** start, const void** end, uint64_t* offset,
+        const char** filename);
 
 #endif  // ABSL_DEBUGGING_INTERNAL_SYMBOLIZE_H_

--- a/absl/debugging/symbolize_elf.inc
+++ b/absl/debugging/symbolize_elf.inc
@@ -1697,10 +1697,9 @@ bool Symbolize(const void *pc, char *out, int out_size) {
 ABSL_NAMESPACE_END
 }  // namespace absl
 
-extern "C" bool AbslInternalGetFileMappingHint(const void **start,
-                                               const void **end,
-                                               uint64_t *offset,
-                                               const char **filename) {
+extern "C" bool ABSL_INTERNAL_C_SYMBOL(AbslInternalGetFileMappingHint)(
+    const void **start, const void **end, uint64_t *offset,
+    const char **filename) {
   return absl::debugging_internal::GetFileMappingHint(start, end, offset,
                                                       filename);
 }


### PR DESCRIPTION
The purpose of `ABSL_OPTION_USE_INLINE_NAMESPACE` is to allow multiple independent copies of abseil-cpp to be linked into the same binary, in different (linker) namespaces. For symbols marked `extern "C"`, we need to manually mangle their names to accomplish the same effect.

Abseil provides the `ABSL_INTERNAL_C_SYMBOL` macro for this purpose, but it wasn't used on `AbslInternalGetFileMappingHint`, leading to symbol conflicts when multiple different copies are linked under the same name.

Fix this by annotating `AbslInternalGetFileMappingHint` with `ABSL_INTERNAL_C_SYMBOL`.

---

Note that an alternative solution is also possible: the `AbslInternalGetFileMappingHint` appears to be dead code in the open-source export of abseil-cpp. (I assume there is nearby google-internal code that uses it.) Instead of mangling the function name, you could also simply remove this code (declaration and definition) from the github export.