### PR TITLE
Fix FreeBSD/PowerPC* issues

### DIFF
--- a/absl/base/internal/unscaledcycleclock.cc
+++ b/absl/base/internal/unscaledcycleclock.cc
@@ -99,9 +99,12 @@ double UnscaledCycleClock::Frequency() {
   static once_flag init_timebase_frequency_once;
   static double timebase_frequency = 0.0;
   base_internal::LowLevelCallOnce(&init_timebase_frequency_once, [&]() {
-    size_t length = sizeof(timebase_frequency);
-    sysctlbyname("kern.timecounter.tc.timebase.frequency", &timebase_frequency,
-                 &length, nullptr, 0);
+    uint64_t freq = 0;
+    size_t length = sizeof(freq);
+    if (sysctlbyname("kern.timecounter.tc.timebase.frequency", &freq, &length,
+                     nullptr, 0) == 0) {
+      timebase_frequency = static_cast<double>(freq);
+    }
   });
   return timebase_frequency;
 #else

--- a/absl/debugging/internal/stacktrace_powerpc-inl.inc
+++ b/absl/debugging/internal/stacktrace_powerpc-inl.inc
@@ -51,11 +51,10 @@ static inline void **StacktracePowerPCGetLRPtr(void **sp) {
   return (sp + 2);
 #elif defined(_CALL_SYSV)
   return (sp + 1);
-#elif defined(__APPLE__) || defined(__FreeBSD__) || \
-    (defined(__linux__) && defined(__PPC64__))
+#elif defined(__APPLE__) || defined(__PPC64__)
   // This check is in case the compiler doesn't define _CALL_AIX/etc.
   return (sp + 2);
-#elif defined(__linux)
+#elif defined(__linux) || defined(__FreeBSD__)
   // This check is in case the compiler doesn't define _CALL_SYSV.
   return (sp + 1);
 #else


### PR DESCRIPTION
This is a cumulative PR for two FreeBSD/PowerPC* changes:
1. Fix for UnscaledCycleClock::Frequency().
2. Fix for saved-LR slot on 32-bits.