### PR TITLE
guard size overflow in BytesToHexString and UrlEscape

### DIFF
--- a/absl/strings/escaping.cc
+++ b/absl/strings/escaping.cc
@@ -1177,6 +1177,8 @@ std::string HexStringToBytes(absl::string_view from) {
 
 std::string BytesToHexString(absl::string_view from) {
   std::string result;
+  ABSL_INTERNAL_CHECK(from.size() <= std::numeric_limits<size_t>::max() / 2,
+                      "BytesToHexString() overflow");
   StringResizeAndOverwrite(
       result, 2 * from.size(), [from](char* buf, size_t buf_size) {
         absl::BytesToHexStringInternal(
@@ -1211,6 +1213,10 @@ static std::string UrlEscapeInternal(absl::string_view input,
 
   // We need a buffer with enough space to store at most the initial portion
   // plus 3 bytes for each remaining character since escapes use 3 characters.
+  // The total is bounded by 3 * input.size(), so guard against a size_t
+  // overflow before computing it.
+  ABSL_INTERNAL_CHECK(input.size() <= std::numeric_limits<size_t>::max() / 3,
+                      "UrlEscape() overflow");
   StringResizeAndOverwrite(
       output, initial_portion + 3 * (input.size() - initial_portion),
       [&](char* buf, size_t) {


### PR DESCRIPTION
BytesToHexString sizes its output as 2 * from.size() and UrlEscapeInternal as initial_portion + 3 * (input.size() - initial_portion), neither of which checks for a size_t overflow, so a large enough input wraps the length and StringResizeAndOverwrite allocates a buffer smaller than the number of bytes the following loop writes into it. CEscapedLength and CalculateBase64EscapedLenInternal in this same file already guard their expansions against size_t max with ABSL_INTERNAL_CHECK, so these two newer helpers just add the matching check with the appropriate divisor.