### PR TITLE
Fix some missing includes for std::-symbols

### DIFF
--- a/absl/base/exception_safety_testing_test.cc
+++ b/absl/base/exception_safety_testing_test.cc
@@ -20,7 +20,10 @@
 #include <exception>
 #include <iostream>
 #include <list>
+#include <memory>
+#include <sstream>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "gtest/gtest-spi.h"

--- a/absl/base/internal/exception_safety_testing.cc
+++ b/absl/base/internal/exception_safety_testing.cc
@@ -16,6 +16,8 @@
 
 #ifdef ABSL_HAVE_EXCEPTIONS
 
+#include <string>
+
 #include "gtest/gtest.h"
 #include "absl/meta/type_traits.h"
 

--- a/absl/base/internal/exception_safety_testing.h
+++ b/absl/base/internal/exception_safety_testing.h
@@ -25,12 +25,19 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <initializer_list>
 #include <iosfwd>
+#include <limits>
+#include <memory>
+#include <new>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "absl/base/internal/pretty_function.h"
@@ -1029,10 +1036,10 @@ class ExceptionSafetyTestBuilder {
   ExceptionSafetyTestBuilder<Factory, Operation, Contracts...,
                              std::decay_t<MoreContracts>...>
   WithContracts(const MoreContracts&... more_contracts) const {
-    return {
-        factory_, operation_,
-        std::tuple_cat(contracts_, std::tuple<std::decay_t<MoreContracts>...>(
-                                       more_contracts...))};
+    return {factory_, operation_,
+            std::tuple_cat(
+                contracts_,
+                std::tuple<std::decay_t<MoreContracts>...>(more_contracts...))};
   }
 
   /*

--- a/absl/container/linked_hash_map_test.cc
+++ b/absl/container/linked_hash_map_test.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <type_traits>

--- a/absl/flags/internal/flag.h
+++ b/absl/flags/internal/flag.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <type_traits>
 #include <typeinfo>
+#include <utility>
 
 #include "absl/base/attributes.h"
 #include "absl/base/call_once.h"
@@ -605,8 +606,8 @@ class FlagImpl final : public CommandLineFlag {
   }
   template <typename T,
             std::enable_if_t<flags_internal::StorageKind<T>() ==
-                                  FlagValueStorageKind::kOneWordAtomic,
-                              int> = 0>
+                                 FlagValueStorageKind::kOneWordAtomic,
+                             int> = 0>
   void Read(T* value) const ABSL_LOCKS_EXCLUDED(DataGuard()) {
     int64_t v = ReadOneWord();
     std::memcpy(value, static_cast<const void*>(&v), sizeof(T));

--- a/absl/functional/bind_front_test.cc
+++ b/absl/functional/bind_front_test.cc
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -165,9 +166,7 @@ TEST(BindTest, StoreByPointer) {
   EXPECT_EQ(&s.value, &g());
 }
 
-int Sink(std::unique_ptr<int> p) {
-  return *p;
-}
+int Sink(std::unique_ptr<int> p) { return *p; }
 
 std::unique_ptr<int> Factory(int n) { return std::make_unique<int>(n); }
 

--- a/absl/status/statusor_test.cc
+++ b/absl/status/statusor_test.cc
@@ -23,6 +23,7 @@
 #include <memory>
 #include <ostream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/absl/strings/string_view.h
+++ b/absl/strings/string_view.h
@@ -24,6 +24,7 @@
 #ifndef ABSL_STRINGS_STRING_VIEW_H_
 #define ABSL_STRINGS_STRING_VIEW_H_
 
+#include <algorithm>
 #include <string_view>
 
 #include "absl/base/attributes.h"

--- a/absl/types/any_span_test.cc
+++ b/absl/types/any_span_test.cc
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -1056,9 +1057,9 @@ TEST(MutableAnySpanTest, NonTruncatingSubspan) {
     EXPECT_DEATH(span.subspan(5, 1), "");
     EXPECT_DEATH(span.subspan(AnySpan<int>::npos, 0), "");
     EXPECT_DEATH(span.subspan(AnySpan<int>::npos, 1), "");
-      EXPECT_DEATH(span.subspan(0, 5), "");
-      EXPECT_DEATH(span.first(5), "");
-      EXPECT_DEATH(span.first(AnySpan<int>::npos), "");
+    EXPECT_DEATH(span.subspan(0, 5), "");
+    EXPECT_DEATH(span.first(5), "");
+    EXPECT_DEATH(span.first(AnySpan<int>::npos), "");
   }
 #endif
 }

--- a/absl/types/compare_test.cc
+++ b/absl/types/compare_test.cc
@@ -14,6 +14,8 @@
 
 #include "absl/types/compare.h"
 
+#include <algorithm>
+
 #include "gtest/gtest.h"
 #include "absl/base/casts.h"
 

--- a/absl/types/span_test.cc
+++ b/absl/types/span_test.cc
@@ -14,6 +14,7 @@
 
 #include "absl/types/span.h"
 
+#include <algorithm>
 #include <array>
 #include <initializer_list>
 #include <numeric>


### PR DESCRIPTION
Found with `clang-tidy`'s `misc-include-cleaner` checker.

Post-processed with clang-format, which then also picked up some other smaller things. Also, gtest is now sorted in the order by the names the gtest headers are accessed.

Breakdown:

```
absl/base/internal/exception_safety_testing.h: #include <cstdlib> for std::abort
absl/base/internal/exception_safety_testing.h: #include <new> for std::bad_alloc
absl/base/internal/exception_safety_testing.h: #include <type_traits> for std::bool_constant
absl/types/span_test.cc:                       #include <algorithm> for std::equal
absl/base/internal/exception_safety_testing.h: #include <utility> for std::index_sequence
absl/flags/internal/flag.h:                    #include <utility> for std::index_sequence
absl/base/exception_safety_testing_test.cc:    #include <sstream> for std::istringstream
absl/types/compare_test.cc:                    #include <algorithm> for std::less
absl/base/internal/exception_safety_testing.h: #include <memory> for std::make_shared
absl/base/exception_safety_testing_test.cc:    #include <memory> for std::make_unique
absl/strings/string_view.h:                    #include <algorithm> for std::min
absl/base/exception_safety_testing_test.cc:    #include <utility> for std::move
absl/functional/bind_front_test.cc:            #include <utility> for std::move
absl/base/internal/exception_safety_testing.h: #include <limits> for std::numeric_limits
absl/container/linked_hash_map_test.cc:        #include <stdexcept> for std::out_of_range
absl/types/any_span_test.cc:                   #include <stdexcept> for std::out_of_range
absl/status/statusor_test.cc:                  #include <stdexcept> for std::runtime_error
absl/base/internal/exception_safety_testing.cc: #include <string> for std::string
absl/base/internal/exception_safety_testing.h: #include <vector> for std::vector
```

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
