### PR TITLE
don't emit silenced punycode identifiers in demangle_rust

### DIFF
--- a/absl/debugging/internal/demangle_rust.cc
+++ b/absl/debugging/internal/demangle_rust.cc
@@ -720,14 +720,25 @@ class RustSymbolParser {
     if (!ParseDecimalNumber(num_bytes)) return false;
     (void)Eat('_');  // optional separator, needed if a digit follows
     if (is_punycoded) {
-      DecodeRustPunycodeOptions options;
-      options.punycode_begin = &encoding_[pos_];
-      options.punycode_end = &encoding_[pos_] + num_bytes;
-      options.out_begin = out_;
-      options.out_end = out_end_;
-      out_ = DecodeRustPunycode(options);
-      if (out_ == nullptr) return false;
-      pos_ += static_cast<size_t>(num_bytes);
+      if (silence_depth_ == 0) {
+        DecodeRustPunycodeOptions options;
+        options.punycode_begin = &encoding_[pos_];
+        options.punycode_end = &encoding_[pos_] + num_bytes;
+        options.out_begin = out_;
+        options.out_end = out_end_;
+        out_ = DecodeRustPunycode(options);
+        if (out_ == nullptr) return false;
+        pos_ += static_cast<size_t>(num_bytes);
+      } else {
+        // Output is silenced, so like EmitChar and Emit we produce nothing and
+        // use no output space.  Still consume the identifier's encoded bytes,
+        // stopping at a premature NUL exactly as the raw-bytes branch below
+        // does, so a suppressed punycoded identifier (e.g. a punycoded
+        // fn-signature abi) cannot leak into the demangling.
+        for (int i = 0; i < num_bytes; ++i) {
+          if (Take() == '\0') return false;
+        }
+      }
     }
 
     // Emit the beginnings of braced forms like {shim:vtable#0}.

--- a/absl/debugging/internal/demangle_rust_test.cc
+++ b/absl/debugging/internal/demangle_rust_test.cc
@@ -524,6 +524,15 @@ TEST(DemangleRust, ExternOther) {
       "<fn... as c::t>::f");
 }
 
+TEST(DemangleRust, ExternPunycodedAbiIsSuppressed) {
+  // The abi is part of the silenced function signature, so a punycoded abi must
+  // be suppressed like any other identifier; its decoded form must not leak
+  // into the output.
+  EXPECT_DEMANGLING(
+      // <extern "Eyjafjallajökull" fn() as c::t>::f
+      "_RNvYFKu19Eyjafjallajkull_jtbEuNtC1c1t1f", "<fn... as c::t>::f");
+}
+
 TEST(DemangleRust, Unsafe) {
   EXPECT_DEMANGLING("_RNvYFUEuNtC1c1t1f",  // <unsafe fn() as c::t>::f
                     "<fn... as c::t>::f");


### PR DESCRIPTION
ParseUndisambiguatedIdentifier decodes a punycoded identifier straight into the output buffer and advances out_ without checking silence_depth_, unlike EmitChar and Emit which write nothing while output is silenced. So a punycoded identifier inside a suppressed region leaks its decoded text into the demangling: _RNvYFKu19Eyjafjallajkull_jtbEuNtC1c1t1f comes out as <fn...Eyjafjallajökull as c::t>::f instead of <fn... as c::t>::f, and the decode also borrows output-buffer space that a suppressed identifier should not need. When silenced the punycode branch now just consumes the encoded bytes, stopping at a premature NUL like the raw-bytes branch, and emits nothing, so the identifier no longer leaks and no output space is used. Added a regression test alongside the existing extern-abi cases.