### PR TITLE
Include <pthread.h> in thread_identity.cc only when the selected mode uses it

### DIFF
--- a/absl/base/internal/thread_identity.cc
+++ b/absl/base/internal/thread_identity.cc
@@ -23,7 +23,7 @@
 #include "absl/base/internal/raw_logging.h"
 #include "absl/base/internal/spinlock.h"
 
-#if !defined(_WIN32) || defined(__MINGW32__)
+#if ABSL_THREAD_IDENTITY_MODE != ABSL_THREAD_IDENTITY_MODE_USE_CPP11
 #include <pthread.h>
 #ifndef __wasi__
 // WASI does not provide this header, either way we disable use
@@ -86,7 +86,7 @@ void SetCurrentThreadIdentity(ThreadIdentity* identity,
 
 #if defined(__wasi__) || defined(__EMSCRIPTEN__) || defined(__MINGW32__) || \
     defined(__hexagon__)
-  // Emscripten, WASI and MinGW pthread implementations does not support
+  // Emscripten, WASI and MinGW pthread implementations do not support
   // signals. See
   // https://kripken.github.io/emscripten-site/docs/porting/pthreads.html for
   // more information.


### PR DESCRIPTION
Every pthread use in thread_identity.cc is already conditional on ABSL_THREAD_IDENTITY_MODE, but the #include <pthread.h> is keyed on the platform instead: it is included on every non-Windows target and on MinGW. That makes ABSL_FORCE_THREAD_IDENTITY_MODE=ABSL_THREAD_IDENTITY_MODE_USE_CPP11 unusable on MinGW toolchains that do not ship winpthreads, since the header is included even though nothing in that mode needs it. Firefox's clang-based MinGW toolchain is one such configuration.

Gate the include on the mode like the rest of the file. Default mode selection is unchanged on every platform, and MinGW toolchains that do provide pthread.h keep the existing POSIX behavior.
