### PR TITLE
Fix CMake MSVC runtime override when CMAKE_MSVC_RUNTIME_LIBRARY is us…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,12 @@ list(APPEND CMAKE_MODULE_PATH
 option(ABSL_MSVC_STATIC_RUNTIME
   "Link static runtime libraries"
   OFF)
-if(ABSL_MSVC_STATIC_RUNTIME)
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-else()
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  if(ABSL_MSVC_STATIC_RUNTIME)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  endif()
 endif()
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
## Summary

This PR updates `CMakeLists.txt` so that `CMAKE_MSVC_RUNTIME_LIBRARY` is only set when it has not already been defined.

## Motivation

Currently, Abseil unconditionally overwrites `CMAKE_MSVC_RUNTIME_LIBRARY`, preventing users from specifying their preferred MSVC runtime through the command line or the CMake cache. This makes it difficult for projects integrating Abseil to control the runtime library consistently across their build.

## Changes

* Only sets `CMAKE_MSVC_RUNTIME_LIBRARY` if it is not already defined.
* Preserves user-provided values passed via the command line or CMake cache.
* Retains Abseil's existing default behavior when no runtime library is explicitly configured.
* Continues to respect `ABSL_MSVC_STATIC_RUNTIME` for selecting the default static or dynamic runtime when no explicit runtime has been provided.

## Impact

This change is backward compatible. Existing users who do not explicitly configure `CMAKE_MSVC_RUNTIME_LIBRARY` will see no behavioral change, while users who do configure it will have their setting preserved.

Fixes #2084.
