### PR TITLE
guard invalid _FloatN width in ParseBuiltinType

### DIFF
--- a/absl/debugging/internal/demangle.cc
+++ b/absl/debugging/internal/demangle.cc
@@ -1645,7 +1645,11 @@ static bool ParseBuiltinType(State *state) {
       return false;
     }
     MaybeAppend(state, "_Float");
-    MaybeAppendDecimal(state, number);
+    if (number >= 0) {
+      MaybeAppendDecimal(state, number);
+    } else {
+      MaybeAppend(state, "?");  // the best we can do for an invalid width
+    }
     if (ParseOneCharToken(state, 'x')) {
       MaybeAppend(state, "x");
       return true;

--- a/absl/debugging/internal/demangle_test.cc
+++ b/absl/debugging/internal/demangle_test.cc
@@ -705,6 +705,18 @@ TEST(Demangle, Float128x) {
   EXPECT_STREQ("S::operator _Float128x()", tmp);
 }
 
+TEST(Demangle, InvalidFloatNWidth) {
+  char tmp[80];
+
+  // A negative or overflowed _FloatN width is not printable, so render it as
+  // "?" like the sibling _BitInt path instead of emitting garbage bytes.
+  EXPECT_TRUE(Demangle("_ZNK1ScvDFn3_Ev", tmp, sizeof(tmp)));
+  EXPECT_STREQ("S::operator _Float?()", tmp);
+
+  EXPECT_TRUE(Demangle("_ZNK1ScvDF2147483648_Ev", tmp, sizeof(tmp)));
+  EXPECT_STREQ("S::operator _Float?()", tmp);
+}
+
 TEST(Demangle, Bfloat16) {
   char tmp[80];
 


### PR DESCRIPTION
the _FloatN branch of ParseBuiltinType passed the parsed width straight to MaybeAppendDecimal, so a crafted symbol with a negative or overflowed width like `_ZNK1ScvDFn3_Ev` printed punctuation bytes in place of digits; guard it with the same `number >= 0` else `?` check the sibling _BitInt branch right above already uses.