### PR TITLE
Guard ABSL_HAVE_ELF_MEM_IMAGE on <link.h> availability, not a deny-list

### DIFF
--- a/absl/debugging/internal/elf_mem_image.h
+++ b/absl/debugging/internal/elf_mem_image.h
@@ -33,10 +33,11 @@
 #error ABSL_HAVE_ELF_MEM_IMAGE cannot be directly set
 #endif
 
-#if defined(__ELF__) && !defined(__OpenBSD__) && !defined(__QNX__) &&    \
-    !defined(__asmjs__) && !defined(__wasm__) && !defined(__HAIKU__) &&  \
-    !defined(__sun) && !defined(__VXWORKS__) && !defined(__hexagon__) && \
-    !defined(__XTENSA__)
+#if defined(__ELF__) && !defined(__OpenBSD__) && !defined(__QNX__) &&     \
+    !defined(__asmjs__) && !defined(__wasm__) && !defined(__HAIKU__) &&   \
+    !defined(__sun) && !defined(__VXWORKS__) && !defined(__hexagon__) &&  \
+    !defined(__XTENSA__) &&                                               \
+    (!defined(__has_include) || __has_include(<link.h>))
 #define ABSL_HAVE_ELF_MEM_IMAGE 1
 #endif
 


### PR DESCRIPTION
Fixes #2153.

`ABSL_HAVE_ELF_MEM_IMAGE` is turned on for every `__ELF__` target except an explicit deny-list, and once it's on, `elf_mem_image.h` unconditionally includes `<link.h>`. That header is a glibc/dynamic-linker thing, not part of the ELF format itself, so any bare-metal ELF toolchain without a real dynamic loader (the reported case is `arm-none-eabi-g++` with newlib) hits a fatal `link.h: No such file or directory` before compilation even gets to using anything from it.

The deny-list (`__QNX__`, `__asmjs__`, `__wasm__`, `__HAIKU__`, `__VXWORKS__`, `__hexagon__`, `__XTENSA__`) is really just a running list of platforms that hit this one at a time, each needing its own PR to add itself.

Added `__has_include(<link.h>)` to the guard so the feature turns on based on whether the header it needs is actually there, with a fallback for preprocessors that don't support `__has_include` (there's already a precedent for this in `absl/base/config.h`).

Verified two ways since I don't have the reporter's exact `arm-none-eabi-g++`/newlib setup handy:
- Isolated the guard logic in a standalone header with a fake include path that has no `link.h`: the current code reproduces the exact reported error, the fix compiles clean and simply doesn't define `ABSL_HAVE_ELF_MEM_IMAGE`.
- Same setup but with a `link.h` present on the include path: confirms the fix still defines `ABSL_HAVE_ELF_MEM_IMAGE` and includes the header, so real ELF/glibc targets are unaffected.

I didn't touch the deny-list itself, it's harmless now (each of those platforms also lacks `link.h`, so the new check alone would already exclude them), but removing it felt like a separate cleanup from the actual bug fix.
