### PR TITLE
reject oversize punycode length in rust demangler

### DIFF
--- a/absl/debugging/internal/demangle_rust.cc
+++ b/absl/debugging/internal/demangle_rust.cc
@@ -712,6 +712,11 @@ class RustSymbolParser {
     if (!ParseDecimalNumber(num_bytes)) return false;
     (void)Eat('_');  // optional separator, needed if a digit follows
     if (is_punycoded) {
+      // A length exceeding the remaining input would make punycode_end point
+      // past the end of the buffer, forming an out-of-bounds pointer.
+      if (static_cast<size_t>(num_bytes) > std::strlen(&encoding_[pos_])) {
+        return false;
+      }
       DecodeRustPunycodeOptions options;
       options.punycode_begin = &encoding_[pos_];
       options.punycode_end = &encoding_[pos_] + num_bytes;

--- a/absl/debugging/internal/demangle_rust_test.cc
+++ b/absl/debugging/internal/demangle_rust_test.cc
@@ -118,6 +118,11 @@ TEST(DemangleRust, UnicodeIdentifiers) {
                     "ice_cap::Eyjafjallajökull");
   EXPECT_DEMANGLING("_RNvC7ice_caps_u19Eyjafjallajkull_jtb",
                     "ice_cap::Eyjafjallajökull");
+
+  // A punycode byte count larger than the remaining input is rejected instead
+  // of running the decoder past the end of the buffer.
+  EXPECT_DEMANGLING_FAILS("_RNvC7ice_caps_u2000000000Eyjafjallajkull_jtb");
+  EXPECT_DEMANGLING_FAILS("_RNvC7ice_caps_u99Eyj_a");
 }
 
 TEST(DemangleRust, FunctionInModule) {


### PR DESCRIPTION
in ParseUndisambiguatedIdentifier a punycoded identifier's decimal byte count is used to form `punycode_end = &encoding_[pos_] + num_bytes` before it is checked against the input, so a mangled name like `_RNvC7ice_caps_u2000000000Eyjafjallajkull_jtb` makes that pointer land far past the end of the buffer (out-of-bounds pointer arithmetic); reject a length larger than the remaining input first, matching how the non-punycode branch already stops at the NUL terminator.