### PR TITLE
Exclude Windows-specific CCTZ source files in podspec

### DIFF
--- a/absl/abseil.podspec.gen.py
+++ b/absl/abseil.podspec.gen.py
@@ -200,8 +200,6 @@ def write_podspec_rule(f, rule, depth):
       srcs)
   # Writes dependencies of this rule.
   for dep in sorted(rule.deps):
-    if not dep.startswith("//absl/"):
-      continue
     name = get_spec_name(dep.replace(":", "/"))
     f.write("{indent}{var}.dependency '{dep}'\n".format(
         indent=indent, var=spec_var, dep=name))

--- a/absl/abseil.podspec.gen.py
+++ b/absl/abseil.podspec.gen.py
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '4.0'
   s.visionos.deployment_target = '1.0'
+  s.exclude_files = [ 'absl/time/internal/cctz/src/*_win.cc' ]
   s.subspec 'xcprivacy' do |ss|
     ss.resource_bundles = {
       ss.module_name => 'PrivacyInfo.xcprivacy',
@@ -189,12 +190,18 @@ def write_podspec_rule(f, rule, depth):
   # Since CocoaPods treats header_files a bit differently from bazel,
   # this won't generate a header_files field so that all source_files
   # are considered as header files.
-  srcs = sorted(set(rule.hdrs + rule.textual_hdrs + rule.srcs))
+  srcs = [
+      s
+      for s in sorted(set(rule.hdrs + rule.textual_hdrs + rule.srcs))
+      if not s.endswith("_win.cc")
+  ]
   write_indented_list(
       f, "{indent}{var}.source_files = ".format(indent=indent, var=spec_var),
       srcs)
   # Writes dependencies of this rule.
   for dep in sorted(rule.deps):
+    if not dep.startswith("//absl/"):
+      continue
     name = get_spec_name(dep.replace(":", "/"))
     f.write("{indent}{var}.dependency '{dep}'\n".format(
         indent=indent, var=spec_var, dep=name))


### PR DESCRIPTION
## Summary
- This PR excludes Windows-specific CCTZ source files (`absl/time/internal/cctz/src/*_win.cc`) in the generated `abseil.podspec`.

## Description
- The CCTZ time zone library in Abseil contains platform-specific source files like `absl/time/internal/cctz/src/time_zone_name_win.cc` intended only for Windows builds. When consuming Abseil via CocoaPods on Apple platforms (iOS, macOS, tvOS, watchOS, visionOS), these Windows-specific files are unnecessary and cause build errors.

## End-to-End Build Test
- Tested integration with CocoaPods client project (`gRPC Sample` on iOS Simulator `arm64` and `x86_64`).
- `xcodebuild -project Pods.xcodeproj -target abseil` passed with **`** BUILD SUCCEEDED **`**.
