### PR TITLE
cmake: skip probes for required C++ standard

### DIFF
--- a/CMake/AbseilDll.cmake
+++ b/CMake/AbseilDll.cmake
@@ -724,10 +724,18 @@ set(ABSL_INTERNAL_TEST_DLL_TARGETS
   "status_matchers"
 )
 
-include(CheckCXXSourceCompiles)
+if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD_REQUIRED)
+  if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+    set(ABSL_INTERNAL_AT_LEAST_CXX20 ON)
+    set(ABSL_INTERNAL_AT_LEAST_CXX17 ON)
+  elseif(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+    set(ABSL_INTERNAL_AT_LEAST_CXX17 ON)
+  endif()
+else()
+  include(CheckCXXSourceCompiles)
 
-check_cxx_source_compiles(
-  [==[
+  check_cxx_source_compiles(
+    [==[
 #ifdef _MSC_VER
 #  if _MSVC_LANG < 201703L
 #    error "The compiler defaults or is configured for C++ < 17"
@@ -737,10 +745,10 @@ check_cxx_source_compiles(
 #endif
 int main() { return 0; }
 ]==]
-  ABSL_INTERNAL_AT_LEAST_CXX17)
+    ABSL_INTERNAL_AT_LEAST_CXX17)
 
-check_cxx_source_compiles(
-  [==[
+  check_cxx_source_compiles(
+    [==[
 #ifdef _MSC_VER
 #  if _MSVC_LANG < 202002L
 #    error "The compiler defaults or is configured for C++ < 20"
@@ -750,7 +758,8 @@ check_cxx_source_compiles(
 #endif
 int main() { return 0; }
 ]==]
-  ABSL_INTERNAL_AT_LEAST_CXX20)
+    ABSL_INTERNAL_AT_LEAST_CXX20)
+endif()
 
 if(ABSL_INTERNAL_AT_LEAST_CXX20)
   set(ABSL_INTERNAL_CXX_STD_FEATURE cxx_std_20)


### PR DESCRIPTION
## Summary

- Skip the C++17/C++20 compiler feature probes when the consuming project has explicitly selected and required a C++ language standard.
- Preserve the existing probe path when no standard is selected, or when CMake is allowed to fall back to a lower standard.

## Root cause

`CMake/AbseilDll.cmake` always ran two `check_cxx_source_compiles` calls, even when `CMAKE_CXX_STANDARD` and `CMAKE_CXX_STANDARD_REQUIRED` already establish the language-mode contract for every target. This adds configuration-time compilations without changing the selected feature level.

The new branch only derives the internal feature flags from `CMAKE_CXX_STANDARD` when the requested standard is required. Optional standards retain compiler probing so a CMake fallback cannot be mistaken for a guaranteed language mode.

Fixes #2023.

## Validation

- Configured with `-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON`: 0 Abseil standard probe lines.
- Configured with `-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON`: 0 Abseil standard probe lines.
- Configured with `-DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=OFF`: existing probes still run.
- Built the `strings` CMake target with both required C++17 and required C++20 configurations on MSVC.
- Ran `git diff --check`.
