### PR TITLE
reject unpaired high surrogate in wchar_t string formatting

### DIFF
--- a/absl/strings/internal/str_format/arg.cc
+++ b/absl/strings/internal/str_format/arg.cc
@@ -322,6 +322,10 @@ inline bool ConvertStringArg(const wchar_t *v,
     if (chars == static_cast<size_t>(-1)) { return false; }
     chars_written += chars;
   }
+  // A trailing high surrogate with no following low surrogate leaves only the
+  // first two bytes of a 4-byte sequence written; reject it instead of emitting
+  // invalid UTF-8, matching the single-character path in ConvertWCharTImpl.
+  if (s.saw_high_surrogate) { return false; }
   return ConvertStringArg(string_view(mb.data(), chars_written), conv, sink);
 }
 

--- a/absl/strings/internal/str_format/convert_test.cc
+++ b/absl/strings/internal/str_format/convert_test.cc
@@ -357,6 +357,28 @@ TEST_F(FormatConvertTest, StringPrecision) {
   EXPECT_EQ("ABC", FormatPack(wformat2, {FormatArgImpl(wp)}));
 }
 
+TEST_F(FormatConvertTest, WideStringUnpairedHighSurrogate) {
+  UntypedFormatSpecImpl format("%ls");
+
+  // A wide string ending with an unpaired UTF-16 high surrogate would otherwise
+  // emit only the first two bytes of a 4-byte sequence. Reject it, matching the
+  // single-character "%lc" path.
+  std::wstring bad = L"AB";
+  bad.push_back(static_cast<wchar_t>(0xD800));
+  EXPECT_EQ("", FormatPack(format, {FormatArgImpl(bad)}));
+
+  // Valid input is unaffected. U+1F600 encodes to the same 4-byte UTF-8 whether
+  // it arrives as a surrogate pair (16-bit wchar_t) or a single code unit.
+  std::wstring good;
+  if (sizeof(wchar_t) * CHAR_BIT <= 16) {
+    good.push_back(static_cast<wchar_t>(0xD83D));
+    good.push_back(static_cast<wchar_t>(0xDE00));
+  } else {
+    good.push_back(static_cast<wchar_t>(0x1F600));
+  }
+  EXPECT_EQ("\xF0\x9F\x98\x80", FormatPack(format, {FormatArgImpl(good)}));
+}
+
 // Pointer formatting is implementation defined. This checks that the argument
 // can be matched to `ptr`.
 MATCHER_P(MatchesPointerString, ptr, "") {


### PR DESCRIPTION
The wide-string overload of ConvertStringArg in str_format runs each wchar_t through WideToUtf8 but never inspects the ShiftState after the loop, so a wide string ending on an unpaired UTF-16 high surrogate has only the first two bytes of a 4-byte sequence written while StrFormat("%ls", ...) still reports success, emitting truncated invalid UTF-8. The single-character path in ConvertWCharTImpl already rejects a lone high surrogate, so this adds the same saw_high_surrogate check after the loop to make the string path fail the same way. The regression test in convert_test.cc covers both a trailing high surrogate and a valid non-BMP code point so surrogate pairs keep working.