### PR TITLE
Link Threads::Threads in tests that use threads directly

### DIFF
--- a/absl/base/CMakeLists.txt
+++ b/absl/base/CMakeLists.txt
@@ -483,6 +483,7 @@ absl_cc_test(
   DEPS
     absl::errno_saver
     absl::strerror
+    Threads::Threads
     GTest::gmock
     GTest::gtest_main
 )
@@ -533,6 +534,7 @@ absl_cc_test(
     absl::config
     absl::core_headers
     absl::synchronization
+    Threads::Threads
     GTest::gtest_main
 )
 
@@ -577,6 +579,7 @@ absl_cc_test(
   DEPS
     absl::config
     absl::synchronization
+    Threads::Threads
     GTest::gtest_main
 )
 
@@ -591,6 +594,7 @@ absl_cc_test(
     absl::base
     absl::core_headers
     absl::synchronization
+    Threads::Threads
     GTest::gtest_main
 )
 
@@ -632,6 +636,7 @@ absl_cc_test(
   DEPS
     absl::base
     absl::synchronization
+    Threads::Threads
     GTest::gtest_main
 )
 
@@ -756,6 +761,7 @@ absl_cc_test(
   DEPS
     absl::strerror
     absl::strings
+    Threads::Threads
     GTest::gmock
     GTest::gtest_main
 )

