### PR TITLE
fix reversed operand in ShouldPickFirstSymbol tie-break

### DIFF
--- a/absl/debugging/symbolize_elf.inc
+++ b/absl/debugging/symbolize_elf.inc
@@ -712,7 +712,7 @@ static bool ShouldPickFirstSymbol(const ElfW(Sym) & symbol1,
   // If one of the symbols is weak and the other is not, pick the one
   // this is not a weak symbol.
   char bind1 = ELF_ST_BIND(symbol1.st_info);
-  char bind2 = ELF_ST_BIND(symbol1.st_info);
+  char bind2 = ELF_ST_BIND(symbol2.st_info);
   if (bind1 == STB_WEAK && bind2 != STB_WEAK) return false;
   if (bind2 == STB_WEAK && bind1 != STB_WEAK) return true;
 
@@ -728,7 +728,7 @@ static bool ShouldPickFirstSymbol(const ElfW(Sym) & symbol1,
   // If one of the symbols has no type and the other is not, pick the
   // one that has a type.
   char type1 = ELF_ST_TYPE(symbol1.st_info);
-  char type2 = ELF_ST_TYPE(symbol1.st_info);
+  char type2 = ELF_ST_TYPE(symbol2.st_info);
   if (type1 != STT_NOTYPE && type2 == STT_NOTYPE) {
     return true;
   }


### PR DESCRIPTION
ShouldPickFirstSymbol breaks ties between two symbols that cover the same address, but it reads bind2 and type2 from symbol1 rather than symbol2, so the weak-versus-strong and typed-versus-untyped comparisons each test a value against itself and can never fire. The practical effect is that when a weak alias and a global symbol share an address the symbolizer may report the weak alias (or an untyped entry) instead of the canonical name, because selection then falls through to the size check and finally to picking whichever symbol happened to be seen first in the table. This reads the second operand from symbol2 so the intended preference actually takes effect; the size comparison in between was already using both operands correctly.