### PR TITLE
debugging: define ElfW when the target has no <link.h>

### DIFF
--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -42,10 +42,20 @@
 
 #ifdef ABSL_HAVE_ELF_MEM_IMAGE
 
+#if __has_include(<link.h>)
 #include <link.h>  // for ElfW
+#else
+#include <elf.h>
+#endif
 
-#if defined(__FreeBSD__) && !defined(ElfW)
-#define ElfW(x) __ElfN(x)
+#ifndef ElfW
+#if defined(__FreeBSD__)
+#define ElfW(type) __ElfN(type)
+#elif __SIZEOF_POINTER__ == 8
+#define ElfW(type) Elf64_##type
+#else
+#define ElfW(type) Elf32_##type
+#endif
 #endif
 
 namespace absl {


### PR DESCRIPTION
Fixes #2153.

  Per review: instead of disabling `ABSL_HAVE_ELF_MEM_IMAGE` on targets without a dynamic loader, define `ElfW` ourselves when `<link.h>` is missing. newlib ships `<elf.h>`, so that is enough to build.

  Two details differ from the snippet in the review. `__SIZEOF_POINTER__ == 8` replaces the architecture list, which covers ppc64/s390x/mips64/loongarch64 as well. And the FreeBSD branch keeps  `defined(__FreeBSD__)`: `__ELF_NATIVE_CLASS` is a glibc macro, and by the time we reach this block glibc's `<link.h>` has already defined `ElfW`, so it would never fire — while FreeBSD would silently lose `__ElfN`.

  The platform deny-list is untouched.

  Verified: `elf_mem_image.cc` and `vdso_support.cc` compile under `arm-none-eabi-g++`, and the host is unchanged — `ElfW` still comes from `<link.h>` there.