### PR TITLE
cast char to unsigned char before ctype calls in cctz parser

### DIFF
--- a/absl/time/internal/cctz/src/time_zone_format.cc
+++ b/absl/time/internal/cctz/src/time_zone_format.cc
@@ -553,7 +553,7 @@ std::string format(const std::string& format, const time_point<seconds>& tp,
       bp = Format64(ep, 4, al.cs.year());
       result.append(bp, ep);
       pending = cur += 2;
-    } else if (std::isdigit(*cur)) {
+    } else if (std::isdigit(static_cast<unsigned char>(*cur))) {
       // Possibly found %E#S or %E#f.
       int n = 0;
       if (const char* np = ParseInt(cur, 0, 0, 1024, &n)) {
@@ -620,7 +620,8 @@ const char* ParseOffset(const char* dp, const char* mode, int* offset) {
 const char* ParseZone(const char* dp, std::string* zone) {
   zone->clear();
   if (dp != nullptr) {
-    while (*dp != '\0' && !std::isspace(*dp)) zone->push_back(*dp++);
+    while (*dp != '\0' && !std::isspace(static_cast<unsigned char>(*dp)))
+      zone->push_back(*dp++);
     if (zone->empty()) dp = nullptr;
   }
   return dp;
@@ -706,7 +707,7 @@ bool parse(const std::string& format, const std::string& input,
   const char* const edata = data + input.size();
 
   // Skips leading whitespace.
-  while (std::isspace(*data)) ++data;
+  while (std::isspace(static_cast<unsigned char>(*data))) ++data;
 
   const year_t kyearmax = std::numeric_limits<year_t>::max();
   const year_t kyearmin = std::numeric_limits<year_t>::min();
@@ -744,9 +745,9 @@ bool parse(const std::string& format, const std::string& input,
 
   // Steps through format, one specifier at a time.
   while (data != nullptr && fmt != efmt) {
-    if (std::isspace(*fmt)) {
-      while (std::isspace(*data)) ++data;
-      while (std::isspace(*++fmt)) continue;
+    if (std::isspace(static_cast<unsigned char>(*fmt))) {
+      while (std::isspace(static_cast<unsigned char>(*data))) ++data;
+      while (std::isspace(static_cast<unsigned char>(*++fmt))) continue;
       continue;
     }
 
@@ -898,7 +899,8 @@ bool parse(const std::string& format, const std::string& input,
           continue;
         }
         if (fmt[0] == '*' && fmt[1] == 'f') {
-          if (data != nullptr && std::isdigit(*data)) {
+          if (data != nullptr &&
+              std::isdigit(static_cast<unsigned char>(*data))) {
             data = ParseSubSeconds(data, &subseconds);
           }
           fmt += 2;
@@ -917,7 +919,7 @@ bool parse(const std::string& format, const std::string& input,
           fmt += 2;
           continue;
         }
-        if (std::isdigit(*fmt)) {
+        if (std::isdigit(static_cast<unsigned char>(*fmt))) {
           int n = 0;  // value ignored
           if (const char* np = ParseInt(fmt, 0, 0, 1024, &n)) {
             if (*np == 'S') {
@@ -929,7 +931,8 @@ bool parse(const std::string& format, const std::string& input,
               continue;
             }
             if (*np == 'f') {
-              if (data != nullptr && std::isdigit(*data)) {
+              if (data != nullptr &&
+                  std::isdigit(static_cast<unsigned char>(*data))) {
                 data = ParseSubSeconds(data, &subseconds);
               }
               fmt = ++np;
@@ -977,7 +980,7 @@ bool parse(const std::string& format, const std::string& input,
   }
 
   // Skip any remaining whitespace.
-  while (std::isspace(*data)) ++data;
+  while (std::isspace(static_cast<unsigned char>(*data))) ++data;
 
   // parse() must consume the entire input string.
   if (data != edata) {


### PR DESCRIPTION
The parse() and format() helpers in time_zone_format.cc feed a raw char straight into std::isspace() and std::isdigit() while scanning the input and format strings. When char is signed and a byte is 0x80 or higher the value is negative, which is undefined behavior for the ctype functions since the argument has to be representable as unsigned char or equal to EOF, and it can index outside the classification table on some libc implementations. This is reachable from ParseTime with any input or format containing a high-bit byte. Casting each argument to unsigned char fixes every site, the same guard already used for the ctype calls in absl/strings/escaping.cc.