### PR TITLE
IWYU for some absl symbols

### DIFF
--- a/absl/base/internal/exception_safety_testing.cc
+++ b/absl/base/internal/exception_safety_testing.cc
@@ -22,6 +22,8 @@
 
 #include "gtest/gtest.h"
 #include "absl/meta/type_traits.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 
 namespace testing {
 

--- a/absl/base/internal/exception_safety_testing.h
+++ b/absl/base/internal/exception_safety_testing.h
@@ -43,6 +43,7 @@
 #include "absl/base/internal/pretty_function.h"
 #include "absl/memory/memory.h"
 #include "absl/meta/type_traits.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "absl/utility/utility.h"

--- a/absl/log/BUILD.bazel
+++ b/absl/log/BUILD.bazel
@@ -514,6 +514,7 @@ cc_test(
         ":check",
         ":log",
         ":log_entry",
+        ":log_sink",
         ":scoped_mock_log",
         "//absl/base:config",
         "//absl/base:core_headers",

--- a/absl/log/log_format_test.cc
+++ b/absl/log/log_format_test.cc
@@ -34,6 +34,7 @@
 #include "absl/log/internal/test_matchers.h"
 #include "absl/log/log.h"
 #include "absl/log/log_entry.h"
+#include "absl/log/log_sink.h"
 #include "absl/log/scoped_mock_log.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"

--- a/absl/strings/internal/cord_rep_flat.h
+++ b/absl/strings/internal/cord_rep_flat.h
@@ -25,6 +25,7 @@
 #include "absl/base/config.h"
 #include "absl/base/macros.h"
 #include "absl/strings/internal/cord_internal.h"
+#include "absl/strings/string_view.h"
 
 namespace absl {
 ABSL_NAMESPACE_BEGIN


### PR DESCRIPTION
add includes in the following for the symbols

```
absl/base/internal/exception_safety_testing.h   absl::StrCat
absl/base/internal/exception_safety_testing.cc  absl::string_view
absl/base/internal/exception_safety_testing.cc  absl::StrAppend
absl/log/log_format_test.cc                     absl::LogSink
absl/strings/internal/cord_rep_flat.h           absl::string_view
```

Thank you for your contribution to Abseil!

Before submitting this PR, please be sure to read our [contributing
guidelines](https://github.com/abseil/abseil-cpp/blob/master/CONTRIBUTING.md).

If you are a Googler, please also note that it is required that you send us a
Piper CL instead of using the GitHub pull-request process. The code propagation
process will deliver the change to GitHub.
