### PR TITLE
Guard ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT against a missing macro

### DIFF
--- a/absl/meta/type_traits.h
+++ b/absl/meta/type_traits.h
@@ -55,8 +55,12 @@
 #endif
 
 // Defines the default alignment. `__STDCPP_DEFAULT_NEW_ALIGNMENT__` is
-// predefined by every C++17 implementation.
+// predefined by C++17 implementations, except by GCC under -fno-aligned-new.
+#ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
 #define ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
+#else
+#define ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT alignof(std::max_align_t)
+#endif
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN


### PR DESCRIPTION
GCC does not predefine `__STDCPP_DEFAULT_NEW_ALIGNMENT__` when `-fno-aligned-new` is in effect, so `absl/meta/type_traits.h` fails to compile:

```
absl/meta/type_traits.h:59:45: error: '__STDCPP_DEFAULT_NEW_ALIGNMENT__' was not declared in this scope
   59 | #define ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
```

followed by a cascade of errors out of `inlined_vector.h`.

| `-std=gnu++17` | default | `-fno-aligned-new` |
|---|---|---|
| g++ 15 | defined | **not defined** |
| clang 21 | defined | defined |

`alignof(std::max_align_t)` is the alignment plain `operator new` guarantees when aligned new is disabled, which matches how the macro is used — both call sites (`inlined_vector.h:115`, `any_invocable.h:533`) test whether a type is over-aligned relative to plain `operator new`. `<cstddef>` is already included.

Verified: a program instantiating `absl::InlinedVector` and `absl::AnyInvocable` and printing the macro compiles, links and prints the same value (16) under all four of {g++, clang} x {default, `-fno-aligned-new`}. Without the patch, g++ with `-fno-aligned-new` does not compile.

Found in Firefox, which passes `-fno-aligned-new` tree-wide.