### PR TITLE
Fix hash_instantiated_test and hash_test on big-endian

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -809,7 +809,9 @@ AbslHashValue(H hash_state, const std::vector<T, Allocator>& vector) {
     for (size_t j = 0; j < 64; ++j) {
       word |= static_cast<uint64_t>(vector[i + j]) << j;
     }
-    word = absl::little_endian::FromHost64(word);
+    if constexpr (absl::endian::native == absl::endian::big) {
+      word = absl::byteswap(word);
+    }
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         sizeof(word));
@@ -822,7 +824,9 @@ AbslHashValue(H hash_state, const std::vector<T, Allocator>& vector) {
     for (size_t j = 0; j < rem; ++j) {
       word |= static_cast<uint64_t>(vector[i + j]) << j;
     }
-    word = absl::little_endian::FromHost64(word);
+    if constexpr (absl::endian::native == absl::endian::big) {
+      word = absl::byteswap(word);
+    }
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         (rem + 7) / 8);
@@ -990,7 +994,9 @@ H AbslHashValue(H hash_state, const std::bitset<N>& set) {
     for (size_t j = 0; j < 64; ++j) {
       word |= static_cast<uint64_t>(set[i + j]) << j;
     }
-    word = absl::little_endian::FromHost64(word);
+    if constexpr (absl::endian::native == absl::endian::big) {
+      word = absl::byteswap(word);
+    }
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         sizeof(word));
@@ -1003,7 +1009,9 @@ H AbslHashValue(H hash_state, const std::bitset<N>& set) {
     for (size_t j = 0; j < rem; ++j) {
       word |= static_cast<uint64_t>(set[i + j]) << j;
     }
-    word = absl::little_endian::FromHost64(word);
+    if constexpr (absl::endian::native == absl::endian::big) {
+      word = absl::byteswap(word);
+    }
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         (rem + 7) / 8);

--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -809,6 +809,7 @@ AbslHashValue(H hash_state, const std::vector<T, Allocator>& vector) {
     for (size_t j = 0; j < 64; ++j) {
       word |= static_cast<uint64_t>(vector[i + j]) << j;
     }
+    word = absl::little_endian::FromHost64(word);
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         sizeof(word));
@@ -821,6 +822,7 @@ AbslHashValue(H hash_state, const std::vector<T, Allocator>& vector) {
     for (size_t j = 0; j < rem; ++j) {
       word |= static_cast<uint64_t>(vector[i + j]) << j;
     }
+    word = absl::little_endian::FromHost64(word);
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         (rem + 7) / 8);
@@ -988,6 +990,7 @@ H AbslHashValue(H hash_state, const std::bitset<N>& set) {
     for (size_t j = 0; j < 64; ++j) {
       word |= static_cast<uint64_t>(set[i + j]) << j;
     }
+    word = absl::little_endian::FromHost64(word);
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         sizeof(word));
@@ -1000,6 +1003,7 @@ H AbslHashValue(H hash_state, const std::bitset<N>& set) {
     for (size_t j = 0; j < rem; ++j) {
       word |= static_cast<uint64_t>(set[i + j]) << j;
     }
+    word = absl::little_endian::FromHost64(word);
     hash_state = combiner.add_buffer(
         std::move(hash_state), reinterpret_cast<const unsigned char*>(&word),
         (rem + 7) / 8);


### PR DESCRIPTION
The two tests are failing on big-endian platforms after 63c77e406.

The new bit-packing code stores packed bits in the LSB of a uint64_t, then feeds raw bytes via reinterpret_cast. On big-endian, the LSB is at the end of the memory layout, so the partial-word path reads leading zero bytes instead of the actual data, causing hash collisions between distinct inputs.

Fix by byte-swapping the word to little-endian layout before feeding it to the combiner.