### PR TITLE
Fix failure to compile on MinGW due to no `O_NONBLOCK` in `fcntl.h`

### DIFF
--- a/absl/time/internal/cctz/src/time_zone_info.cc
+++ b/absl/time/internal/cctz/src/time_zone_info.cc
@@ -403,7 +403,8 @@ using FilePtr = std::unique_ptr<FILE, int (*)(FILE*)>;
 
 // fopen(3) adaptor for reading zoneinfo files (read-only binary mode).
 inline FilePtr FOpen(const char* path) {
-#if defined(_MSC_VER)
+// MinGW lacks O_NONBLOCK in fcntl.h, but it does have fopen_s().
+#if defined(_MSC_VER) || defined(__MINGW32__)
   FILE* fp;
   if (fopen_s(&fp, path, "rb") != 0) fp = nullptr;
   return FilePtr(fp, fclose);


### PR DESCRIPTION
While testing Abseil LTS 20260817.0 for Fedora, I encountered the following error:

```
/usr/bin/i686-w64-mingw32-g++ -Dtime_zone_EXPORTS -I/builddir/build/BUILD/abseil-cpp-20260817.0-build/abseil-cpp-20260817.0 -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=
ssp-buffer-size=4 -Wall -Wextra -Wcast-qual -Wconversion-null -Wformat-security -Wmissing-declarations -Wnon-virtual-dtor -Woverlength-strings -Wpointer-arith -Wundef -Wunused-local-typede
fs -Wunused-result -Wvarargs -Wvla -Wwrite-strings -DNOMINMAX -MD -MT absl/time/CMakeFiles/time_zone.dir/internal/cctz/src/time_zone_info.cc.obj -MF absl/time/CMakeFiles/time_zone.dir/inte
rnal/cctz/src/time_zone_info.cc.obj.d -o absl/time/CMakeFiles/time_zone.dir/internal/cctz/src/time_zone_info.cc.obj -c /builddir/build/BUILD/abseil-cpp-20260817.0-build/abseil-cpp-20260817
.0/absl/time/internal/cctz/src/time_zone_info.cc
/builddir/build/BUILD/abseil-cpp-20260817.0-build/abseil-cpp-20260817.0/absl/time/internal/cctz/src/time_zone_info.cc: In function 'absl::lts_20260817::time_internal::cctz::{anonymous}::Fi
lePtr absl::lts_20260817::time_internal::cctz::{anonymous}::FOpen(const char*)':
/builddir/build/BUILD/abseil-cpp-20260817.0-build/abseil-cpp-20260817.0/absl/time/internal/cctz/src/time_zone_info.cc:416:40: error: 'O_NONBLOCK' was not declared in this scope
  416 |   const int fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
      |                                        ^~~~~~~~~~
```

Apparently, MinGW does not declare `O_NONBLOCK` in `fcntl.h`. Accordingly, this PR adjusts the MinGW case to instead use the same implementation as MSVC, opening the zoneinfo file with `fopen_s()`, which MinGW *does* provide.