### PR TITLE
BuildBreak: UWP apps can't link GetWindowsLocalTimeZone

### DIFF
--- a/absl/time/CMakeLists.txt
+++ b/absl/time/CMakeLists.txt
@@ -77,8 +77,8 @@ absl_cc_library(
     "internal/cctz/src/time_zone_posix.h"
     "internal/cctz/src/tzfile.h"
     "internal/cctz/src/zone_info_source.cc"
-    $<$<PLATFORM_ID:Windows>:internal/cctz/src/time_zone_name_win.cc>
-    $<$<PLATFORM_ID:Windows>:internal/cctz/src/time_zone_name_win.h>
+    $<$<PLATFORM_ID:Windows,WindowsStore>:internal/cctz/src/time_zone_name_win.cc>
+    $<$<PLATFORM_ID:Windows,WindowsStore>:internal/cctz/src/time_zone_name_win.h>
   COPTS
     ${ABSL_DEFAULT_COPTS}
   DEPS


### PR DESCRIPTION
Because it is not even compiled.
