### PR TITLE
log/internal: fix ambiguous EncodeVarint calls where int32_t is not int

### DIFF
--- a/absl/log/internal/log_message.cc
+++ b/absl/log/internal/log_message.cc
@@ -219,7 +219,8 @@ LogMessage::LogMessageData::LogMessageData(absl::string_view file,
 void LogMessage::LogMessageData::InitializeEncodingAndFormat() {
   EncodeStringTruncate(EventTag::kFileName, entry.source_filename(),
                        &encoded_remaining());
-  EncodeVarint(EventTag::kFileLine, entry.source_line(), &encoded_remaining());
+  EncodeVarint(EventTag::kFileLine, static_cast<int32_t>(entry.source_line()),
+               &encoded_remaining());
   EncodeVarint(EventTag::kTimeNsecs, absl::ToUnixNanos(entry.timestamp()),
                &encoded_remaining());
   EncodeVarint(EventTag::kSeverity,

--- a/absl/log/internal/proto.h
+++ b/absl/log/internal/proto.h
@@ -79,6 +79,9 @@ inline bool EncodeVarint(uint64_t tag, uint32_t value, absl::Span<char> *buf) {
 inline bool EncodeVarint(uint64_t tag, int32_t value, absl::Span<char> *buf) {
   return EncodeVarint(tag, static_cast<uint64_t>(value), buf);
 }
+inline bool EncodeVarint(uint64_t tag, bool value, absl::Span<char> *buf) {
+  return EncodeVarint(tag, static_cast<uint64_t>(value), buf);
+}
 
 // Encodes the specified integer as a varint field using ZigZag encoding and
 // returns true if it fits.

--- a/absl/log/internal/structured_proto_test.cc
+++ b/absl/log/internal/structured_proto_test.cc
@@ -77,6 +77,17 @@ INSTANTIATE_TEST_SUITE_P(
             {'\xD0', '\x02', '\x17'},
         },
         {
+            "VarintBool",
+            {
+                42,
+                StructuredProtoField::Value{
+                    std::in_place_type<StructuredProtoField::Varint>,
+                    true,
+                },
+            },
+            {'\xD0', '\x02', '\x01'},
+        },
+        {
             "I64",
             {
                 42,


### PR DESCRIPTION
Fixes #2148

  `absl/log/internal/proto.h` declares `EncodeVarint` overloads for `uint64_t`, `int64_t`, `uint32_t` and `int32_t`, but not for plain `int` or `bool` — and two call sites pass exactly those: `log_message.cc` passes `source_line()` (an `int`), and `structured_proto.cc` visits the `bool` alternative of `StructuredProtoField::Varint`. This resolves only because `int32_t` is normally a typedef for `int`; on newlib/`arm-none-eabi`, where it is `long int`, both calls are ambiguous and the build fails. Verbatim diagnostics and a host-reproducible reduction are in the issue.

  Adds a `bool` overload and casts `source_line()` at the call site — an `int` overload is not an option, it would redeclare the `int32_t` one where `int32_t` is `int`. Also adds a `structured_proto_test` case for the `bool` alternative, which the variant declares but nothing exercised.

  Happy to collapse the overload set into a single `std::is_integral` constrained template instead, if you prefer that shape.

  ### Testing

  Both files fail to compile with `arm-none-eabi-g++ 13.2.1` on `master` and compile cleanly with this change; `ctest -R '^absl_log'` passes 14/14 on the host. The new test does not fail without the fix where `int32_t` is `int` — it covers a previously untested variant alternative.