--- a/absl/container/CMakeLists.txt
+++ b/absl/container/CMakeLists.txt
@@ -602,6 +602,7 @@ absl_cc_test(
   DEPS
     absl::container_memory
     absl::hash_policy_traits
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -628,6 +629,7 @@ absl_cc_test(
   DEPS
     absl::common_policy_traits
     absl::config
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -664,6 +666,7 @@ absl_cc_test(
     absl::config
     absl::hashtablez_sampler
     absl::random_random
+    Threads::Threads
     GTest::gmock_main
 )
 

--- a/absl/debugging/CMakeLists.txt
+++ b/absl/debugging/CMakeLists.txt
@@ -60,6 +60,7 @@ absl_cc_test(
     absl::core_headers
     absl::errno_saver
     absl::span
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -117,6 +118,7 @@ absl_cc_test(
     absl::strings
     absl::str_format
     absl::symbolize
+    Threads::Threads
     GTest::gmock
 )
 

--- a/absl/flags/CMakeLists.txt
+++ b/absl/flags/CMakeLists.txt
@@ -355,6 +355,7 @@ absl_cc_test(
     absl::raw_logging_internal
     absl::strings
     absl::time
+    Threads::Threads
     GTest::gtest_main
 )
 
@@ -443,6 +444,7 @@ absl_cc_test(
     absl::base
     absl::flags_internal
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 

--- a/absl/log/CMakeLists.txt
+++ b/absl/log/CMakeLists.txt
@@ -807,6 +807,7 @@ absl_cc_test(
     absl::vlog_is_on
     absl::log_severity
     absl::flags
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -870,6 +871,7 @@ absl_cc_test(
     absl::log_internal_test_helpers
     absl::log_internal_test_matchers
     absl::scoped_mock_log
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -930,6 +932,7 @@ absl_cc_test(
     absl::log_internal_test_helpers
     absl::log_internal_test_matchers
     absl::scoped_mock_log
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -979,6 +982,7 @@ absl_cc_test(
     absl::flags_reflection
     absl::scoped_mock_log
     absl::strings
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -999,6 +1003,7 @@ absl_cc_test(
     absl::log_internal_test_helpers
     absl::log_severity
     absl::scoped_mock_log
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1020,6 +1025,7 @@ absl_cc_test(
     absl::source_location
     absl::str_format
     absl::strings
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1037,6 +1043,7 @@ absl_cc_test(
     absl::log
     absl::log_severity
     absl::scoped_mock_log
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1060,6 +1067,7 @@ absl_cc_test(
     absl::log_severity
     absl::scoped_mock_log
     absl::strings
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1084,6 +1092,7 @@ absl_cc_test(
     absl::scoped_mock_log
     absl::source_location
     absl::strings
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1106,6 +1115,7 @@ absl_cc_test(
     absl::source_location
     absl::strings
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1130,6 +1140,7 @@ absl_cc_test(
     absl::scoped_mock_log
     absl::strings
     absl::synchronization
+    Threads::Threads
     GTest::gmock
     GTest::gtest_main
 )
@@ -1171,6 +1182,7 @@ absl_cc_test(
     absl::strerror
     absl::strings
     absl::str_format
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1190,6 +1202,7 @@ absl_cc_test(
     absl::log_internal_test_matchers
     absl::log_structured
     absl::scoped_mock_log
+    Threads::Threads
     GTest::gmock_main
 )
 

--- a/absl/profiling/CMakeLists.txt
+++ b/absl/profiling/CMakeLists.txt
@@ -35,6 +35,7 @@ absl_cc_test(
     absl::random_random
     absl::sample_recorder
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -89,6 +90,7 @@ absl_cc_test(
   DEPS
     absl::core_headers
     absl::periodic_sampler
+    Threads::Threads
     GTest::gmock_main
 )
 

--- a/absl/random/CMakeLists.txt
+++ b/absl/random/CMakeLists.txt
@@ -158,6 +158,7 @@ absl_cc_test(
     absl::random_distributions
     absl::random_mocking_bit_gen
     absl::random_random
+    Threads::Threads
     GTest::gmock
     GTest::gtest_main
 )
@@ -175,6 +176,7 @@ absl_cc_test(
     absl::random_bit_gen_ref
     absl::random_mocking_bit_gen
     absl::random_random
+    Threads::Threads
     GTest::gmock
     GTest::gtest_main
 )
@@ -1059,6 +1061,7 @@ absl_cc_test(
     absl::random_random
     absl::synchronization
     absl::type_traits
+    Threads::Threads
     GTest::gtest_main
 )
 
@@ -1093,6 +1096,7 @@ absl_cc_test(
     absl::flat_hash_map
     absl::random_internal_entropy_pool
     absl::synchronization
+    Threads::Threads
     GTest::gtest_main
 )
 

--- a/absl/strings/CMakeLists.txt
+++ b/absl/strings/CMakeLists.txt
@@ -620,6 +620,7 @@ absl_cc_test(
     absl::span
     absl::str_format
     absl::strings
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -828,6 +829,7 @@ absl_cc_test(
     absl::cordz_update_tracker
     absl::core_headers
     absl::synchronization
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -857,6 +859,7 @@ absl_cc_test(
     absl::config
     absl::cordz_functions
     absl::cordz_test_helpers
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -907,6 +910,7 @@ absl_cc_test(
     absl::random_distributions
     absl::synchronization
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -978,6 +982,7 @@ absl_cc_test(
     absl::cordz_update_tracker
     absl::crc_cord_state
     absl::thread_pool
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -1017,6 +1022,7 @@ absl_cc_test(
     absl::synchronization
     absl::thread_pool
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 

--- a/absl/synchronization/CMakeLists.txt
+++ b/absl/synchronization/CMakeLists.txt
@@ -130,6 +130,7 @@ absl_cc_test(
   DEPS
     absl::synchronization
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -144,6 +145,7 @@ absl_cc_test(
     absl::synchronization
     absl::time
     absl::tracing_internal
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -195,6 +197,7 @@ absl_cc_test(
     absl::memory
     absl::random_random
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -226,6 +229,7 @@ absl_cc_test(
     absl::synchronization
     absl::time
     absl::tracing_internal
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -259,6 +263,7 @@ absl_cc_test(
     absl::synchronization
     absl::strings
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -276,6 +281,7 @@ absl_cc_test(
     absl::synchronization
     absl::thread_pool
     absl::time
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -290,4 +296,5 @@ absl_cc_test(
     absl::synchronization
     absl::core_headers
     absl::check
+    Threads::Threads
 )

--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -163,6 +163,7 @@ absl_cc_test(
     absl::config
     absl::bind_front
     absl::synchronization
+    Threads::Threads
     GTest::gmock_main
 )
 
@@ -201,6 +202,7 @@ absl_cc_test(
     absl::random_random
     absl::raw_logging_internal
     absl::synchronization
+    Threads::Threads
     GTest::gmock_main
 )
 


### PR DESCRIPTION
## Summary

Link `Threads::Threads` in tests that use threads directly.

## Problem

Building Abseil as a monolithic shared library (`-DABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON` with `-DBUILD_SHARED_LIBS=ON`) with tests enabled fails to link on platforms where `libpthread` is a **separate DSO** (glibc < 2.34):

```
ld: absl_lifetime_test.dir/lifetime_test.cc.o: undefined reference to symbol 'pthread_join@@GLIBC_2.2.5'
ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

### Root cause

In monolithic-DLL mode, `absl_cc_test` collapses every in-DLL `absl::` dependency down to the single `abseil_dll` target. `abseil_dll` links `Threads::Threads` **privately** (`CMake/AbseilDll.cmake`), so `-lpthread` is *not* propagated to the test executables.

- `lifetime_test` links no GoogleTest target (it has its own `main`), so its entire link line is just `libabseil_dll.so`. It uses `std::thread` directly → unresolved `pthread_join` → **hard link failure**.
- ~46 other thread-using tests only link today because `GTest::gtest`'s imported target happens to drag `-lpthread` onto their link line. That is a fragile, incidental transitive dependency — exactly what breaks under the monolithic DLL once a test stops pulling GoogleTest.

## Fix

Every test that references pthread symbols now depends on `Threads::Threads` explicitly, matching the existing convention already used by `low_level_alloc_test` and `thread_identity_test`.

## Notes

- Rather than guess from source greps, the exact set was measured. All tests were built inside `quay.io/pypa/manylinux_2_28_x86_64` (glibc 2.28) container with `-Wl,--as-needed -lpthread` appended at the end of every test link line. The binaries that retained `libpthread`, minus the two that already declared `Threads::Threads`, are exactly the 47 targets fixed here.
- Some tests — e.g. `config_test`, `errno_saver_test`, several `log_*` — pull pthread via thread-local storage `pthread_getspecific`/`pthread_setspecific` rather than `std::thread`. They still genuinely need `libpthread` on old glibc, so they are included.
- No change needed for Bazel. Bazel has no monolithic-DLL mode; thread-using libraries (`base`, `malloc_internal`, `synchronization`) carry `linkopts = ["-pthread"]`, and Bazel propagates library `linkopts` transitively through `deps` to test binaries.