### PR TITLE
fix off-by-one truncation detection in VADoRawLog and DoRawLog

### DIFF
--- a/absl/base/internal/raw_logging.cc
+++ b/absl/base/internal/raw_logging.cc
@@ -95,7 +95,7 @@ bool VADoRawLog(char** buf, int* size, const char* format, va_list ap) {
   if (*size < 0) return false;
   int n = vsnprintf(*buf, static_cast<size_t>(*size), format, ap);
   bool result = true;
-  if (n < 0 || n > *size) {
+  if (n < 0 || n >= *size) {
     result = false;
     if (static_cast<size_t>(*size) > sizeof(kTruncated)) {
       n = *size - static_cast<int>(sizeof(kTruncated));
@@ -125,7 +125,7 @@ bool DoRawLog(char** buf, int* size, const char* format, ...) {
   va_start(ap, format);
   int n = vsnprintf(*buf, static_cast<size_t>(*size), format, ap);
   va_end(ap);
-  if (n < 0 || n > *size) return false;
+  if (n < 0 || n >= *size) return false;
   *size -= n;
   *buf += n;
   return true;

--- a/absl/base/raw_logging_test.cc
+++ b/absl/base/raw_logging_test.cc
@@ -20,6 +20,13 @@
 
 #include <tuple>
 
+#if (defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))) && \
+    !defined(__EMSCRIPTEN__)
+#include <unistd.h>
+
+#include <string>
+#endif
+
 #include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 
@@ -74,23 +81,49 @@ TEST(RawLoggingDeathTest, LogFatal) {
                             kExpectedDeathOutput);
 }
 
-TEST(RawLoggingDeathTest, TruncationMarkerAtExactBufferBoundary) {
+// Raw logging writes to STDERR_FILENO via write()/syscall on POSIX platforms,
+// so the truncation path can be exercised directly by capturing stderr, without
+// relying on death tests.
+#if (defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))) && \
+    !defined(__EMSCRIPTEN__)
+TEST(RawLoggingTest, TruncationMarkerAtExactBufferBoundary) {
   if (!absl::raw_log_internal::RawLoggingFullySupported()) {
     GTEST_SKIP() << "Raw logging output is not supported on this platform.";
   }
-  EXPECT_DEATH_IF_SUPPORTED(
-      [] {
-        absl::raw_log_internal::RegisterLogFilterAndPrefixHook(
-            [](absl::LogSeverity, const char*, int, char**, int*) {
-              return true;  // Enable logging, write no prefix.
-            });
-        // kLogBufSize in raw_logging.cc is 3000; a message of exactly that many
-        // characters fills the buffer and must be reported as truncated.
-        const std::string msg(3000, 'x');
-        ABSL_RAW_LOG(FATAL, "%s", msg.c_str());
-      }(),
-      "message truncated");
+  // kLogBufSize in raw_logging.cc; a message of exactly this length fills the
+  // buffer, so vsnprintf() reports a would-be length equal to the buffer size.
+  constexpr int kLogBufSize = 3000;
+
+  // Install a prefix hook that writes nothing so the whole raw-log buffer is
+  // available to the message and the exact boundary is hit deterministically.
+  absl::raw_log_internal::RegisterLogFilterAndPrefixHook(
+      [](absl::LogSeverity, const char*, int, char**, int*) { return true; });
+
+  int fds[2];
+  ASSERT_EQ(pipe(fds), 0);
+  int saved_stderr = dup(STDERR_FILENO);
+  ASSERT_NE(saved_stderr, -1);
+  ASSERT_NE(dup2(fds[1], STDERR_FILENO), -1);
+
+  // A would-be length equal to the buffer size must be reported as truncated:
+  // otherwise the message loses its final byte and is emitted with neither the
+  // "(message truncated)" marker nor a trailing newline.
+  const std::string msg(kLogBufSize, 'x');
+  ABSL_RAW_LOG(ERROR, "%s", msg.c_str());
+
+  ASSERT_NE(dup2(saved_stderr, STDERR_FILENO), -1);
+  close(saved_stderr);
+  close(fds[1]);
+  char buf[kLogBufSize + 64];
+  ssize_t n = read(fds[0], buf, sizeof(buf));
+  close(fds[0]);
+  ASSERT_GT(n, 0);
+  const std::string output(buf, static_cast<size_t>(n));
+
+  EXPECT_NE(output.find("(message truncated)"), std::string::npos);
+  EXPECT_EQ(output.back(), '\n');
 }
+#endif
 
 TEST(InternalLog, CompilationTest) {
   ABSL_INTERNAL_LOG(INFO, "Internal Log");

--- a/absl/base/raw_logging_test.cc
+++ b/absl/base/raw_logging_test.cc
@@ -90,14 +90,8 @@ TEST(RawLoggingTest, TruncationMarkerAtExactBufferBoundary) {
   if (!absl::raw_log_internal::RawLoggingFullySupported()) {
     GTEST_SKIP() << "Raw logging output is not supported on this platform.";
   }
-  // kLogBufSize in raw_logging.cc; a message of exactly this length fills the
-  // buffer, so vsnprintf() reports a would-be length equal to the buffer size.
+  // kLogBufSize in raw_logging.cc.
   constexpr int kLogBufSize = 3000;
-
-  // Install a prefix hook that writes nothing so the whole raw-log buffer is
-  // available to the message and the exact boundary is hit deterministically.
-  absl::raw_log_internal::RegisterLogFilterAndPrefixHook(
-      [](absl::LogSeverity, const char*, int, char**, int*) { return true; });
 
   int fds[2];
   ASSERT_EQ(pipe(fds), 0);
@@ -105,10 +99,20 @@ TEST(RawLoggingTest, TruncationMarkerAtExactBufferBoundary) {
   ASSERT_NE(saved_stderr, -1);
   ASSERT_NE(dup2(fds[1], STDERR_FILENO), -1);
 
-  // A would-be length equal to the buffer size must be reported as truncated:
-  // otherwise the message loses its final byte and is emitted with neither the
-  // "(message truncated)" marker nor a trailing newline.
-  const std::string msg(kLogBufSize, 'x');
+  // RawLogVA() first writes the default "[file : line] RAW: " prefix, so size
+  // the message to the space left after it.  vsnprintf() then reports a would-be
+  // length equal to that space, the exact boundary the fix addresses: it must be
+  // treated as truncated, otherwise the message loses its final byte and is
+  // emitted with neither the "(message truncated)" marker nor a trailing
+  // newline.  Reconstruct the prefix from the same basename and source line the
+  // ABSL_RAW_LOG below reports; kLogCallLine must match its line.
+  constexpr int kLogCallLine = __LINE__ + 7;
+  const char* basename =
+      absl::raw_log_internal::Basename(__FILE__, sizeof(__FILE__) - 1);
+  const std::string prefix =
+      absl::StrCat("[", basename, " : ", kLogCallLine, "] RAW: ");
+  ASSERT_LT(prefix.size(), static_cast<size_t>(kLogBufSize));
+  const std::string msg(static_cast<size_t>(kLogBufSize) - prefix.size(), 'x');
   ABSL_RAW_LOG(ERROR, "%s", msg.c_str());
 
   ASSERT_NE(dup2(saved_stderr, STDERR_FILENO), -1);

--- a/absl/base/raw_logging_test.cc
+++ b/absl/base/raw_logging_test.cc
@@ -74,6 +74,31 @@ TEST(RawLoggingDeathTest, LogFatal) {
                             kExpectedDeathOutput);
 }
 
+// A message whose formatted length exactly equals the remaining buffer size is
+// still truncated: vsnprintf() only writes size-1 characters plus the NUL, so
+// truncation must be detected when the would-be length is >= the size, not only
+// when it is strictly greater.  With the off-by-one, such a message loses its
+// final character and is emitted without the "(message truncated)" marker (and
+// without the trailing newline).  A custom zero-length prefix hook makes the
+// whole raw-log buffer available so the boundary is hit deterministically.
+TEST(RawLoggingDeathTest, TruncationMarkerAtExactBufferBoundary) {
+  if (!absl::raw_log_internal::RawLoggingFullySupported()) {
+    GTEST_SKIP() << "Raw logging output is not supported on this platform.";
+  }
+  EXPECT_DEATH_IF_SUPPORTED(
+      [] {
+        absl::raw_log_internal::RegisterLogFilterAndPrefixHook(
+            [](absl::LogSeverity, const char*, int, char**, int*) {
+              return true;  // Enable logging, write no prefix.
+            });
+        // kLogBufSize in raw_logging.cc is 3000; a message of exactly that many
+        // characters fills the buffer and must be reported as truncated.
+        const std::string msg(3000, 'x');
+        ABSL_RAW_LOG(FATAL, "%s", msg.c_str());
+      }(),
+      "message truncated");
+}
+
 TEST(InternalLog, CompilationTest) {
   ABSL_INTERNAL_LOG(INFO, "Internal Log");
   std::string log_msg = "Internal Log";

--- a/absl/base/raw_logging_test.cc
+++ b/absl/base/raw_logging_test.cc
@@ -74,13 +74,6 @@ TEST(RawLoggingDeathTest, LogFatal) {
                             kExpectedDeathOutput);
 }
 
-// A message whose formatted length exactly equals the remaining buffer size is
-// still truncated: vsnprintf() only writes size-1 characters plus the NUL, so
-// truncation must be detected when the would-be length is >= the size, not only
-// when it is strictly greater.  With the off-by-one, such a message loses its
-// final character and is emitted without the "(message truncated)" marker (and
-// without the trailing newline).  A custom zero-length prefix hook makes the
-// whole raw-log buffer available so the boundary is hit deterministically.
 TEST(RawLoggingDeathTest, TruncationMarkerAtExactBufferBoundary) {
   if (!absl::raw_log_internal::RawLoggingFullySupported()) {
     GTEST_SKIP() << "Raw logging output is not supported on this platform.";


### PR DESCRIPTION
treat n == size as truncation in VADoRawLog and DoRawLog: vsnprintf writes only size-1 chars at that boundary, so an exactly-buffer-filling raw log message was losing its last byte and being emitted without the `(message truncated)` marker or trailing newline, letting a following line concatenate onto it.