### PR TITLE
Use `volatile` instead of `benchmark::DoNotOptimize` as GCC optimizes awa…

### DIFF
--- a/absl/debugging/stacktrace_benchmark.cc
+++ b/absl/debugging/stacktrace_benchmark.cc
@@ -44,8 +44,8 @@ ABSL_ATTRIBUTE_NOINLINE void func(benchmark::State& state, int x, int depth) {
     // Touch a significant amount of memory so that the stack is likely to be
     // not cached in the L1 cache.
     state.PauseTiming();
-    int* arr = new int[kCacheSize];
-    for (int i = 0; i < kCacheSize; ++i) benchmark::DoNotOptimize(arr[i] = 100);
+    volatile int* arr = new int[kCacheSize];
+    for (int i = 0; i < kCacheSize; ++i) a[i] = 100;
     delete[] arr;
     state.ResumeTiming();
     benchmark::DoNotOptimize(absl::GetStackTrace(pcs, depth, 0));

--- a/absl/debugging/stacktrace_benchmark.cc
+++ b/absl/debugging/stacktrace_benchmark.cc
@@ -45,7 +45,7 @@ ABSL_ATTRIBUTE_NOINLINE void func(benchmark::State& state, int x, int depth) {
     // not cached in the L1 cache.
     state.PauseTiming();
     volatile int* arr = new int[kCacheSize];
-    for (int i = 0; i < kCacheSize; ++i) a[i] = 100;
+    for (int i = 0; i < kCacheSize; ++i) arr[i] = 100;
     delete[] arr;
     state.ResumeTiming();
     benchmark::DoNotOptimize(absl::GetStackTrace(pcs, depth, 0));


### PR DESCRIPTION
GCC optimizes away the write when we use `benchmark::DoNotOptimize` in [`stacktrace_benchmark.cc` ](https://github.com/abseil/abseil-cpp/blob/master/absl/debugging/stacktrace_benchmark.cc#L48) file.  Using volatile for the array pointer fixes this.  Compiler explorer link: https://godbolt.org/z/jzbKK3M1n