### PR TITLE
Backport 1895 to 20250512

### DIFF
--- a/absl/abseil.podspec.gen.py
+++ b/absl/abseil.podspec.gen.py
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_TARGET_SRCROOT)"',
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
   }
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.13'


### PR DESCRIPTION
### Description
Backport of #1895 (commit `03f6a39f502026d80064786353e55bbbf01fb922`) to the `lts_2025_05_12` branch.

### Why this is needed
Abseil requires C++17 as the baseline C++ standard. However, the CocoaPods specification template in `absl/abseil.podspec.gen.py` for the 20250512 LTS release did not explicitly configure `CLANG_CXX_LANGUAGE_STANDARD`.
When projects consume Abseil via CocoaPods on iOS/macOS, Xcode default to C++14 or the host project's default dialect, leading to compilation errors when building Abseil headers/sources that rely on C++17 language features and standard library components.