### PR TITLE
guard SnprintF return against int overflow

### DIFF
--- a/absl/strings/internal/str_format/bind.cc
+++ b/absl/strings/internal/str_format/bind.cc
@@ -267,6 +267,10 @@ int SnprintF(char* output, size_t size, const UntypedFormatSpecImpl format,
   }
   size_t total = sink.total_written();
   if (size) output[std::min(total, size - 1)] = 0;
+  if (total > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    errno = EFBIG;
+    return -1;
+  }
   return static_cast<int>(total);
 }
 

--- a/absl/strings/str_format_test.cc
+++ b/absl/strings/str_format_test.cc
@@ -524,6 +524,19 @@ TEST_F(FormatEntryPointTest, SNPrintF) {
   EXPECT_EQ(buffer[0], '\0');
 }
 
+TEST_F(FormatEntryPointTest, SNPrintFTooLarge) {
+  // Formatting more than INT_MAX bytes cannot be represented in the int return
+  // value, so the call reports an error via errno rather than returning a
+  // truncated (and possibly negative) count, matching FPrintF. A zero size
+  // means nothing is written to the buffer.
+  char buffer[16];
+  int width = 2000000000;
+  errno = 0;
+  int result = SNPrintF(buffer, 0, "%*d %*d", width, 0, width, 0);
+  EXPECT_LT(result, 0);
+  EXPECT_EQ(errno, EFBIG);
+}
+
 TEST_F(FormatEntryPointTest, SNPrintFWithV) {
   char buffer[16];
   int result =


### PR DESCRIPTION
**snprintf can return a bogus length for oversize output**

If SnprintF is asked to format more than INT_MAX bytes the size_t byte count is narrowed straight into the int return value, so absl::SNPrintF may hand back a negative or otherwise wrong length while errno is left untouched. The sibling FprintF already rejects the same case with EFBIG, so this just brings the buffer path into line and adds a test next to the existing FprintfTooLarge one.