### PR TITLE
fnmatch internal: added escape character

### DIFF
--- a/absl/log/internal/fnmatch.cc
+++ b/absl/log/internal/fnmatch.cc
@@ -43,10 +43,21 @@ bool FNMatch(absl::string_view pattern, absl::string_view str) {
         pattern.remove_prefix(1);
         str.remove_prefix(1);
         break;
+      case '\\':
+        pattern.remove_prefix(1);
+        if (pattern.empty()) {
+          return !str.empty() && str.front() == '\\' && str.size() == 1;
+        }
+        if (pattern.front() != str.front()) {
+          return false;
+        }
+        str.remove_prefix(1);
+        pattern.remove_prefix(1);
+        break;
       default:
         if (in_wildcard_match) {
           absl::string_view fixed_portion = pattern;
-          const size_t end = fixed_portion.find_first_of("*?");
+          const size_t end = fixed_portion.find_first_of("*?\\");
           if (end != fixed_portion.npos) {
             fixed_portion = fixed_portion.substr(0, end);
           }

--- a/absl/log/internal/fnmatch_test.cc
+++ b/absl/log/internal/fnmatch_test.cc
@@ -55,6 +55,8 @@ TEST(FNMatchTest, Works) {
   EXPECT_THAT(FNMatch("***", "**p"), IsTrue());
   EXPECT_THAT(FNMatch("**", "*"), IsTrue());
   EXPECT_THAT(FNMatch("*?", "*"), IsTrue());
+  EXPECT_THAT(FNMatch("f\\*o", "f*o"), IsTrue());
+  EXPECT_THAT(FNMatch("f\\*o", "fuo"), IsFalse());
 }
 
 }  // namespace


### PR DESCRIPTION
Before this change, it was impossible to match `*` and `?` literally with `FNMatch`. For example, the pattern `i love the * character` would also match `i love the foo character`.
This change adds backslash (`\`) escaping: placing a backslash before a character causes that character to be matched literally and not interpreted according to its special meaning. For example, `i love the \* character` matches the literal `*` character, not any string. (Although, since backslashes themselves need to be escaped in C++ strings, this would be written as `i love the \\* character` in source code.)
Because this is a behavioral change to an internal function and not a public API change, I wasn't sure whether this change is significant enough to require its own separate issue, so I opened this PR directly. All tests pass.