### PR TITLE
Fix stale C++11 references in options.h and attributes.h

### DIFF
--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -494,8 +494,8 @@
 //
 // These attributes only take effect when the following conditions are met:
 //
-//   * The file/target is built in at least C++11 mode, with a Clang compiler
-//     that supports XRay attributes.
+//   * The file/target is built with a Clang compiler that supports XRay
+//     attributes.
 //   * The file/target is built with the -fxray-instrument flag set for the
 //     Clang/LLVM compiler.
 //   * The function is defined in the translation unit (the compiler honors the

--- a/absl/base/options.h
+++ b/absl/base/options.h
@@ -107,7 +107,7 @@
 // implemented as aliases to the std:: ordering types, or as an independent
 // implementation.
 //
-// A value of 0 means to use Abseil's implementation.  This requires only C++11
+// A value of 0 means to use Abseil's implementation.  This requires only C++17
 // support, and is expected to work on every toolchain we support.
 //
 // A value of 1 means to use aliases.  This requires that all code using Abseil


### PR DESCRIPTION
Fixes stale/misleading C++11 references flagged in #1264.

- absl/base/options.h: corrected ABSL_OPTION_USE_STD_ORDERING comment,
  which said "C++11" but should match the project's actual minimum,
  consistent with the ABSL_OPTION_USE_STD_SOURCE_LOCATION option just
  above it in the same file (which already says C++17).
- absl/base/attributes.h: removed an outdated "C++11 mode" qualifier
  on XRay attribute requirements, since it's trivially satisfied given
  the project's current baseline.

Fixes #1264