### PR TITLE
fix: export absl::time_zone name on MinGW DLL builds

### DIFF
--- a/CMake/AbseilDll.cmake
+++ b/CMake/AbseilDll.cmake
@@ -470,12 +470,14 @@ set(ABSL_INTERNAL_DLL_FILES
   "strings/string_view.h"
 )
 
-if(MSVC)
+if(WIN32)
   list(APPEND ABSL_INTERNAL_DLL_FILES
     "time/internal/cctz/src/time_zone_name_win.cc"
     "time/internal/cctz/src/time_zone_name_win.h"
   )
-else()
+endif()
+
+if(NOT MSVC)
   list(APPEND ABSL_INTERNAL_DLL_FILES
     "flags/commandlineflag.cc"
     "flags/commandlineflag.h"


### PR DESCRIPTION
## Summary

Building the monolithic shared library (`-DABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON -DBUILD_SHARED_LIBS=ON`) with MinGW on Windows fails at link time with an undefined reference to `absl::time_internal::cctz::GetWindowsLocalTimeZone()`. That symbol lives in `time/internal/cctz/src/time_zone_name_win.cc`, which `CMake/AbseilDll.cmake` only appends to `ABSL_INTERNAL_DLL_FILES` under `if(MSVC)` - so MinGW DLL builds never compile it, even though `time_zone_lookup.cc` calls it on all Windows toolchains.

This splits the single `if(MSVC) ... else() ... endif()` block into two independent conditions: the `time_zone_name_win.cc`/`.h` sources are appended under `if(WIN32)` (covering MSVC, clang-cl, and MinGW), and the `flags/*` source group stays under `if(NOT MSVC)` so MinGW keeps receiving exactly the flags sources it gets today.

## Why this matters

The per-target (non-DLL) build in `absl/time/CMakeLists.txt` already gates this file on `$<$<PLATFORM_ID:Windows>:...>` - i.e. any Windows platform - so the DLL list's `MSVC`-only gate is the inconsistency. `WIN32` is the correct CMake variable here; the patch sketched in the issue comments used `if(Windows)`, which is not a variable CMake defines, so this supersedes it. A carry-along fix was merged downstream into microsoft/vcpkg (#50887), but upstream remains broken.

## Testing

No C++ sources change and there is no test file for the DLL file list, so verification is a CMake configure/build matrix: the monolithic shared-library build now links under MinGW (the previously-undefined `GetWindowsLocalTimeZone()` is compiled into the DLL), and the MSVC and non-MSVC builds are unchanged (MSVC still gets the Windows time-zone source via `WIN32`; MinGW still gets the `flags/*` sources via `NOT MSVC`).

Fixes #2025
